### PR TITLE
chore: add supabase temp dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ test-results/
 
 # Vercel
 .vercel/
+supabase/.temp/


### PR DESCRIPTION
Adds `supabase/.temp/` to gitignore (Supabase CLI cache directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)