### PR TITLE
feat(realtime): add Supabase Realtime sync for live matches

### DIFF
--- a/src/core/contexts/RepositoryContext.tsx
+++ b/src/core/contexts/RepositoryContext.tsx
@@ -1,49 +1,131 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useMemo, useEffect, useRef } from 'react';
 import { useAuth } from '../../features/auth/hooks/useAuth';
 import { ITournamentRepository } from '../repositories/ITournamentRepository';
+import { ILiveMatchRepository } from '../repositories/ILiveMatchRepository';
 import { LocalStorageRepository } from '../repositories/LocalStorageRepository';
+import { LocalStorageLiveMatchRepository } from '../repositories/LocalStorageLiveMatchRepository';
 import { SupabaseRepository } from '../repositories/SupabaseRepository';
+import { SupabaseLiveMatchRepository } from '../repositories/SupabaseLiveMatchRepository';
 import { OfflineRepository } from '../repositories/OfflineRepository';
 import { isSupabaseConfigured } from '../../lib/supabase';
 
-const RepositoryContext = createContext<ITournamentRepository | null>(null);
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface RepositoryContextValue {
+    tournamentRepository: ITournamentRepository;
+    liveMatchRepository: ILiveMatchRepository;
+    /** True if using Supabase with realtime capabilities */
+    isRealtimeEnabled: boolean;
+    /** Supabase-specific repo for subscriptions (null if not available) */
+    supabaseLiveMatchRepo: SupabaseLiveMatchRepository | null;
+}
+
+// ============================================================================
+// CONTEXT
+// ============================================================================
+
+const RepositoryContext = createContext<RepositoryContextValue | null>(null);
 
 export const RepositoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const { user } = useAuth(); // Wait for auth to settle
+    const supabaseLiveMatchRepoRef = useRef<SupabaseLiveMatchRepository | null>(null);
 
