### PR TITLE
fix(auth): add auto-reconnect after timeout

### DIFF
--- a/src/features/auth/context/authContextValue.ts
+++ b/src/features/auth/context/authContextValue.ts
@@ -33,4 +33,6 @@ export interface AuthContextValue extends AuthState {
   resetPassword: (email: string) => Promise<{ success: boolean; error?: string }>;
   /** Setzt ein neues Passwort (nach Recovery) (async) */
   updatePassword: (newPassword: string) => Promise<{ success: boolean; error?: string }>;
+  /** Versucht, die Verbindung zu Supabase wiederherzustellen */
+  reconnect: () => Promise<void>;
 }

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -198,6 +198,11 @@ export const INVITATION_DURATION = {
 // ============================================
 
 /**
+ * Connection state to Supabase Auth
+ */
+export type ConnectionState = 'connected' | 'connecting' | 'offline';
+
+/**
  * Auth-State für Hooks
  */
 export interface AuthState {
@@ -206,6 +211,8 @@ export interface AuthState {
   isAuthenticated: boolean;
   isGuest: boolean;
   isLoading: boolean;
+  /** Connection state to Supabase - 'offline' means auth init timed out */
+  connectionState: ConnectionState;
 }
 
 /**


### PR DESCRIPTION
## Problem

When auth init times out (slow network, Supabase cold start), the app stays in offline mode forever without attempting to reconnect. This was discovered in E2E testing where headless browsers consistently hit the 5s timeout.

## Solution

- Add `connectionState` ('connected' | 'connecting' | 'offline') to AuthState
- Auto-retry every 30s when in offline mode
- Listen for browser `online` event and retry immediately
- Add `reconnect()` function for manual retry
- Increase initial timeout from 5s to 8s

## Changes

| File | Change |
|------|--------|
| `auth.types.ts` | Add `ConnectionState` type and `connectionState` to `AuthState` |
| `authContextValue.ts` | Add `reconnect` function to interface |
| `AuthContext.tsx` | Implement auto-reconnect logic |

## Test plan

- [ ] Start app with slow network → should eventually reconnect
- [ ] Trigger browser offline/online → should retry on online
- [ ] Call `reconnect()` manually → should attempt connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)