### PR TITLE
fix(offline): sync local data to cloud on reconnect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ToastProvider, useToast } from './components/ui/Toast';
 import { ConfirmDialog, useConfirmDialog } from './components/ui/ConfirmDialog';
 import { StorageWarningBanner } from './components/StorageWarningBanner';
 import { OfflineBanner } from './components/OfflineBanner';
+import { useSyncOnReconnect } from './hooks/useSyncOnReconnect';
 import { AuthProvider } from './features/auth/context/AuthContext';
 import { useAuth } from './features/auth/hooks/useAuth';
 import { ThemeProvider } from './hooks/useTheme';
@@ -654,15 +655,23 @@ function AppContent() {
 // Providers
 import { RepositoryProvider } from './core/contexts/RepositoryContext';
 
-// ... (imports)
-
-// ...
+/**
+ * SyncManager - Background component that syncs local data to cloud
+ * Triggers sync when:
+ * - User reconnects after being offline
+ * - App starts while online
+ */
+function SyncManager(): null {
+  useSyncOnReconnect();
+  return null;
+}
 
 function App() {
   return (
     <ThemeProvider defaultTheme="system">
       <AuthProvider>
         <RepositoryProvider>
+          <SyncManager />
           <ToastProvider>
             <StorageWarningBanner />
             <OfflineBanner />

--- a/src/core/repositories/ITournamentRepository.ts
+++ b/src/core/repositories/ITournamentRepository.ts
@@ -42,4 +42,10 @@ export interface ITournamentRepository {
      * - Supabase: Returns tournaments owned by the user.
      */
     listForCurrentUser(): Promise<Tournament[]>;
+
+    /**
+     * Syncs local data to cloud.
+     * Only relevant for OfflineRepository - others can no-op.
+     */
+    syncUp?(): Promise<void>;
 }

--- a/src/hooks/useSyncOnReconnect.ts
+++ b/src/hooks/useSyncOnReconnect.ts
@@ -1,0 +1,36 @@
+/**
+ * useSyncOnReconnect - Triggers sync when coming back online
+ *
+ * Automatically syncs local data to cloud when:
+ * - User reconnects after being offline
+ * - App starts while online
+ */
+
+import { useEffect, useRef } from 'react';
+import { useRepositoryContext } from '../core/contexts/RepositoryContext';
+import { useOnlineStatus } from './useOnlineStatus';
+
+export function useSyncOnReconnect(): void {
+    const repository = useRepositoryContext();
+    const { isOnline, wasOffline } = useOnlineStatus();
+    const hasSyncedOnMount = useRef(false);
+
+    // Sync on reconnect
+    useEffect(() => {
+        if (isOnline && wasOffline && repository.syncUp) {
+            repository.syncUp().catch(() => {
+                // Sync failures are tolerated - data stays local
+            });
+        }
+    }, [isOnline, wasOffline, repository]);
+
+    // Sync on mount if online (catch up after app restart)
+    useEffect(() => {
+        if (isOnline && !hasSyncedOnMount.current && repository.syncUp) {
+            hasSyncedOnMount.current = true;
+            repository.syncUp().catch(() => {
+                // Sync failures are tolerated - data stays local
+            });
+        }
+    }, [isOnline, repository]);
+}


### PR DESCRIPTION
## Summary

Fixes two critical issues with offline-first data handling:

1. **Local-only tournaments now remain visible when online**
   - `listForCurrentUser()` now merges cloud and local lists
   - Unsynced local tournaments appear alongside cloud data
   - Prevents tournaments from "disappearing" when switching to online mode

2. **Sync is now triggered automatically**
   - When user reconnects after being offline
   - When app starts while online (catches up after restart)

## Changes

- Modified `OfflineRepository.listForCurrentUser()` with merge logic
- Added optional `syncUp()` method to `ITournamentRepository` interface
- Created new `useSyncOnReconnect` hook
- Added `SyncManager` component to App.tsx

## Test plan

- [ ] Create tournament while offline
- [ ] Go online → verify tournament appears and syncs
- [ ] Restart app → verify sync triggers on mount
- [ ] Verify existing online functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)