### PR TITLE
fix(a11y): prevent iOS auto-zoom on form inputs

### DIFF
--- a/src/components/ui/Combobox.tsx
+++ b/src/components/ui/Combobox.tsx
@@ -143,7 +143,8 @@ export const Combobox: React.FC<ComboboxProps> = ({
     border: `1px solid ${error ? cssVars.colors.error : isOpen ? cssVars.colors.primary : cssVars.colors.border}`,
     borderRadius: cssVars.borderRadius.md,
     color: cssVars.colors.textPrimary,
-    fontSize: cssVars.fontSizes.md,
+    // Minimum 16px (fontSizes.lg) required to prevent iOS auto-zoom on focus
+    fontSize: cssVars.fontSizes.lg,
     fontFamily: cssVars.fontFamilies.body,
     outline: 'none',
     cursor: disabled ? 'not-allowed' : 'pointer',

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -62,7 +62,8 @@ export const Input: React.FC<InputProps> = ({
     border: `1px solid ${hasError ? cssVars.colors.error : cssVars.colors.border}`,
     borderRadius: cssVars.borderRadius.md,
     color: cssVars.colors.textPrimary,
-    fontSize: cssVars.fontSizes.md,
+    // Minimum 16px (fontSizes.lg) required to prevent iOS auto-zoom on focus
+    fontSize: cssVars.fontSizes.lg,
     fontFamily: cssVars.fontFamilies.body,
     outline: 'none',
     transition: 'border-color 0.2s ease, box-shadow 0.2s ease',

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -51,7 +51,8 @@ export const Select: React.FC<SelectProps> = ({
     border: `1px solid ${error ? cssVars.colors.error : cssVars.colors.border}`,
     borderRadius: cssVars.borderRadius.md,
     color: cssVars.colors.textPrimary,
-    fontSize: cssVars.fontSizes.md,
+    // Minimum 16px (fontSizes.lg) required to prevent iOS auto-zoom on focus
+    fontSize: cssVars.fontSizes.lg,
     fontFamily: cssVars.fontFamilies.body,
     outline: 'none',
     cursor: 'pointer',


### PR DESCRIPTION
## Summary
- Set font-size to 16px (fontSizes.lg) on all input elements to prevent iOS Safari from auto-zooming when users focus on form fields

## Affected components
- Input.tsx
- Select.tsx
- Combobox.tsx

## Test plan
- [x] Lint passes
- [x] Build passes
- [ ] E2E test "Alle Inputs haben mindestens 16px font-size" should now pass

Fixes the failing CI from yesterday's push.

---
Generated with [Claude Code](https://claude.com/claude-code)