### PR TITLE
fix(auth): Use correct OTP type for Magic Link verification

### DIFF
--- a/src/features/auth/components/AuthConfirmPage.tsx
+++ b/src/features/auth/components/AuthConfirmPage.tsx
@@ -120,9 +120,10 @@ export const AuthConfirmPage: React.FC = () => {
 
         case 'magiclink': {
           // Magic Link Login
+          // Note: Supabase docs specify 'email' as the type for passwordless magic link verification
           const { error: magicError } = await supabase.auth.verifyOtp({
             token_hash: token,
-            type: 'magiclink',
+            type: 'email',
           });
           if (magicError) {
             throw magicError;


### PR DESCRIPTION
## Summary
- Fixed Magic Link authentication by using correct `verifyOtp` type parameter
- Supabase docs specify `'email'` as the type for passwordless magic link verification, not `'magiclink'`

## Changes
- `AuthConfirmPage.tsx`: Changed `type: 'magiclink'` → `type: 'email'` in `verifyOtp` call

## Test plan
- [ ] Request Magic Link via login page
- [ ] Receive email and click link
- [ ] AuthConfirmPage shows "Anmeldung bestätigen"
- [ ] Click confirm button → Redirect to `/` (logged in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)