### PR TITLE
feat(visibility): change default to 'shareable with link'

### DIFF
--- a/src/core/services/TournamentCreationService.ts
+++ b/src/core/services/TournamentCreationService.ts
@@ -56,6 +56,7 @@ export class TournamentCreationService {
             hideRankingsForPublic: false,
             resultMode: 'goals',
             pointSystem: defaultConfig.defaults.pointSystem,
+            isPublic: true, // Default: Mit Link teilbar
             title: '',
             ageClass: 'U11',
             date: new Date().toISOString().split('T')[0],


### PR DESCRIPTION
## Summary
- New tournaments now default to `isPublic: true`
- "Mit Link teilbar" is pre-selected in Admin Center visibility settings
- Existing tournaments already have `is_public: true` in Supabase, no migration needed

## Test plan
- [ ] Create a new tournament
- [ ] Check Admin Center → Sichtbarkeit → "Mit Link teilbar" should be selected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)