### PR TITLE
fix: import status, schedule display & share URL bugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,8 +310,12 @@ function AppContent() {
       const hasMatches = tournament.matches.length > 0;
 
       if (hasMatches) {
-        // Complete import → Just save and stay in dashboard
-        await saveTournament(tournament);
+        // Complete import → Set status to 'published' (ready to use)
+        const completeTournament: Tournament = {
+          ...tournament,
+          status: 'published', // Complete imports are ready to use
+        };
+        await saveTournament(completeTournament);
         // Dashboard will auto-refresh via useTournaments hook
       } else {
         // Partial import → Open wizard at Step 2 to generate schedule

--- a/src/components/ScheduleDisplay.tsx
+++ b/src/components/ScheduleDisplay.tsx
@@ -276,6 +276,13 @@ export const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({
 
       {/* Global styles for responsive design */}
       <style>{`
+        /* Tailwind-like utility: hide on medium screens and above */
+        @media (min-width: 769px) {
+          .md\\:hidden {
+            display: none !important;
+          }
+        }
+
         @media (max-width: 768px) {
           .schedule-display {
             padding: 20px 12px !important;

--- a/src/utils/shareUtils.ts
+++ b/src/utils/shareUtils.ts
@@ -156,7 +156,8 @@ export function getShareMessage(result: ShareResult): string {
  */
 export function generatePublicUrl(tournamentId: string, baseUrl?: string): string {
   const origin = baseUrl || (typeof window !== 'undefined' ? window.location.origin : '');
-  return `${origin}/public/${tournamentId}`;
+  // HashRouter requires /#/ prefix for all routes
+  return `${origin}/#/public/${tournamentId}`;
 }
 
 /**
@@ -164,9 +165,10 @@ export function generatePublicUrl(tournamentId: string, baseUrl?: string): strin
  *
  * @param shareCode - 6-character share code (e.g., "ABC123")
  * @param baseUrl - Base URL (defaults to current origin)
- * @returns Full live view URL (e.g., "https://example.com/live/ABC123")
+ * @returns Full live view URL (e.g., "https://example.com/#/live/ABC123")
  */
 export function generateLiveUrl(shareCode: string, baseUrl?: string): string {
   const origin = baseUrl || (typeof window !== 'undefined' ? window.location.origin : '');
-  return `${origin}/live/${shareCode}`;
+  // HashRouter requires /#/ prefix for all routes
+  return `${origin}/#/live/${shareCode}`;
 }


### PR DESCRIPTION
## Summary
- **Import Fix**: Complete imports now correctly saved with `status: 'published'` instead of `'draft'`
- **Schedule Display**: Added `md:hidden` CSS rule to fix duplicate tournament header on desktop
- **Share URLs**: Added `/#/` prefix for HashRouter compatibility - share links now work correctly

## Test plan
- [ ] Import a tournament JSON file → verify status is 'published'
- [ ] View tournament schedule on desktop → verify no duplicate header
- [ ] Copy share link → verify URL contains `/#/live/` path
- [ ] Open share link in new tab → verify it loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)