### PR TITLE
fix(settings): add Force Update button and guard empty tournamentId queries

### DIFF
--- a/src/core/repositories/SupabaseLiveMatchRepository.ts
+++ b/src/core/repositories/SupabaseLiveMatchRepository.ts
@@ -58,6 +58,11 @@ export class SupabaseLiveMatchRepository implements ILiveMatchRepository {
       return null;
     }
 
+    // Guard: Don't query with empty IDs
+    if (!tournamentId || !matchId) {
+      return null;
+    }
+
     try {
       // Load teams if not cached
       const teamsMap = await this.ensureTeamsLoaded(tournamentId);
@@ -96,6 +101,11 @@ export class SupabaseLiveMatchRepository implements ILiveMatchRepository {
 
   async getAll(tournamentId: string): Promise<Map<string, LiveMatch>> {
     if (!isSupabaseConfigured || !supabase) {
+      return new Map();
+    }
+
+    // Guard: Don't query with empty tournamentId
+    if (!tournamentId) {
       return new Map();
     }
 
@@ -373,6 +383,11 @@ export class SupabaseLiveMatchRepository implements ILiveMatchRepository {
   // ==========================================================================
 
   private async ensureTeamsLoaded(tournamentId: string): Promise<Map<string, TeamRow>> {
+    // Guard: Don't query with empty tournamentId
+    if (!tournamentId) {
+      return new Map();
+    }
+
     // Return cached if available
     const cached = this.teamsCache.get(tournamentId);
     if (cached) {

--- a/src/hooks/useLiveMatches.ts
+++ b/src/hooks/useLiveMatches.ts
@@ -351,6 +351,11 @@ export function useLiveMatches(tournamentId: string): UseLiveMatchesReturn {
 
   // Helper to update matches from repository (for Realtime mode)
   const loadFromRepository = useCallback(async () => {
+    // Guard: Don't query with empty tournamentId
+    if (!tournamentId) {
+      return;
+    }
+
     const matches = await liveMatchRepository.getAll(tournamentId);
     const converted = new Map<string, LiveMatch>();
     matches.forEach((match, id) => {
@@ -405,6 +410,11 @@ export function useLiveMatches(tournamentId: string): UseLiveMatchesReturn {
 
   // Initial load and subscribe/poll based on mode
   useEffect(() => {
+    // Guard: Don't subscribe/poll with empty tournamentId
+    if (!tournamentId) {
+      return;
+    }
+
     // Reset initial load flag when tournament changes
     isInitialLoad.current = true;
 


### PR DESCRIPTION
## Summary
- Add "App-Update erzwingen" button in Settings → Daten to clear Service Worker cache and reload (fixes stale cache issues after deployments)
- Guard against empty tournamentId in useLiveMatches hook (prevents queries when tournament?.id is undefined)
- Add defensive guards in SupabaseLiveMatchRepository for empty IDs (fixes 400 errors from `tournament_id=eq.` queries)

## Test plan
- [ ] Navigate to Settings → Daten and verify "App-Update erzwingen" button appears
- [ ] Click button and confirm dialog works
- [ ] Verify Service Worker is unregistered and caches are cleared on confirm
- [ ] Verify no 400 errors in console when navigating to tournament pages before tournament is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)