### PR TITLE
fix(auth): suppress AbortError in React StrictMode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Hallenfußball PWA - Turnierverwaltung für Hallenturniere" />
     <meta name="theme-color" content="#0A1628" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Hallenfußball Turnierverwaltung</title>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,24 @@ import App from './App';
 import './styles/global.css';
 
 /**
+ * Global handler for unhandled promise rejections
+ *
+ * AbortError is expected in React StrictMode when Supabase auth initializes:
+ * - StrictMode mounts/unmounts/remounts components
+ * - First mount starts Supabase lock acquisition
+ * - Unmount aborts the lock (AbortError)
+ * - Second mount succeeds normally
+ *
+ * We suppress this specific error to keep the console clean.
+ */
+window.addEventListener('unhandledrejection', (event) => {
+  if (event.reason instanceof Error && event.reason.name === 'AbortError') {
+    // Suppress AbortError - expected in StrictMode with Supabase
+    event.preventDefault();
+  }
+});
+
+/**
  * OAuth/Auth Redirect Fix for HashRouter
  *
  * Problem: Supabase auth redirects to /auth/callback with tokens in different formats:


### PR DESCRIPTION
## Summary
- Add global `unhandledrejection` handler to suppress AbortError from async Supabase operations
- Handle AbortError in auth initialization and callback (expected in StrictMode)
- Add modern `mobile-web-app-capable` meta tag (fixes deprecation warning)

## Why this happens
React StrictMode double-mounts components (mount → unmount → remount) in development. Supabase's internal lock mechanism (`_acquireLock`) gets aborted when the first mount unmounts, causing an AbortError. The second mount succeeds normally.

## Changes
- `src/main.tsx`: Global handler for unhandled AbortError rejections
- `src/features/auth/context/AuthContext.tsx`: AbortError handling in auth init
- `src/features/auth/components/AuthCallback.tsx`: AbortError handling in callback
- `index.html`: Add `mobile-web-app-capable` meta tag

## Test plan
- [x] Build passes
- [x] All 440 tests pass
- [ ] Verify console is clean after Google login

🤖 Generated with [Claude Code](https://claude.com/claude-code)