### PR TITLE
fix(supabase): use UUID for team IDs and trim env vars

### DIFF
--- a/src/features/tournament-admin/categories/Settings/index.tsx
+++ b/src/features/tournament-admin/categories/Settings/index.tsx
@@ -16,6 +16,7 @@ import { cssVars } from '../../../../design-tokens';
 import { CategoryPage, CollapsibleSection } from '../shared';
 import { FieldManagement } from '../../../tournament-management/FieldManagement';
 import { useTournaments } from '../../../../hooks';
+import { generateTeamId } from '../../../../utils/idGenerator';
 import type { Tournament } from '../../../../types/tournament';
 
 // =============================================================================
@@ -211,7 +212,7 @@ export function SettingsCategory({
         teams: duplicateOptions.teams
           ? tournament.teams.map((team) => ({
             ...team,
-            id: `team-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+            id: generateTeamId(),
           }))
           : [],
         numberOfTeams: duplicateOptions.teams ? tournament.numberOfTeams : 0,

--- a/src/features/tournament-creation/Step4_Teams.tsx
+++ b/src/features/tournament-creation/Step4_Teams.tsx
@@ -4,6 +4,7 @@ import { Tournament, Team, TeamLogo } from '../../types/tournament';
 import { cssVars } from '../../design-tokens'
 import { generateGroupLabels } from '../../utils/groupHelpers';
 import { getGroupDisplayName } from '../../utils/displayNames';
+import { generateTeamId } from '../../utils/idGenerator';
 import styles from './Step4_Teams.module.css';
 
 interface Step4Props {
@@ -175,7 +176,7 @@ export const Step4_Teams: React.FC<Step4Props> = ({
     const newTeams: Team[] = [];
     for (let i = 1; i <= numberOfTeams; i++) {
       newTeams.push({
-        id: `team-${Date.now()}-${i}`,
+        id: generateTeamId(),
         name: `Team ${i}`,
       });
     }

--- a/src/hooks/useTournamentWizard.ts
+++ b/src/hooks/useTournamentWizard.ts
@@ -12,6 +12,7 @@ import { countMatchesWithResults } from '../utils/teamHelpers';
 import { getSportConfig, DEFAULT_SPORT_ID } from '../config/sports';
 import { TournamentCreationService } from '../core/services/TournamentCreationService';
 import { useRepository } from './useRepository';
+import { generateTeamId } from '../utils/idGenerator';
 
 export interface WizardState {
   step: number;
@@ -247,7 +248,7 @@ export function useTournamentWizard(
   // Team actions
   const addTeam = useCallback(() => {
     const newTeam = {
-      id: `team-${Date.now()}`,
+      id: generateTeamId(),
       name: `Team ${(formData.teams?.length ?? 0) + 1}`,
     };
     updateForm('teams', [...(formData.teams ?? []), newTeam]);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -9,8 +9,9 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '../types/supabase';
 import { safeLocalStorage } from '../core/utils/safeStorage';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+// Trim to prevent issues with trailing newlines in env vars (e.g., from copy-paste in Vercel)
+const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.trim();
+const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined)?.trim();
 
 /**
  * Check if Supabase is configured

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -55,6 +55,14 @@ export function generateTournamentId(): string {
 }
 
 /**
+ * Generiert eine Team-ID
+ * @returns UUID (kompatibel mit Supabase)
+ */
+export function generateTeamId(): string {
+  return generateUniqueId();
+}
+
+/**
  * Reset counter (nur für Tests)
  */
 export function resetCounter(): void {


### PR DESCRIPTION
## Summary

- **Bug 1: Team-ID Format invalid** - Supabase expects UUIDs but code generated timestamp-based IDs like `team-1768849387916-1`
- **Bug 2: WebSocket URL with %0A** - Trailing newline in Vercel env vars caused connection issues

## Changes

### Team-ID Generation
- Added `generateTeamId()` to central `idGenerator.ts` using `crypto.randomUUID()`
- Fixed 3 files that bypassed the central generator:
  - `useTournamentWizard.ts`
  - `Step4_Teams.tsx`  
  - `Settings/index.tsx`

### Environment Variable Sanitization
- Added `.trim()` to `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
- Prevents issues from copy-paste in Vercel dashboard

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] All unit tests pass
- [ ] Create new tournament → Team IDs are valid UUIDs
- [ ] WebSocket connects without `%0A` in URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)