### PR TITLE
feat(auth): email scanner protection & auth architecture cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ mcp-adesso-analyzer/
 **/credentials.json
 **/*secret*
 **/*apikey*
+TEST-CREDENTIALS.md
 
 # Entwickler-Skripte mit API Keys (adesso AI Hub)
 evaluate-plan.js

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,29 @@
 # TODO - Hallenfußball PWA
 
 > Zentrale Aufgabenliste für das Projekt. Neue Aufgaben werden hier erfasst.
-> **Letzte Aktualisierung:** 2026-01-11
+> **Letzte Aktualisierung:** 2026-01-13
+
+---
+
+## ✅ ERLEDIGT: Supabase Email Templates aktualisiert
+
+**Status:** ✅ Erledigt (2026-01-13, via Management API)
+**Priorität:** 🟠 Hoch
+
+> **Problem:** Outlook/O365 Email-Scanner öffnen Links automatisch und verbrauchen Token bevor User klickt.
+> **Lösung:** Links auf `/auth/confirm` geändert - diese Seite zeigt einen Button, Scanner klicken nicht auf Buttons.
+
+| Template | Status |
+|----------|--------|
+| Confirm signup | ✅ Erledigt |
+| Magic Link | ✅ Erledigt |
+| Reset Password | ✅ Erledigt |
+| Invite User | ✅ Erledigt |
+
+**Erledigt:**
+- [x] Templates via Supabase Management API aktualisiert
+- [x] Deutsche Betreffzeilen gesetzt
+- [x] `docs/wip/SUPABASE-EMAIL-TEMPLATES-TODO.md` gelöscht
 
 ---
 


### PR DESCRIPTION
## Summary

- **Email Scanner Protection:** Neue `/auth/confirm` Zwischenseite die Email-Scanner (Outlook/O365) daran hindert, Auth-Tokens automatisch zu verbrauchen
- **Ghost Password Prevention:** OAuth-User können kein Passwort setzen (verhindert unbeabsichtigte Passwort-Resets)
- **Auth Architecture Cleanup:** Stateless Services, deprecated Code markiert, redundante Hooks entfernt
- **Supabase Email Templates:** Deutsche Betreffzeilen, Links auf `/auth/confirm` geändert (via Management API)

## Changes

| Commit | Description |
|--------|-------------|
| `2b5fd46` | chore: cleanup legacy code, add backdrop token, improve accessibility |
| `5e924d8` | feat: AuthConfirmPage, authHelpers, stateless services |
| `4fdf42c` | chore: add test credentials to gitignore |

## Test plan

- [ ] Registrierung auf Vercel testen (`test@hallenfussball.de` / `Test1234!`)
- [ ] Magic Link testen (prüfen ob `/auth/confirm` Seite erscheint)
- [ ] Google OAuth testen
- [ ] Passwort-Reset für Email-User testen
- [ ] Passwort-Reset für OAuth-User blockiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)