### PR TITLE
fix(auth): resolve race condition in password recovery flow

### DIFF
--- a/src/features/auth/components/AuthCallback.tsx
+++ b/src/features/auth/components/AuthCallback.tsx
@@ -124,6 +124,8 @@ export const AuthCallback: React.FC = () => {
           if (exchangeError) {
             // If code was already used, check if session exists now
             if (exchangeError.message.includes('code') || exchangeError.message.includes('expired')) {
+              // Wait briefly for PASSWORD_RECOVERY event to fire
+              await new Promise(resolve => setTimeout(resolve, 100));
               const { data: { session: retrySession } } = await supabase.auth.getSession();
               if (retrySession) {
                 const isPasswordRecovery = type === 'recovery' || safeSessionStorage.getItem('auth:passwordRecovery') === 'true';
@@ -140,6 +142,10 @@ export const AuthCallback: React.FC = () => {
             setError(exchangeError.message);
             return;
           }
+
+          // Wait briefly for PASSWORD_RECOVERY event to fire and set the sessionStorage flag
+          // The event fires asynchronously after exchangeCodeForSession completes
+          await new Promise(resolve => setTimeout(resolve, 100));
 
           // Check if this is a recovery flow
           // Check both URL param (legacy/implicit) and sessionStorage flag (PKCE)


### PR DESCRIPTION
## Summary
- Fixed password reset flow not redirecting to Set Password screen
- The `PASSWORD_RECOVERY` event fires asynchronously after `exchangeCodeForSession` completes
- Without waiting, the sessionStorage flag check happens before the event handler sets it
- Added 100ms delay to allow the event to fire before checking for password recovery

## Problem
When clicking "Forgot Password" and then the email link:
1. User gets redirected to auth/callback
2. `exchangeCodeForSession` succeeds
3. Code immediately checks for `auth:passwordRecovery` flag in sessionStorage
4. BUT: The `PASSWORD_RECOVERY` event hasn't fired yet → flag not set
5. User gets redirected to `/` instead of `/set-password`

## Solution
Wait 100ms after `exchangeCodeForSession` for the event to propagate before checking the recovery flag.

## Test plan
- [ ] Click "Forgot Password" on login screen
- [ ] Enter email and receive reset email
- [ ] Click link in email
- [ ] Should redirect to Set Password screen (not home)
- [ ] Set new password
- [ ] Login with new password works

🤖 Generated with [Claude Code](https://claude.com/claude-code)