### PR TITLE
refactor(auth): migrate invitation/membership services to Supabase

### DIFF
--- a/src/features/auth/components/InviteDialog.tsx
+++ b/src/features/auth/components/InviteDialog.tsx
@@ -40,10 +40,10 @@ export const InviteDialog: React.FC<InviteDialogProps> = ({
   const [maxUses, setMaxUses] = useState<number>(1);
   const [expiresInDays, setExpiresInDays] = useState<number>(7);
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     clearError();
 
-    const result = createNewInvitation({
+    const result = await createNewInvitation({
       tournamentId,
       role: selectedRole,
       teamIds: selectedRole === 'trainer' ? selectedTeamIds : undefined,
@@ -151,7 +151,7 @@ export const InviteDialog: React.FC<InviteDialogProps> = ({
           </Button>
           <Button
             variant="primary"
-            onClick={handleCreate}
+            onClick={() => void handleCreate()}
             loading={isLoading}
             disabled={selectedRole === 'trainer' && selectedTeamIds.length === 0 && availableTeams.length > 0}
           >

--- a/src/features/auth/components/MemberList.tsx
+++ b/src/features/auth/components/MemberList.tsx
@@ -47,16 +47,18 @@ export const MemberList: React.FC<MemberListProps> = ({
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null);
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
 
-  const handleRoleChange = (membershipId: string, newRole: TournamentRole) => {
+  const handleRoleChange = async (membershipId: string, newRole: TournamentRole) => {
     clearError();
-    if (setRole(membershipId, newRole)) {
+    const success = await setRole(membershipId, newRole);
+    if (success) {
       setEditingMemberId(null);
     }
   };
 
-  const handleRemove = (membershipId: string) => {
+  const handleRemove = async (membershipId: string) => {
     clearError();
-    if (remove(membershipId)) {
+    const success = await remove(membershipId);
+    if (success) {
       setConfirmRemoveId(null);
     }
   };
@@ -140,7 +142,7 @@ export const MemberList: React.FC<MemberListProps> = ({
                               ...(membership.role === role ? styles.roleOptionActive : {}),
                               ...(canAssign ? {} : styles.roleOptionDisabled),
                             }}
-                            onClick={() => canAssign && handleRoleChange(membership.id, role)}
+                            onClick={() => canAssign && void handleRoleChange(membership.id, role)}
                             disabled={!canAssign || isLoading}
                           >
                             {ROLE_LABELS[role].label}
@@ -160,7 +162,7 @@ export const MemberList: React.FC<MemberListProps> = ({
                       <Button
                         variant="danger"
                         size="sm"
-                        onClick={() => handleRemove(membership.id)}
+                        onClick={() => void handleRemove(membership.id)}
                         loading={isLoading}
                       >
                         Ja, entfernen

--- a/src/features/auth/services/invitationService.ts
+++ b/src/features/auth/services/invitationService.ts
@@ -1,7 +1,8 @@
 /**
- * Invitation Service - Einladungs-Verwaltung
+ * Invitation Service - Einladungs-Verwaltung (Supabase)
  *
  * Verwaltet Token-basierte Einladungen zu Turnieren.
+ * Nutzt die tournament_collaborators Tabelle in Supabase.
  *
  * @see docs/concepts/ANMELDUNG-KONZEPT.md Abschnitt 5.3
  */
@@ -14,9 +15,9 @@ import type {
 } from '../types/auth.types';
 // Re-export for consumers
 export type { InvitationValidationResult } from '../types/auth.types';
-import { AUTH_STORAGE_KEYS } from '../types/auth.types';
-import { generateToken, generateUUID } from '../utils/tokenGenerator';
+import { generateToken } from '../utils/tokenGenerator';
 import { getCurrentUser } from './authService';
+import { supabase, isSupabaseConfigured } from '../../../lib/supabase';
 
 // ============================================
 // TYPES
@@ -62,46 +63,72 @@ export interface AcceptInvitationResult {
 }
 
 // ============================================
-// STORAGE
+// DATABASE TYPES (from Supabase)
+// ============================================
+
+interface CollaboratorRow {
+  id: string;
+  tournament_id: string;
+  user_id: string | null;
+  invite_email: string | null;
+  invite_code: string | null;
+  role: string;
+  team_ids: string[] | null;
+  label: string | null;
+  max_uses: number | null;
+  use_count: number | null;
+  expires_at: string | null;
+  invited_at: string | null;
+  invited_by: string | null;
+  accepted_at: string | null;
+  declined_at: string | null;
+  created_at: string | null;
+  allowed_fields: number[] | null;
+  allowed_groups: string[] | null;
+}
+
+// ============================================
+// MAPPER FUNCTIONS
 // ============================================
 
 /**
- * Lädt alle Einladungen
+ * Maps DB row to Invitation type
  */
-const getInvitations = (): Invitation[] => {
-  try {
-    const raw = localStorage.getItem(AUTH_STORAGE_KEYS.INVITATIONS);
-    return raw ? (JSON.parse(raw) as Invitation[]) : [];
-  } catch {
-    return [];
-  }
-};
+function mapRowToInvitation(row: CollaboratorRow): Invitation {
+  return {
+    id: row.id,
+    token: row.invite_code ?? '',
+    tournamentId: row.tournament_id,
+    role: row.role as TournamentRole,
+    teamIds: row.team_ids ?? [],
+    label: row.label ?? undefined,
+    createdBy: row.invited_by ?? '',
+    createdAt: row.invited_at ?? row.created_at ?? new Date().toISOString(),
+    expiresAt: row.expires_at ?? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    maxUses: row.max_uses ?? 1,
+    useCount: row.use_count ?? 0,
+    usedBy: [], // Not stored in DB, could add if needed
+    isActive: !row.accepted_at && !row.declined_at && row.invite_code !== null,
+  };
+}
 
 /**
- * Speichert alle Einladungen
+ * Maps DB row to Membership type
  */
-const saveInvitations = (invitations: Invitation[]): void => {
-  localStorage.setItem(AUTH_STORAGE_KEYS.INVITATIONS, JSON.stringify(invitations));
-};
-
-/**
- * Lädt alle Memberships
- */
-const getMemberships = (): TournamentMembership[] => {
-  try {
-    const raw = localStorage.getItem(AUTH_STORAGE_KEYS.MEMBERSHIPS);
-    return raw ? (JSON.parse(raw) as TournamentMembership[]) : [];
-  } catch {
-    return [];
-  }
-};
-
-/**
- * Speichert alle Memberships
- */
-const saveMemberships = (memberships: TournamentMembership[]): void => {
-  localStorage.setItem(AUTH_STORAGE_KEYS.MEMBERSHIPS, JSON.stringify(memberships));
-};
+function mapRowToMembership(row: CollaboratorRow): TournamentMembership {
+  return {
+    id: row.id,
+    userId: row.user_id ?? '',
+    tournamentId: row.tournament_id,
+    role: row.role as TournamentRole,
+    teamIds: row.team_ids ?? [],
+    invitedBy: row.invited_by ?? undefined,
+    invitedAt: row.invited_at ?? undefined,
+    acceptedAt: row.accepted_at ?? undefined,
+    createdAt: row.created_at ?? new Date().toISOString(),
+    updatedAt: row.created_at ?? new Date().toISOString(),
+  };
+}
 
 // ============================================
 // PUBLIC API
@@ -112,23 +139,8 @@ const saveMemberships = (memberships: TournamentMembership[]): void => {
  *
  * @param options - Einladungs-Optionen
  * @returns Ergebnis mit Einladung und Link
- *
- * @example
- * ```ts
- * const result = createInvitation({
- *   tournamentId: 'abc123',
- *   role: 'trainer',
- *   teamIds: ['team-1', 'team-2'],
- *   duration: INVITATION_DURATION.ONE_WEEK,
- *   maxUses: 1,
- * });
- *
- * if (result.success) {
- *   console.log('Link:', result.inviteLink);
- * }
- * ```
  */
-export const createInvitation = (options: CreateInvitationOptions): CreateInvitationResult => {
+export const createInvitation = async (options: CreateInvitationOptions): Promise<CreateInvitationResult> => {
   const currentUser = getCurrentUser();
 
   if (!currentUser) {
@@ -144,39 +156,50 @@ export const createInvitation = (options: CreateInvitationOptions): CreateInvita
     return { success: false, error: 'Owner-Einladungen sind nicht erlaubt' };
   }
 
+  if (!isSupabaseConfigured || !supabase) {
+    return { success: false, error: 'Cloud-Funktionen sind nicht verfügbar' };
+  }
+
   const now = new Date();
   const daysInMs = (options.expiresInDays ?? 7) * 24 * 60 * 60 * 1000;
+  const inviteCode = generateToken();
 
-  const invitation: Invitation = {
-    id: generateUUID(),
-    token: generateToken(),
-    tournamentId: options.tournamentId,
-    role: options.role,
-    teamIds: options.teamIds ?? [],
-    label: options.label,
-    createdBy: options.createdBy,
-    createdAt: now.toISOString(),
-    expiresAt: new Date(now.getTime() + daysInMs).toISOString(),
-    maxUses: options.maxUses ?? 1,
-    useCount: 0,
-    usedBy: [],
-    isActive: true,
-  };
+  try {
+    const { data, error } = await supabase
+      .from('tournament_collaborators')
+      .insert({
+        tournament_id: options.tournamentId,
+        invite_code: inviteCode,
+        role: options.role,
+        team_ids: options.teamIds ?? [],
+        label: options.label,
+        max_uses: options.maxUses ?? 1,
+        use_count: 0,
+        expires_at: new Date(now.getTime() + daysInMs).toISOString(),
+        invited_by: options.createdBy,
+        invited_at: now.toISOString(),
+      })
+      .select()
+      .single();
 
-  // Speichern
-  const invitations = getInvitations();
-  invitations.push(invitation);
-  saveInvitations(invitations);
+    if (error) {
+      console.error('Create invitation error:', error);
+      return { success: false, error: error.message };
+    }
 
-  // Link generieren
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://app.turnier.de';
-  const inviteLink = `${baseUrl}/invite?token=${invitation.token}`;
+    const invitation = mapRowToInvitation(data as CollaboratorRow);
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://app.turnier.de';
+    const inviteLink = `${baseUrl}/invite?token=${inviteCode}`;
 
-  return {
-    success: true,
-    invitation,
-    inviteLink,
-  };
+    return {
+      success: true,
+      invitation,
+      inviteLink,
+    };
+  } catch (err) {
+    console.error('Create invitation error:', err);
+    return { success: false, error: 'Ein unerwarteter Fehler ist aufgetreten' };
+  }
 };
 
 /**
@@ -185,42 +208,76 @@ export const createInvitation = (options: CreateInvitationOptions): CreateInvita
  * @param token - Der zu validierende Token
  * @returns Validierungs-Ergebnis
  */
-export const validateInvitation = (token: string): InvitationValidationResult => {
-  const invitations = getInvitations();
-  const invitation = invitations.find((i) => i.token === token);
-
-  if (!invitation) {
+export const validateInvitation = async (token: string): Promise<InvitationValidationResult> => {
+  if (!isSupabaseConfigured || !supabase) {
     return { valid: false, error: 'not_found' };
   }
 
-  if (!invitation.isActive) {
-    return { valid: false, error: 'deactivated' };
+  try {
+    const { data, error } = await supabase
+      .from('tournament_collaborators')
+      .select('*, tournaments(id, title)')
+      .eq('invite_code', token)
+      .single();
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (error || !data) {
+      return { valid: false, error: 'not_found' };
+    }
+
+    const row = data as CollaboratorRow & { tournaments?: { id: string; title: string } };
+
+    // Check if already used (has user_id = accepted)
+    if (row.user_id) {
+      return { valid: false, error: 'already_used' };
+    }
+
+    // Check if deactivated
+    if (row.declined_at) {
+      return { valid: false, error: 'deactivated' };
+    }
+
+    // Check expiry
+    if (row.expires_at && new Date(row.expires_at) < new Date()) {
+      return { valid: false, error: 'expired' };
+    }
+
+    // Check max uses
+    const maxUses = row.max_uses ?? 1;
+    const useCount = row.use_count ?? 0;
+    if (maxUses > 0 && useCount >= maxUses) {
+      return { valid: false, error: 'max_uses_reached' };
+    }
+
+    const invitation = mapRowToInvitation(row);
+
+    // Get inviter info
+    let inviter: { id: string; name: string } | undefined;
+    if (row.invited_by) {
+      const { data: profileData } = await supabase
+        .from('profiles')
+        .select('id, display_name')
+        .eq('id', row.invited_by)
+        .single();
+
+      if (profileData) {
+        inviter = {
+          id: profileData.id,
+          name: profileData.display_name ?? 'Unknown',
+        };
+      }
+    }
+
+    return {
+      valid: true,
+      invitation,
+      tournament: row.tournaments ? { id: row.tournaments.id, name: row.tournaments.title } : undefined,
+      inviter,
+    };
+  } catch (err) {
+    console.error('Validate invitation error:', err);
+    return { valid: false, error: 'not_found' };
   }
-
-  if (new Date(invitation.expiresAt) < new Date()) {
-    return { valid: false, error: 'expired' };
-  }
-
-  if (invitation.maxUses > 0 && invitation.useCount >= invitation.maxUses) {
-    return { valid: false, error: 'max_uses_reached' };
-  }
-
-  // Turnier-Info laden (vereinfacht)
-  const tournamentsRaw = localStorage.getItem('tournaments');
-  const tournaments = tournamentsRaw ? (JSON.parse(tournamentsRaw) as Array<{ id: string; title: string }>) : [];
-  const tournament = tournaments.find((t) => t.id === invitation.tournamentId);
-
-  // Ersteller-Info laden (vereinfacht)
-  const usersRaw = localStorage.getItem(AUTH_STORAGE_KEYS.USERS);
-  const users = usersRaw ? (JSON.parse(usersRaw) as Array<{ id: string; name: string }>) : [];
-  const inviter = users.find((u) => u.id === invitation.createdBy);
-
-  return {
-    valid: true,
-    invitation,
-    tournament: tournament ? { id: tournament.id, name: tournament.title } : undefined,
-    inviter: inviter ? { id: inviter.id, name: inviter.name } : undefined,
-  };
 };
 
 /**
@@ -230,54 +287,58 @@ export const validateInvitation = (token: string): InvitationValidationResult =>
  * @param userId - ID des annehmenden Users
  * @returns Ergebnis mit Membership
  */
-export const acceptInvitation = (token: string, userId: string): AcceptInvitationResult => {
-  const validation = validateInvitation(token);
+export const acceptInvitation = async (token: string, userId: string): Promise<AcceptInvitationResult> => {
+  if (!isSupabaseConfigured || !supabase) {
+    return { success: false, error: 'Cloud-Funktionen sind nicht verfügbar' };
+  }
+
+  const validation = await validateInvitation(token);
 
   if (!validation.valid || !validation.invitation) {
     return { success: false, error: validation.error ?? 'Einladung nicht gefunden' };
   }
 
   const invitation = validation.invitation;
-  const memberships = getMemberships();
 
-  // Prüfen ob User bereits Mitglied ist
-  const existingMembership = memberships.find(
-    (m) => m.userId === userId && m.tournamentId === invitation.tournamentId
-  );
+  try {
+    // Check if user is already a member
+    const { data: existingMember } = await supabase
+      .from('tournament_collaborators')
+      .select('id')
+      .eq('tournament_id', invitation.tournamentId)
+      .eq('user_id', userId)
+      .single();
 
-  if (existingMembership) {
-    return { success: false, error: 'already_member' };
+    if (existingMember) {
+      return { success: false, error: 'already_member' };
+    }
+
+    const now = new Date().toISOString();
+
+    // Update the invitation row: set user_id and accepted_at
+    const { data, error } = await supabase
+      .from('tournament_collaborators')
+      .update({
+        user_id: userId,
+        accepted_at: now,
+        use_count: invitation.useCount + 1,
+      })
+      .eq('id', invitation.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Accept invitation error:', error);
+      return { success: false, error: error.message };
+    }
+
+    const membership = mapRowToMembership(data as CollaboratorRow);
+
+    return { success: true, membership };
+  } catch (err) {
+    console.error('Accept invitation error:', err);
+    return { success: false, error: 'Ein unerwarteter Fehler ist aufgetreten' };
   }
-
-  // Neue Membership erstellen
-  const now = new Date().toISOString();
-  const membership: TournamentMembership = {
-    id: generateUUID(),
-    userId,
-    tournamentId: invitation.tournamentId,
-    role: invitation.role,
-    teamIds: invitation.teamIds,
-    invitedBy: invitation.createdBy,
-    invitedAt: invitation.createdAt,
-    acceptedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  // Membership speichern
-  memberships.push(membership);
-  saveMemberships(memberships);
-
-  // Einladung aktualisieren
-  const invitations = getInvitations();
-  const invIndex = invitations.findIndex((i) => i.id === invitation.id);
-  if (invIndex >= 0) {
-    invitations[invIndex].useCount++;
-    invitations[invIndex].usedBy.push(userId);
-    saveInvitations(invitations);
-  }
-
-  return { success: true, membership };
 };
 
 /**
@@ -286,17 +347,22 @@ export const acceptInvitation = (token: string, userId: string): AcceptInvitatio
  * @param invitationId - ID der Einladung
  * @returns true wenn erfolgreich
  */
-export const deactivateInvitation = (invitationId: string): boolean => {
-  const invitations = getInvitations();
-  const index = invitations.findIndex((i) => i.id === invitationId);
-
-  if (index < 0) {
+export const deactivateInvitation = async (invitationId: string): Promise<boolean> => {
+  if (!isSupabaseConfigured || !supabase) {
     return false;
   }
 
-  invitations[index].isActive = false;
-  saveInvitations(invitations);
-  return true;
+  try {
+    const { error } = await supabase
+      .from('tournament_collaborators')
+      .update({ declined_at: new Date().toISOString() })
+      .eq('id', invitationId)
+      .is('user_id', null); // Only deactivate pending invitations
+
+    return !error;
+  } catch {
+    return false;
+  }
 };
 
 /**
@@ -305,15 +371,35 @@ export const deactivateInvitation = (invitationId: string): boolean => {
  * @param tournamentId - Turnier-ID
  * @returns Array von Einladungen
  */
-export const getActiveInvitationsForTournament = (tournamentId: string): Invitation[] => {
-  const invitations = getInvitations();
-  return invitations.filter(
-    (i) =>
-      i.tournamentId === tournamentId &&
-      i.isActive &&
-      new Date(i.expiresAt) > new Date() &&
-      (i.maxUses === 0 || i.useCount < i.maxUses)
-  );
+export const getActiveInvitationsForTournament = async (tournamentId: string): Promise<Invitation[]> => {
+  if (!isSupabaseConfigured || !supabase) {
+    return [];
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('tournament_collaborators')
+      .select('*')
+      .eq('tournament_id', tournamentId)
+      .is('user_id', null) // Pending invitations only
+      .is('declined_at', null) // Not deactivated
+      .gt('expires_at', new Date().toISOString()); // Not expired
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (error || !data) {
+      return [];
+    }
+
+    return (data as CollaboratorRow[])
+      .filter((row) => {
+        const maxUses = row.max_uses ?? 1;
+        const useCount = row.use_count ?? 0;
+        return maxUses === 0 || useCount < maxUses;
+      })
+      .map(mapRowToInvitation);
+  } catch {
+    return [];
+  }
 };
 
 /**
@@ -322,7 +408,40 @@ export const getActiveInvitationsForTournament = (tournamentId: string): Invitat
  * @param token - Der Token
  * @returns Die Einladung oder undefined
  */
-export const getInvitationByToken = (token: string): Invitation | undefined => {
-  const invitations = getInvitations();
-  return invitations.find((i) => i.token === token);
+export const getInvitationByToken = async (token: string): Promise<Invitation | undefined> => {
+  if (!isSupabaseConfigured || !supabase) {
+    return undefined;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('tournament_collaborators')
+      .select('*')
+      .eq('invite_code', token)
+      .single();
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (error || !data) {
+      return undefined;
+    }
+
+    return mapRowToInvitation(data as CollaboratorRow);
+  } catch {
+    return undefined;
+  }
+};
+
+// ============================================
+// LEGACY SYNC FUNCTIONS (for backward compatibility)
+// ============================================
+
+/**
+ * @deprecated Use async version instead
+ * Synchronous wrapper - returns empty for non-async contexts
+ */
+export const createInvitationSync = (options: CreateInvitationOptions): CreateInvitationResult => {
+  console.warn('createInvitationSync is deprecated. Use createInvitation() async function.');
+  // Trigger async operation
+  void createInvitation(options);
+  return { success: false, error: 'Use async version' };
 };

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -244,7 +244,7 @@ export interface InvitationValidationResult {
     id: string;
     name: string;
   };
-  error?: 'not_found' | 'expired' | 'max_uses_reached' | 'deactivated';
+  error?: 'not_found' | 'expired' | 'max_uses_reached' | 'deactivated' | 'already_used';
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Refactor invitationService.ts: localStorage → Supabase tournament_collaborators table
- Refactor membershipService.ts: localStorage → Supabase tournament_collaborators table
- Update useTournamentMembers hook for async Supabase operations
- Update useInvitation hook for proper async patterns
- Fix async handlers in InviteAcceptScreen.tsx and InviteDialog.tsx
- Add 'already_used' to InvitationValidationResult error types
- Align CollaboratorRow interface with actual Supabase schema

## Test plan
- [x] Build passes
- [x] Lint passes (440 tests)
- [x] TypeScript compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)