### PR TITLE
fix(security): Update jspdf to 4.0.0 to fix CVE-2025-29529

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/qrcode": "^1.5.6",
         "browser-image-compression": "^2.0.2",
         "idb-keyval": "^6.2.2",
-        "jspdf": "^3.0.4",
+        "jspdf": "^4.0.0",
         "jspdf-autotable": "^5.0.2",
         "qrcode": "^1.5.4",
         "react": "^18.2.0",
@@ -7391,9 +7391,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/qrcode": "^1.5.6",
     "browser-image-compression": "^2.0.2",
     "idb-keyval": "^6.2.2",
-    "jspdf": "^3.0.4",
+    "jspdf": "^4.0.0",
     "jspdf-autotable": "^5.0.2",
     "qrcode": "^1.5.4",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Updates jspdf from 3.0.4 to 4.0.0
- Fixes critical Local File Inclusion/Path Traversal vulnerability (CVE-2025-29529)
- jspdf-autotable supports jspdf 4.x (verified via peerDependencies)

## Test plan
- [x] Build passes (`npm run build`)
- [x] All unit tests pass (506 passed, 8 skipped)
- [x] `npm audit` shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)