### PR TITLE
fix(urls): use HashRouter-compatible URL generation for all share links

### DIFF
--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -9,6 +9,7 @@ import {
   copyToClipboard,
   isShareSupported,
   generateLiveUrl,
+  generateTournamentUrl,
   getShareMessage,
 } from '../../utils/shareUtils';
 
@@ -46,7 +47,7 @@ export const ShareDialog = ({
   const hasShareCode = isPublic && shareCode;
   const canonicalUrl = baseUrl ?? (hasShareCode
     ? generateLiveUrl(shareCode)
-    : `${window.location.origin}/tournament/${tournamentId}`);
+    : generateTournamentUrl(tournamentId));
 
   // Determine effective URL
   const hasDeepLinkOption = !!deepLinkUrl && deepLinkUrl !== canonicalUrl;

--- a/src/features/monitor-display/MonitorDisplayPage.tsx
+++ b/src/features/monitor-display/MonitorDisplayPage.tsx
@@ -39,6 +39,7 @@ import { calculateStandings } from '../../utils/calculations';
 import { TeamAvatar } from '../../components/ui/TeamAvatar';
 import { useLiveMatches } from '../../hooks/useLiveMatches';
 import { GoalAnimation, CardAnimation } from '../../components/monitor';
+import { generateTournamentUrl } from '../../utils/shareUtils';
 
 // =============================================================================
 // THEME RESOLUTION
@@ -714,7 +715,7 @@ function SponsorSlide({ slide, tournament, performanceSettings, theme, style }: 
   const logoSrc = sponsor.logoUrl ?? sponsor.logoBase64;
 
   // Generate QR code URL with validation to prevent XSS
-  const fallbackUrl = `${window.location.origin}/tournament/${tournament.id}`;
+  const fallbackUrl = generateTournamentUrl(tournament.id);
   const qrUrl = slide.config.qrTarget === 'sponsor-website' && sponsor.websiteUrl
     ? getSafeUrl(sponsor.websiteUrl, fallbackUrl)
     : slide.config.qrTarget === 'custom' && slide.config.customQrUrl

--- a/src/features/tournament-admin/categories/Visibility/index.tsx
+++ b/src/features/tournament-admin/categories/Visibility/index.tsx
@@ -15,6 +15,7 @@ import type { Tournament } from '../../../../types/tournament';
 import { SupabaseRepository } from '../../../../core/repositories/SupabaseRepository';
 import { isSupabaseConfigured } from '../../../../lib/supabase';
 import { generateShareCode } from '../../../../utils/shareCode';
+import { generateLiveUrl, generateTournamentUrl } from '../../../../utils/shareUtils';
 
 // =============================================================================
 // PROPS
@@ -276,8 +277,8 @@ export function VisibilityCategory({
     void autoGenerateShareCode();
   }, [tournament, tournamentId, onTournamentUpdate, isUpdating]);
 
-  // Generate public URL based on share code
-  const publicUrl = shareCode ? `${window.location.origin}/live/${shareCode}` : null;
+  // Generate public URL based on share code (uses HashRouter: /#/live/...)
+  const publicUrl = shareCode ? generateLiveUrl(shareCode) : null;
 
   // Make tournament public (generate share code)
   const handleMakePublic = useCallback(async () => {
@@ -565,7 +566,7 @@ export function VisibilityCategory({
               <div style={styles.linkRow}>
                 <input
                   type="text"
-                  value={`${window.location.origin}/tournament/${tournamentId}`}
+                  value={generateTournamentUrl(tournamentId)}
                   readOnly
                   style={styles.linkInput}
                   onClick={(e) => (e.target as HTMLInputElement).select()}
@@ -576,7 +577,7 @@ export function VisibilityCategory({
                     ...(copied ? styles.copyButtonSuccess : {}),
                   }}
                   onClick={() => {
-                    const internalUrl = `${window.location.origin}/tournament/${tournamentId}`;
+                    const internalUrl = generateTournamentUrl(tournamentId);
                     navigator.clipboard.writeText(internalUrl)
                       .then(() => {
                         setCopied(true);

--- a/src/utils/shareUtils.ts
+++ b/src/utils/shareUtils.ts
@@ -176,3 +176,17 @@ export function generateLiveUrl(shareCode: string, baseUrl?: string): string {
   // HashRouter requires /#/ prefix for all routes
   return `${origin}/#/live/${shareCode}`;
 }
+
+/**
+ * Generate tournament URL
+ *
+ * @param tournamentId - Tournament ID
+ * @param baseUrl - Base URL (defaults to current origin)
+ * @returns Full tournament URL (e.g., "https://example.com/#/tournament/abc123")
+ */
+export function generateTournamentUrl(tournamentId: string, baseUrl?: string): string {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Empty baseUrl should use window.location.origin
+  const origin = baseUrl || (typeof window !== 'undefined' ? window.location.origin : '');
+  // HashRouter requires /#/ prefix for all routes
+  return `${origin}/#/tournament/${tournamentId}`;
+}


### PR DESCRIPTION
## Summary
- Fix URL generation to include `/#/` prefix required by HashRouter
- Add `generateTournamentUrl()` utility function for consistent URL generation
- Fix share links in ShareDialog, MonitorDisplayPage, and Visibility settings

## Changes
| File | Fix |
|------|-----|
| `shareUtils.ts` | Add `generateTournamentUrl()` function |
| `ShareDialog.tsx` | Use `generateTournamentUrl` for canonical URL |
| `MonitorDisplayPage.tsx` | Fix QR code fallback URL |
| `Visibility/index.tsx` | Fix public URL and internal link (3 places) |

## Test Plan
- [x] Lint passes
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual: Share link in Visibility settings shows `/#/live/{shareCode}`
- [ ] Manual: Monitor QR code scans to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)