-    const repository = useMemo(() => {
-        // Always need local repo
-        const localRepo = new LocalStorageRepository();
+    const value = useMemo(() => {
+        // Always need local repos
+        const localTournamentRepo = new LocalStorageRepository();
+        const localLiveMatchRepo = new LocalStorageLiveMatchRepository();
 
-        // If authenticated AND Supabase is configured -> Use Offline/Sync Repo
+        // If authenticated AND Supabase is configured -> Use Supabase repos
         if (user && isSupabaseConfigured) {
             try {
-                const supabaseRepo = new SupabaseRepository();
-                const offlineRepo = new OfflineRepository(localRepo, supabaseRepo);
+                const supabaseTournamentRepo = new SupabaseRepository();
+                const offlineTournamentRepo = new OfflineRepository(localTournamentRepo, supabaseTournamentRepo);
 
-                return offlineRepo;
+                // Create Supabase live match repo
+                const supabaseLiveMatchRepo = new SupabaseLiveMatchRepository();
+                supabaseLiveMatchRepoRef.current = supabaseLiveMatchRepo;
+
+                return {
+                    tournamentRepository: offlineTournamentRepo,
+                    liveMatchRepository: supabaseLiveMatchRepo,
+                    isRealtimeEnabled: true,
+                    supabaseLiveMatchRepo: supabaseLiveMatchRepo,
+                };
             } catch (e) {
-                console.error('RepositoryProvider: Failed to init SupabaseRepo', e);
-                return localRepo;
+                console.error('RepositoryProvider: Failed to init Supabase repos', e);
+                supabaseLiveMatchRepoRef.current = null;
+                return {
+                    tournamentRepository: localTournamentRepo,
+                    liveMatchRepository: localLiveMatchRepo,
+                    isRealtimeEnabled: false,
+                    supabaseLiveMatchRepo: null,
+                };
             }
         }
 
         // Fallback / Guest -> Local Only
-        return localRepo;
+        supabaseLiveMatchRepoRef.current = null;
+        return {
+            tournamentRepository: localTournamentRepo,
+            liveMatchRepository: localLiveMatchRepo,
+            isRealtimeEnabled: false,
+            supabaseLiveMatchRepo: null,
+        };
     }, [user]);
 
+    // Cleanup subscriptions on unmount
+    useEffect(() => {
+        return () => {
+            supabaseLiveMatchRepoRef.current?.unsubscribeAll();
+        };
+    }, []);
+
     return (
-        <RepositoryContext.Provider value={repository}>
+        <RepositoryContext.Provider value={value}>
             {children}
         </RepositoryContext.Provider>
     );
 };
 
+// ============================================================================
+// HOOKS
+// ============================================================================
+
+/**
+ * @deprecated Use useRepositories() instead for full context
+ */
 // eslint-disable-next-line react-refresh/only-export-components
 export const useRepositoryContext = () => {
     const context = useContext(RepositoryContext);
     if (!context) {
         throw new Error('useRepositoryContext must be used within a RepositoryProvider');
     }
+    // For backwards compatibility, return just the tournament repository
+    return context.tournamentRepository;
+};
+
+/**
+ * Access all repositories and realtime capabilities
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const useRepositories = () => {
+    const context = useContext(RepositoryContext);
+    if (!context) {
+        throw new Error('useRepositories must be used within a RepositoryProvider');
+    }
     return context;
+};
+
+/**
+ * Access just the live match repository
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLiveMatchRepository = () => {
+    const context = useContext(RepositoryContext);
+    if (!context) {
+        throw new Error('useLiveMatchRepository must be used within a RepositoryProvider');
+    }
+    return context.liveMatchRepository;
 };

--- a/src/core/repositories/SupabaseLiveMatchRepository.ts
+++ b/src/core/repositories/SupabaseLiveMatchRepository.ts
@@ -1,0 +1,408 @@
+/**
+ * SupabaseLiveMatchRepository
+ *
+ * Supabase implementation of ILiveMatchRepository with Realtime subscriptions.
+ * Enables cross-device synchronization of live match state.
+ *
+ * Uses:
+ * - matches table (with live_state JSONB column)
+ * - match_events table for event history
+ * - Supabase Realtime for live updates
+ */
+
+import { RealtimeChannel } from '@supabase/supabase-js';
+import { ILiveMatchRepository } from './ILiveMatchRepository';
+import { LiveMatch } from '../models/LiveMatch';
+import { supabase, isSupabaseConfigured } from '../../lib/supabase';
+import type { Tables } from '../../types/supabase';
+import {
+  mapLiveMatchFromSupabase,
+  mapLiveMatchToSupabase,
+  isMatchActive,
+} from './liveMatchMappers';
+
+type MatchRow = Tables<'matches'>;
+type MatchEventRow = Tables<'match_events'>;
+type TeamRow = Tables<'teams'>;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type LiveMatchChangeHandler = (
+  matchId: string,
+  match: LiveMatch | null, // null = deleted
+  changeType: 'INSERT' | 'UPDATE' | 'DELETE'
+) => void;
+
+export interface SubscriptionOptions {
+  onMatchChange?: LiveMatchChangeHandler;
+  onError?: (error: Error) => void;
+}
+
+// ============================================================================
+// REPOSITORY
+// ============================================================================
+
+export class SupabaseLiveMatchRepository implements ILiveMatchRepository {
+  private subscriptions = new Map<string, RealtimeChannel>();
+  private teamsCache = new Map<string, Map<string, TeamRow>>();
+  private eventIdsCache = new Map<string, Set<string>>();
+
+  // ==========================================================================
+  // ILiveMatchRepository Implementation
+  // ==========================================================================
+
+  async get(tournamentId: string, matchId: string): Promise<LiveMatch | null> {
+    if (!isSupabaseConfigured || !supabase) {
+      return null;
+    }
+
+    try {
+      // Load teams if not cached
+      const teamsMap = await this.ensureTeamsLoaded(tournamentId);
+
+      // Fetch match
+      const { data: matchRow, error: matchError } = await supabase
+        .from('matches')
+        .select('*')
+        .eq('id', matchId)
+        .single();
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (matchError || !matchRow) {
+        return null;
+      }
+
+      // Only return if match has live state (is active)
+      if (!isMatchActive(matchRow)) {
+        return null;
+      }
+
+      // Fetch events
+      const { data: events } = await supabase
+        .from('match_events')
+        .select('*')
+        .eq('match_id', matchId)
+        .eq('is_deleted', false)
+        .order('timestamp_seconds', { ascending: true });
+
+      return mapLiveMatchFromSupabase(matchRow, events ?? [], teamsMap);
+    } catch (error) {
+      console.error('[SupabaseLiveMatchRepository] get failed:', error);
+      return null;
+    }
+  }
+
+  async getAll(tournamentId: string): Promise<Map<string, LiveMatch>> {
+    if (!isSupabaseConfigured || !supabase) {
+      return new Map();
+    }
+
+    try {
+      // Load teams if not cached
+      const teamsMap = await this.ensureTeamsLoaded(tournamentId);
+
+      // Fetch active matches (have live_state or are running/paused)
+      const { data: matchRows, error: matchError } = await supabase
+        .from('matches')
+        .select('*')
+        .eq('tournament_id', tournamentId)
+        .in('match_status', ['running', 'paused']);
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (matchError || !matchRows) {
+        return new Map();
+      }
+
+      if (matchRows.length === 0) {
+        return new Map();
+      }
+
+      // Fetch all events for these matches
+      const matchIds = matchRows.map((m) => m.id);
+      const { data: allEvents } = await supabase
+        .from('match_events')
+        .select('*')
+        .in('match_id', matchIds)
+        .eq('is_deleted', false)
+        .order('timestamp_seconds', { ascending: true });
+
+      // Group events by match
+      const eventsByMatch = new Map<string, MatchEventRow[]>();
+      for (const event of allEvents ?? []) {
+        const existing = eventsByMatch.get(event.match_id) ?? [];
+        existing.push(event);
+        eventsByMatch.set(event.match_id, existing);
+      }
+
+      // Map to LiveMatch
+      const result = new Map<string, LiveMatch>();
+      for (const matchRow of matchRows) {
+        const events = eventsByMatch.get(matchRow.id) ?? [];
+        const liveMatch = mapLiveMatchFromSupabase(matchRow, events, teamsMap);
+        result.set(matchRow.id, liveMatch);
+      }
+
+      // Update event ID cache
+      for (const event of allEvents ?? []) {
+        const cached = this.eventIdsCache.get(event.match_id) ?? new Set();
+        cached.add(event.id);
+        this.eventIdsCache.set(event.match_id, cached);
+      }
+
+      return result;
+    } catch (error) {
+      console.error('[SupabaseLiveMatchRepository] getAll failed:', error);
+      return new Map();
+    }
+  }
+
+  async save(_tournamentId: string, match: LiveMatch): Promise<void> {
+    if (!isSupabaseConfigured || !supabase) {
+      return;
+    }
+
+    try {
+      // Get existing event IDs
+      const existingEventIds = this.eventIdsCache.get(match.id) ?? new Set();
+
+      // Map to Supabase format
+      const { matchUpdate, newEvents } = mapLiveMatchToSupabase(match, existingEventIds);
+
+      // Update match
+      const { error: matchError } = await supabase
+        .from('matches')
+        .update(matchUpdate as unknown as Record<string, unknown>)
+        .eq('id', match.id);
+
+      if (matchError) {
+        console.error('[SupabaseLiveMatchRepository] match update failed:', matchError);
+        throw matchError;
+      }
+
+      // Insert new events
+      if (newEvents.length > 0) {
+        const { error: eventsError } = await supabase
+          .from('match_events')
+          .insert(newEvents);
+
+        if (eventsError) {
+          console.error('[SupabaseLiveMatchRepository] events insert failed:', eventsError);
+          // Don't throw - match was updated successfully
+        }
+
+        // Update event ID cache
+        for (const event of newEvents) {
+          existingEventIds.add(event.id);
+        }
+        this.eventIdsCache.set(match.id, existingEventIds);
+      }
+    } catch (error) {
+      console.error('[SupabaseLiveMatchRepository] save failed:', error);
+      throw error;
+    }
+  }
+
+  async saveAll(tournamentId: string, matches: Map<string, LiveMatch>): Promise<void> {
+    // Save each match individually (could be optimized with batch upsert)
+    const promises = Array.from(matches.values()).map((match) =>
+      this.save(tournamentId, match)
+    );
+    await Promise.all(promises);
+  }
+
+  async delete(_tournamentId: string, matchId: string): Promise<void> {
+    if (!isSupabaseConfigured || !supabase) {
+      return;
+    }
+
+    try {
+      // Clear live_state (don't delete the match, just clear live state)
+      const { error } = await supabase
+        .from('matches')
+        .update({ live_state: null } as unknown as Record<string, unknown>)
+        .eq('id', matchId);
+
+      if (error) {
+        console.error('[SupabaseLiveMatchRepository] delete failed:', error);
+        throw error;
+      }
+
+      // Clear event cache
+      this.eventIdsCache.delete(matchId);
+    } catch (error) {
+      console.error('[SupabaseLiveMatchRepository] delete failed:', error);
+      throw error;
+    }
+  }
+
+  async clear(tournamentId: string): Promise<void> {
+    if (!isSupabaseConfigured || !supabase) {
+      return;
+    }
+
+    try {
+      // Clear live_state for all tournament matches
+      const { error } = await supabase
+        .from('matches')
+        .update({ live_state: null } as unknown as Record<string, unknown>)
+        .eq('tournament_id', tournamentId);
+
+      if (error) {
+        console.error('[SupabaseLiveMatchRepository] clear failed:', error);
+        throw error;
+      }
+
+      // Clear caches
+      this.teamsCache.delete(tournamentId);
+      // Clear all event caches for this tournament (would need match IDs)
+    } catch (error) {
+      console.error('[SupabaseLiveMatchRepository] clear failed:', error);
+      throw error;
+    }
+  }
+
+  // ==========================================================================
+  // Realtime Subscriptions
+  // ==========================================================================
+
+  /**
+   * Subscribe to live match changes for a tournament
+   */
+  subscribe(tournamentId: string, options: SubscriptionOptions): void {
+    if (!isSupabaseConfigured || !supabase) {
+      return;
+    }
+
+    // Unsubscribe if already subscribed
+    this.unsubscribe(tournamentId);
+
+    const channel = supabase
+      .channel(`live-matches-${tournamentId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'matches',
+          filter: `tournament_id=eq.${tournamentId}`,
+        },
+        (payload) => {
+          void (async () => {
+            try {
+              const matchRow = payload.new as MatchRow | undefined;
+              const oldRow = payload.old as { id: string } | undefined;
+
+              if (payload.eventType === 'DELETE' && oldRow) {
+                options.onMatchChange?.(oldRow.id, null, 'DELETE');
+                return;
+              }
+
+              if (!matchRow) { return; }
+
+            // Skip if not active
+            if (!isMatchActive(matchRow)) {
+              // If it was active before, treat as delete
+              if (payload.eventType === 'UPDATE') {
+                const oldMatch = payload.old as MatchRow | undefined;
+                if (oldMatch && isMatchActive(oldMatch)) {
+                  options.onMatchChange?.(matchRow.id, null, 'DELETE');
+                }
+              }
+              return;
+            }
+
+            // Load teams and events
+            const teamsMap = await this.ensureTeamsLoaded(tournamentId);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const { data: events } = await supabase!
+              .from('match_events')
+              .select('*')
+              .eq('match_id', matchRow.id)
+              .eq('is_deleted', false)
+              .order('timestamp_seconds', { ascending: true });
+
+            const liveMatch = mapLiveMatchFromSupabase(matchRow, events ?? [], teamsMap);
+
+            options.onMatchChange?.(
+              matchRow.id,
+              liveMatch,
+              payload.eventType as 'INSERT' | 'UPDATE'
+            );
+            } catch (error) {
+              console.error('[SupabaseLiveMatchRepository] subscription handler error:', error);
+              options.onError?.(error as Error);
+            }
+          })();
+        }
+      )
+      .subscribe((status: string) => {
+        if (status === 'SUBSCRIBED') {
+          // Successfully subscribed to realtime changes
+        } else if (status === 'CHANNEL_ERROR') {
+          options.onError?.(new Error('Realtime subscription failed'));
+        }
+      });
+
+    this.subscriptions.set(tournamentId, channel);
+  }
+
+  /**
+   * Unsubscribe from live match changes
+   */
+  unsubscribe(tournamentId: string): void {
+    const channel = this.subscriptions.get(tournamentId);
+    if (channel && supabase) {
+      void supabase.removeChannel(channel);
+      this.subscriptions.delete(tournamentId);
+    }
+  }
+
+  /**
+   * Unsubscribe from all tournaments
+   */
+  unsubscribeAll(): void {
+    for (const tournamentId of this.subscriptions.keys()) {
+      this.unsubscribe(tournamentId);
+    }
+  }
+
+  // ==========================================================================
+  // Private Helpers
+  // ==========================================================================
+
+  private async ensureTeamsLoaded(tournamentId: string): Promise<Map<string, TeamRow>> {
+    // Return cached if available
+    const cached = this.teamsCache.get(tournamentId);
+    if (cached) {
+      return cached;
+    }
+
+    if (!supabase) {
+      return new Map();
+    }
+
+    // Load teams
+    const { data: teams } = await supabase
+      .from('teams')
+      .select('*')
+      .eq('tournament_id', tournamentId)
+      .eq('is_removed', false);
+
+    const teamsMap = new Map<string, TeamRow>();
+    for (const team of teams ?? []) {
+      teamsMap.set(team.id, team);
+    }
+
+    this.teamsCache.set(tournamentId, teamsMap);
+    return teamsMap;
+  }
+
+  /**
+   * Invalidate teams cache (call when teams are updated)
+   */
+  invalidateTeamsCache(tournamentId: string): void {
+    this.teamsCache.delete(tournamentId);
+  }
+}

--- a/src/core/repositories/index.ts
+++ b/src/core/repositories/index.ts
@@ -6,7 +6,10 @@ export type { ILiveMatchRepository } from './ILiveMatchRepository';
 export { LocalStorageRepository } from './LocalStorageRepository';
 export { LocalStorageLiveMatchRepository } from './LocalStorageLiveMatchRepository';
 export { SupabaseRepository } from './SupabaseRepository';
+export { SupabaseLiveMatchRepository } from './SupabaseLiveMatchRepository';
+export type { LiveMatchChangeHandler, SubscriptionOptions } from './SupabaseLiveMatchRepository';
 
 // Mappers
 export * from './supabaseMappers';
+export * from './liveMatchMappers';
 

--- a/src/core/repositories/liveMatchMappers.ts
+++ b/src/core/repositories/liveMatchMappers.ts
@@ -1,0 +1,308 @@
+/**
+ * LiveMatch Mappers - Supabase ↔ LiveMatch Type Conversion
+ *
+ * Converts between Supabase database rows and LiveMatch frontend types.
+ * Used by SupabaseLiveMatchRepository for real-time match state sync.
+ */
+
+import type { Json, Tables } from '../../types/supabase';
+import type {
+  LiveMatch,
+  LiveTeamInfo,
+  MatchEvent,
+  MatchEventType,
+  MatchStatus,
+  PlayPhase,
+  TournamentPhase,
+  TiebreakerMode,
+} from '../models/LiveMatch';
+import type { TeamLogo, TeamColors } from '../../types/tournament';
+
+// ============================================================================
+// TYPE ALIASES
+// ============================================================================
+
+type MatchRow = Tables<'matches'>;
+type MatchEventRow = Tables<'match_events'>;
+type TeamRow = Tables<'teams'>;
+
+// ============================================================================
+// STATUS MAPPING
+// ============================================================================
+
+const STATUS_TO_FRONTEND: Record<string, MatchStatus> = {
+  not_started: 'NOT_STARTED',
+  running: 'RUNNING',
+  paused: 'PAUSED',
+  finished: 'FINISHED',
+};
+
+const STATUS_TO_DB: Record<MatchStatus, string> = {
+  NOT_STARTED: 'not_started',
+  RUNNING: 'running',
+  PAUSED: 'paused',
+  FINISHED: 'finished',
+};
+
+const PHASE_TO_FRONTEND: Record<string, TournamentPhase> = {
+  groupStage: 'groupStage',
+  roundOf16: 'roundOf16',
+  quarterfinal: 'quarterfinal',
+  semifinal: 'semifinal',
+  final: 'final',
+};
+
+// ============================================================================
+// TEAM INFO MAPPER
+// ============================================================================
+
+/**
+ * Maps a TeamRow to LiveTeamInfo
+ */
+export function mapTeamToLiveTeamInfo(team: TeamRow | null): LiveTeamInfo {
+  if (!team) {
+    return {
+      id: '',
+      name: 'TBD',
+    };
+  }
+
+  const logo: TeamLogo | undefined = team.logo_path
+    ? {
+        type: 'url',
+        value: team.logo_path,
+        backgroundColor: team.logo_background_color ?? undefined,
+      }
+    : undefined;
+
+  const colors: TeamColors | undefined =
+    team.color_primary || team.color_secondary
+      ? {
+          primary: team.color_primary ?? '#333333',
+          secondary: team.color_secondary ?? '#ffffff',
+        }
+      : undefined;
+
+  return {
+    id: team.id,
+    name: team.name,
+    logo,
+    colors,
+  };
+}
+
+// ============================================================================
+// EVENT MAPPERS
+// ============================================================================
+
+/**
+ * Maps a Supabase match_events row to MatchEvent
+ */
+export function mapMatchEventFromSupabase(row: MatchEventRow): MatchEvent {
+  const payload = row.payload as Record<string, unknown> | null;
+
+  return {
+    id: row.id,
+    matchId: row.match_id,
+    timestampSeconds: row.timestamp_seconds,
+    type: row.type as MatchEventType,
+    payload: {
+      team: payload?.team as 'home' | 'away' | undefined,
+      delta: payload?.delta as number | undefined,
+      playerNumber: payload?.playerNumber as number | undefined,
+      assists: payload?.assists as number[] | undefined,
+      cardType: payload?.cardType as 'YELLOW' | 'RED' | undefined,
+      toStatus: payload?.toStatus as MatchStatus | undefined,
+      durationSeconds: payload?.durationSeconds as number | undefined,
+      playersIn: payload?.playersIn as number[] | undefined,
+      playersOut: payload?.playersOut as number[] | undefined,
+    },
+    scoreAfter: {
+      home: row.score_home,
+      away: row.score_away,
+    },
+  };
+}
+
+/**
+ * Maps a MatchEvent to Supabase match_events insert format
+ */
+export function mapMatchEventToSupabase(
+  event: MatchEvent,
+  matchId: string
+): Omit<MatchEventRow, 'created_at'> {
+  return {
+    id: event.id,
+    match_id: matchId,
+    timestamp_seconds: event.timestampSeconds,
+    type: event.type,
+    payload: event.payload as unknown as Json,
+    score_home: event.scoreAfter.home,
+    score_away: event.scoreAfter.away,
+    team_id: null, // Could be mapped if we track team_id in payload
+    player_id: null, // Could be mapped if we track player_id
+    period: null,
+    incomplete: false,
+    is_deleted: false,
+  };
+}
+
+// ============================================================================
+// LIVE MATCH MAPPERS
+// ============================================================================
+
+/**
+ * Live state stored in JSONB column - fields not in main match row
+ */
+interface LiveStateJson {
+  elapsedSeconds?: number;
+  durationSeconds?: number;
+  playPhase?: PlayPhase;
+  tiebreakerMode?: TiebreakerMode;
+  overtimeDurationSeconds?: number;
+  overtimeElapsedSeconds?: number;
+  awaitingTiebreakerChoice?: boolean;
+  refereeName?: string;
+}
+
+/**
+ * Maps Supabase match row + events to LiveMatch
+ *
+ * @param matchRow - The match row from Supabase
+ * @param events - Array of match events
+ * @param teamsMap - Map of team ID to TeamRow for lookup
+ */
+export function mapLiveMatchFromSupabase(
+  matchRow: MatchRow,
+  events: MatchEventRow[],
+  teamsMap: Map<string, TeamRow>
+): LiveMatch {
+  const homeTeam = teamsMap.get(matchRow.team_a_id ?? '');
+  const awayTeam = teamsMap.get(matchRow.team_b_id ?? '');
+
+  // Parse live_state JSONB if present (note: not in generated types yet, so we cast)
+  const liveState = (matchRow as MatchRow & { live_state?: LiveStateJson }).live_state;
+
+  // Map status
+  const status = STATUS_TO_FRONTEND[matchRow.match_status ?? 'not_started'] ?? 'NOT_STARTED';
+
+  // Map tournament phase
+  const tournamentPhase = matchRow.phase
+    ? (PHASE_TO_FRONTEND[matchRow.phase] ?? undefined)
+    : undefined;
+
+  // Sort events by timestamp
+  const sortedEvents = [...events]
+    .filter((e) => !e.is_deleted)
+    .sort((a, b) => a.timestamp_seconds - b.timestamp_seconds);
+
+  return {
+    // Identity
+    id: matchRow.id,
+    number: matchRow.match_number ?? 0,
+    phaseLabel: matchRow.label ?? matchRow.phase ?? 'Gruppe',
+    fieldId: String(matchRow.field),
+    scheduledKickoff: matchRow.scheduled_start ?? new Date().toISOString(),
+    refereeName: liveState?.refereeName,
+
+    // Teams
+    homeTeam: mapTeamToLiveTeamInfo(homeTeam ?? null),
+    awayTeam: mapTeamToLiveTeamInfo(awayTeam ?? null),
+
+    // Scores
+    homeScore: matchRow.score_a ?? 0,
+    awayScore: matchRow.score_b ?? 0,
+
+    // Status
+    status,
+    elapsedSeconds: liveState?.elapsedSeconds ?? 0,
+    durationSeconds: liveState?.durationSeconds ?? (matchRow.duration_minutes ?? 10) * 60,
+
+    // Timer persistence
+    timerStartTime: matchRow.timer_start_time ?? undefined,
+    timerPausedAt: matchRow.timer_paused_at ?? undefined,
+    timerElapsedSeconds: matchRow.timer_elapsed_seconds ?? undefined,
+
+    // Events
+    events: sortedEvents.map(mapMatchEventFromSupabase),
+
+    // Tournament context
+    tournamentPhase,
+
+    // Tiebreaker
+    playPhase: liveState?.playPhase,
+    tiebreakerMode: liveState?.tiebreakerMode,
+    overtimeDurationSeconds: liveState?.overtimeDurationSeconds,
+    overtimeElapsedSeconds: liveState?.overtimeElapsedSeconds,
+    awaitingTiebreakerChoice: liveState?.awaitingTiebreakerChoice,
+
+    // Tiebreaker scores
+    overtimeScoreA: matchRow.overtime_score_a ?? undefined,
+    overtimeScoreB: matchRow.overtime_score_b ?? undefined,
+    penaltyScoreA: matchRow.penalty_score_a ?? undefined,
+    penaltyScoreB: matchRow.penalty_score_b ?? undefined,
+  };
+}
+
+/**
+ * Maps a LiveMatch to Supabase match update format
+ *
+ * Returns both the match update and new events to insert
+ */
+export function mapLiveMatchToSupabase(
+  liveMatch: LiveMatch,
+  existingEventIds: Set<string> = new Set<string>()
+): {
+  matchUpdate: Partial<MatchRow> & { live_state: LiveStateJson | null };
+  newEvents: Array<Omit<MatchEventRow, 'created_at'>>;
+} {
+  // Build live_state JSONB
+  const liveState: LiveStateJson = {
+    elapsedSeconds: liveMatch.elapsedSeconds,
+    durationSeconds: liveMatch.durationSeconds,
+    playPhase: liveMatch.playPhase,
+    tiebreakerMode: liveMatch.tiebreakerMode,
+    overtimeDurationSeconds: liveMatch.overtimeDurationSeconds,
+    overtimeElapsedSeconds: liveMatch.overtimeElapsedSeconds,
+    awaitingTiebreakerChoice: liveMatch.awaitingTiebreakerChoice,
+    refereeName: liveMatch.refereeName,
+  };
+
+  // Match update
+  const matchUpdate: Partial<MatchRow> & { live_state: LiveStateJson | null } = {
+    match_status: STATUS_TO_DB[liveMatch.status],
+    score_a: liveMatch.homeScore,
+    score_b: liveMatch.awayScore,
+    timer_start_time: liveMatch.timerStartTime ?? null,
+    timer_paused_at: liveMatch.timerPausedAt ?? null,
+    timer_elapsed_seconds: liveMatch.timerElapsedSeconds ?? null,
+    overtime_score_a: liveMatch.overtimeScoreA ?? null,
+    overtime_score_b: liveMatch.overtimeScoreB ?? null,
+    penalty_score_a: liveMatch.penaltyScoreA ?? null,
+    penalty_score_b: liveMatch.penaltyScoreB ?? null,
+    live_state: liveMatch.status === 'FINISHED' ? null : liveState,
+    updated_at: new Date().toISOString(),
+  };
+
+  // Find new events (not yet in DB)
+  const newEvents = liveMatch.events
+    .filter((event) => !existingEventIds.has(event.id))
+    .map((event) => mapMatchEventToSupabase(event, liveMatch.id));
+
+  return { matchUpdate, newEvents };
+}
+
+/**
+ * Checks if a match is "active" (has live state)
+ */
+export function isMatchActive(matchRow: MatchRow): boolean {
+  const status = matchRow.match_status ?? 'not_started';
+  return status === 'running' || status === 'paused';
+}
+
+/**
+ * Clears live state when match finishes
+ */
+export function clearLiveState(): { live_state: null } {
+  return { live_state: null };
+}

--- a/src/hooks/useLiveMatches.ts
+++ b/src/hooks/useLiveMatches.ts
@@ -1,12 +1,13 @@
 /**
  * useLiveMatches Hook
  *
- * Shared hook for polling live match data from localStorage.
+ * Shared hook for live match data with Supabase Realtime support.
  * Used by MonitorTab and ScheduleTab for real-time match updates.
  *
  * Features:
- * - Polls localStorage every 2 seconds
- * - Listens to storage events for cross-tab updates
+ * - Uses Supabase Realtime when authenticated (instant updates)
+ * - Falls back to localStorage polling for guest users
+ * - Listens to storage events for cross-tab updates (localStorage only)
  * - Detects goal events by comparing event arrays
  * - Calculates real-time elapsed seconds from timer fields
  */
@@ -14,6 +15,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { STORAGE_KEYS } from '../constants/storage';
 import type { RuntimeMatchEvent } from '../types/tournament';
+import { useRepositories } from '../core/contexts/RepositoryContext';
+import type { LiveMatch as CoreLiveMatch } from '../core/models/LiveMatch';
 
 // Types - MatchEvent is re-exported from tournament.ts
 export type MatchStatus = 'NOT_STARTED' | 'RUNNING' | 'PAUSED' | 'FINISHED';
@@ -104,7 +107,8 @@ export interface UseLiveMatchesReturn {
   calculateElapsedSeconds: (match: LiveMatch) => number;
 }
 
-const POLL_INTERVAL = 500; // 500ms for responsive goal updates
+const POLL_INTERVAL = 500; // 500ms for responsive goal updates (localStorage only)
+const REALTIME_TIMER_INTERVAL = 1000; // 1s timer refresh for Realtime mode
 
 /**
  * Calculate elapsed seconds based on timer fields
@@ -129,10 +133,52 @@ function calculateMatchElapsedSeconds(match: LiveMatch): number {
   return (match.timerElapsedSeconds ?? 0) + runtimeSeconds;
 }
 
+/**
+ * Convert CoreLiveMatch to local LiveMatch type
+ */
+function coreToLocalMatch(coreMatch: CoreLiveMatch): LiveMatch {
+  return {
+    id: coreMatch.id,
+    number: coreMatch.number,
+    phaseLabel: coreMatch.phaseLabel,
+    fieldId: coreMatch.fieldId,
+    scheduledKickoff: coreMatch.scheduledKickoff,
+    durationSeconds: coreMatch.durationSeconds,
+    refereeName: coreMatch.refereeName,
+    homeTeam: coreMatch.homeTeam,
+    awayTeam: coreMatch.awayTeam,
+    homeScore: coreMatch.homeScore,
+    awayScore: coreMatch.awayScore,
+    status: coreMatch.status,
+    elapsedSeconds: coreMatch.elapsedSeconds,
+    events: coreMatch.events.map(e => ({
+      id: e.id,
+      matchId: e.matchId,
+      timestamp: e.timestampSeconds,
+      type: e.type,
+      scoreAfter: e.scoreAfter,
+      payload: {
+        teamId: e.payload.team === 'home' ? coreMatch.homeTeam.id : coreMatch.awayTeam.id,
+        teamName: e.payload.team === 'home' ? coreMatch.homeTeam.name : coreMatch.awayTeam.name,
+        direction: e.payload.delta === 1 ? 'INC' : e.payload.delta === -1 ? 'DEC' : undefined,
+        delta: e.payload.delta,
+        playerNumber: e.payload.playerNumber,
+        cardType: e.payload.cardType,
+      },
+    })) as unknown as MatchEvent[],
+    timerStartTime: coreMatch.timerStartTime,
+    timerPausedAt: coreMatch.timerPausedAt,
+    timerElapsedSeconds: coreMatch.timerElapsedSeconds,
+  };
+}
+
 export function useLiveMatches(tournamentId: string): UseLiveMatchesReturn {
   const [liveMatches, setLiveMatches] = useState<Map<string, LiveMatch>>(new Map());
   const [lastGoalEvent, setLastGoalEvent] = useState<GoalEventInfo | null>(null);
   const [lastCardEvent, setLastCardEvent] = useState<CardEventInfo | null>(null);
+
+  // Get repository context for Realtime support
+  const { liveMatchRepository, isRealtimeEnabled, supabaseLiveMatchRepo } = useRepositories();
 
   // Track seen goal event IDs to avoid duplicate animations
   const seenGoalIds = useRef<Set<string>>(new Set());
@@ -301,27 +347,118 @@ export function useLiveMatches(tournamentId: string): UseLiveMatchesReturn {
     });
   }, [parseLiveMatches, detectGoalEvent, detectCardEvent, markAllEventsAsSeen]);
 
-  // Initial load and polling
-  useEffect(() => {
-    // Initial update
-    updateFromStorage();
+  // Helper to update matches from repository (for Realtime mode)
+  const loadFromRepository = useCallback(async () => {
+    const matches = await liveMatchRepository.getAll(tournamentId);
+    const converted = new Map<string, LiveMatch>();
+    matches.forEach((match, id) => {
+      converted.set(id, coreToLocalMatch(match));
+    });
 
-    // Poll every 2 seconds
-    const interval = setInterval(updateFromStorage, POLL_INTERVAL);
-
-    // Listen for storage events (cross-tab updates)
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === storageKey) {
-        updateFromStorage();
+    // Apply event detection logic
+    if (isInitialLoad.current) {
+      isInitialLoad.current = false;
+      markAllEventsAsSeen(converted);
+    } else {
+      const goalEvent = detectGoalEvent(converted);
+      if (goalEvent) {
+        setLastGoalEvent(goalEvent);
       }
-    };
-    window.addEventListener('storage', handleStorageChange);
+      const cardEvent = detectCardEvent(converted);
+      if (cardEvent) {
+        setLastCardEvent(cardEvent);
+      }
+    }
 
-    return () => {
-      clearInterval(interval);
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, [storageKey, updateFromStorage]);
+    setLiveMatches(converted);
+  }, [liveMatchRepository, tournamentId, markAllEventsAsSeen, detectGoalEvent, detectCardEvent]);
+
+  // Realtime subscription handler
+  const handleRealtimeChange = useCallback((matchId: string, match: CoreLiveMatch | null) => {
+    if (!match) {
+      // Match deleted
+      setLiveMatches(prev => {
+        const next = new Map(prev);
+        next.delete(matchId);
+        return next;
+      });
+      return;
+    }
+
+    const converted = coreToLocalMatch(match);
+
+    // Detect events
+    const singleMap = new Map<string, LiveMatch>([[matchId, converted]]);
+    const goalEvent = detectGoalEvent(singleMap);
+    if (goalEvent) {
+      setLastGoalEvent(goalEvent);
+    }
+    const cardEvent = detectCardEvent(singleMap);
+    if (cardEvent) {
+      setLastCardEvent(cardEvent);
+    }
+
+    setLiveMatches(prev => new Map(prev).set(matchId, converted));
+  }, [detectGoalEvent, detectCardEvent]);
+
+  // Initial load and subscribe/poll based on mode
+  useEffect(() => {
+    // Reset initial load flag when tournament changes
+    isInitialLoad.current = true;
+
+    if (isRealtimeEnabled && supabaseLiveMatchRepo) {
+      // Realtime mode: Subscribe to changes
+      void loadFromRepository();
+
+      supabaseLiveMatchRepo.subscribe(tournamentId, {
+        onMatchChange: handleRealtimeChange,
+        onError: (error) => {
+          console.error('Realtime subscription error:', error);
+          // Could fall back to polling here if needed
+        },
+      });
+
+      // Timer update for running matches (Realtime doesn't push timer updates)
+      const timerInterval = setInterval(() => {
+        setLiveMatches(prev => {
+          const hasRunning = Array.from(prev.values()).some(m => m.status === 'RUNNING' && m.timerStartTime);
+          if (!hasRunning) {return prev;}
+
+          const updated = new Map(prev);
+          updated.forEach((match, id) => {
+            if (match.status === 'RUNNING' && match.timerStartTime) {
+              const elapsed = calculateMatchElapsedSeconds(match);
+              updated.set(id, { ...match, elapsedSeconds: elapsed });
+            }
+          });
+          return updated;
+        });
+      }, REALTIME_TIMER_INTERVAL);
+
+      return () => {
+        supabaseLiveMatchRepo.unsubscribe(tournamentId);
+        clearInterval(timerInterval);
+      };
+    } else {
+      // localStorage mode: Poll for changes
+      updateFromStorage();
+
+      const interval = setInterval(updateFromStorage, POLL_INTERVAL);
+
+      // Listen for storage events (cross-tab updates)
+      const handleStorageChange = (e: StorageEvent) => {
+        if (e.key === storageKey) {
+          updateFromStorage();
+        }
+      };
+      window.addEventListener('storage', handleStorageChange);
+
+      return () => {
+        clearInterval(interval);
+        window.removeEventListener('storage', handleStorageChange);
+      };
+    }
+  }, [tournamentId, storageKey, updateFromStorage, isRealtimeEnabled, supabaseLiveMatchRepo, loadFromRepository, handleRealtimeChange]);
 
   // Derived state
   const runningMatches = useMemo(


### PR DESCRIPTION
## Summary
- Add `SupabaseLiveMatchRepository` with Realtime subscriptions for cross-device match state synchronization
- Add `liveMatchMappers` for type conversion between Supabase and frontend types
- Extend `RepositoryContext` to provide live match repository based on authentication state
- Update `useMatchExecution` to use injected repository from context
- Update `useLiveMatches` to use Realtime when authenticated, fallback to localStorage polling for guests

## What it does
Enables authenticated users to see live match updates instantly across multiple devices via Supabase Realtime, while maintaining offline-first localStorage support for guest users.

## Test plan
- [ ] Verify authenticated users receive real-time match updates across devices
- [ ] Verify guest users still get localStorage polling fallback
- [ ] Verify match events (goals, cards) sync correctly
- [ ] Verify timer state syncs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)