### PR TITLE
fix(auth): improve auth init timeout handling and remove deprecated meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Hallenfußball PWA - Turnierverwaltung für Hallenturniere" />
     <meta name="theme-color" content="#0A1628" />
     <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Hallenfußball Turnierverwaltung</title>
     <!-- FOUC Prevention: Apply saved corporate colors before React hydration -->


### PR DESCRIPTION
## Summary
- Remove deprecated `apple-mobile-web-app-capable` meta tag that was causing browser console warnings
- Fix race condition in auth initialization where multiple safety timeouts could fire simultaneously
- Improve mounted flag handling with object ref pattern for proper cleanup tracking

## Changes
1. **index.html**: Removed deprecated `apple-mobile-web-app-capable` meta tag (Safari now uses standard `mobile-web-app-capable`)

2. **AuthContext.tsx**: Refactored auth initialization:
   - Move safety timeout OUTSIDE the retry loop (single timeout instead of one per retry)
   - Use object ref pattern for mounted flag (`{ current: boolean }`) so TypeScript understands it can change
   - Check mounted status before AND after async operations
   - Properly clear timeout on successful auth or cleanup

## Test plan
- [x] All 440 tests pass
- [ ] Verify no more "Auth init timed out" console warnings on Vercel deployment
- [ ] Verify deprecated meta tag warning is gone
- [ ] Test auth flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)