### PR TITLE
fix(auth): preserve hash fragment tokens in auth redirect

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,23 +9,49 @@ import App from './App';
 import './styles/global.css';
 
 /**
- * OAuth Redirect Fix for HashRouter
+ * OAuth/Auth Redirect Fix for HashRouter
  *
- * Problem: Supabase OAuth redirects to /auth/callback?code=xxx
- * But HashRouter only routes based on the hash (/#/path)
+ * Problem: Supabase auth redirects to /auth/callback with tokens in different formats:
+ * - PKCE flow: /auth/callback?code=xxx (query params)
+ * - Implicit flow: /auth/callback#access_token=xxx&type=recovery (hash fragment)
+ *
+ * But HashRouter only routes based on hash paths (/#/path).
  * So the AuthCallback component never mounts.
  *
- * Solution: Detect OAuth callback at /auth/callback and redirect to /#/auth/callback
+ * Solution: Detect auth callback at /auth/callback and redirect to /#/auth/callback
+ * Converting hash fragment tokens to query params (since URLs can only have ONE hash).
  * This runs BEFORE React/HashRouter initializes.
  */
-(function handleOAuthRedirect() {
+(function handleAuthRedirect() {
   const { pathname, search, hash } = window.location;
 
   // Only intercept if we're at /auth/callback WITHOUT a hash route
-  // (If hash already contains a path, HashRouter is already handling it)
+  // Hash might contain tokens (implicit flow) like #access_token=xxx
+  // Or be empty (PKCE flow uses query params)
   if (pathname === '/auth/callback' && !hash.startsWith('#/')) {
-    // Redirect to hash-based route, preserving query params
-    const newUrl = `${window.location.origin}/#/auth/callback${search}`;
+    // Build new URL with HashRouter path
+    let newUrl = `${window.location.origin}/#/auth/callback`;
+
+    // Collect all params - from both query string AND hash fragment
+    // URLs can only have ONE hash, so we convert hash fragment tokens to query params
+    const allParams: string[] = [];
+
+    // Add existing query params (PKCE flow: ?code=xxx)
+    if (search) {
+      allParams.push(search.substring(1)); // Remove leading ?
+    }
+
+    // Convert hash fragment tokens to query params (implicit flow: #access_token=xxx)
+    // Hash fragment format: #access_token=xxx&refresh_token=yyy&type=recovery
+    if (hash && !hash.startsWith('#/')) {
+      allParams.push(hash.substring(1)); // Remove leading #
+    }
+
+    // Append all params as query string
+    if (allParams.length > 0) {
+      newUrl += '?' + allParams.join('&');
+    }
+
     window.location.replace(newUrl);
     return; // Stop execution, page will reload
   }


### PR DESCRIPTION
## Summary
- Fixes OAuth login getting stuck on "Anmeldung wird verarbeitet..." screen
- The main.tsx redirect now preserves BOTH query params (PKCE flow) AND hash fragment tokens (implicit flow)
- This ensures tokens like `#access_token=xxx` are passed to the AuthCallback component

## Problem
Supabase can send auth tokens in two formats:
- PKCE flow: `/auth/callback?code=xxx`
- Implicit flow: `/auth/callback#access_token=xxx&type=recovery`

The previous fix only preserved query params (`search`), but not hash fragment tokens.

## Test plan
- [ ] Test Google OAuth login (implicit flow)
- [ ] Test password reset flow
- [ ] Verify redirect to dashboard after successful login

🤖 Generated with [Claude Code](https://claude.com/claude-code)