### PR TITLE
test(wizard): add data-testid attributes for E2E testing

### DIFF
--- a/src/features/tournament-creation/Step1_SportAndType.tsx
+++ b/src/features/tournament-creation/Step1_SportAndType.tsx
@@ -23,6 +23,7 @@ interface SelectionButtonProps {
   details?: string[];
   variant?: 'default' | 'warning';
   layout?: 'center' | 'left';
+  testId?: string;
 }
 
 const SelectionButton: React.FC<SelectionButtonProps> = ({
@@ -33,6 +34,7 @@ const SelectionButton: React.FC<SelectionButtonProps> = ({
   details,
   variant = 'default',
   layout = 'center',
+  testId,
 }) => {
   const accentColor = variant === 'warning' ? cssVars.colors.warning : cssVars.colors.primary;
   const bgColor = variant === 'warning' ? cssVars.colors.warningSelected : cssVars.colors.primarySelected;
@@ -60,6 +62,7 @@ const SelectionButton: React.FC<SelectionButtonProps> = ({
       }}
       role="radio"
       aria-checked={isSelected}
+      data-testid={testId}
     >
       <div style={{ fontSize: layout === 'center' ? cssVars.fontSizes.md : cssVars.fontSizes.sm, fontWeight: '700', color: cssVars.colors.textPrimary }}>
         {title}
@@ -193,6 +196,7 @@ export const Step1_SportAndType: React.FC<Step1Props> = ({
               `• Normale ${currentConfig.terminology.goal}zählung`,
             ]}
             layout="left"
+            testId="wizard-type-classic"
           />
           <SelectionButton
             isSelected={formData.tournamentType === 'bambini'}
@@ -202,6 +206,7 @@ export const Step1_SportAndType: React.FC<Step1Props> = ({
             details={['• Ergebnisneutral', '• Ohne Tabellen/Platzierungen', '• Nur Sieg/Unentsch./Nied.']}
             variant="warning"
             layout="left"
+            testId="wizard-type-bambini"
           />
         </div>
       </div>

--- a/src/features/tournament-creation/Step2_ModeAndSystem.tsx
+++ b/src/features/tournament-creation/Step2_ModeAndSystem.tsx
@@ -181,6 +181,7 @@ export const Step2_ModeAndSystem: React.FC<Step2Props> = ({
                     alignItems: 'center',
                     gap: cssVars.spacing.xs,
                   }}
+                  data-testid="wizard-reset-tournament"
                 >
                   <span>🔄</span> Turnier zurücksetzen
                 </button>

--- a/src/features/tournament-creation/Step4_Teams.tsx
+++ b/src/features/tournament-creation/Step4_Teams.tsx
@@ -200,7 +200,7 @@ export const Step4_Teams: React.FC<Step4Props> = ({
       </h2>
 
       <div className={styles.buttonRow}>
-        <Button onClick={onAddTeam} icon={<Icons.Plus />} variant="secondary">
+        <Button onClick={onAddTeam} icon={<Icons.Plus />} variant="secondary" data-testid="wizard-add-team">
           Team hinzufügen
         </Button>
 
@@ -209,6 +209,7 @@ export const Step4_Teams: React.FC<Step4Props> = ({
             onClick={handleGenerateTeams}
             icon={<Icons.Plus />}
             variant="primary"
+            data-testid="wizard-generate-teams"
           >
             {numberOfTeams} Teams generieren
           </Button>
@@ -218,6 +219,7 @@ export const Step4_Teams: React.FC<Step4Props> = ({
           <Button
             onClick={handleAutoAssignGroups}
             variant="secondary"
+            data-testid="wizard-auto-assign-groups"
           >
             Gruppen automatisch zuweisen
           </Button>
@@ -319,6 +321,7 @@ export const Step4_Teams: React.FC<Step4Props> = ({
                     onClick={() => onRemoveTeam(team.id)}
                     className={styles.deleteButton}
                     aria-label={`Team ${team.name} löschen`}
+                    data-testid={`wizard-remove-team-${team.id}`}
                   >
                     <Icons.Trash size={18} />
                   </button>

--- a/src/features/tournament-creation/Step5_Overview.tsx
+++ b/src/features/tournament-creation/Step5_Overview.tsx
@@ -122,7 +122,7 @@ export const Step5_Overview: React.FC<Step5Props> = ({ formData, onSave }) => {
 
         {/* Preview Button */}
         <div style={{ marginTop: '24px' }}>
-          <Button onClick={onSave} icon={<Icons.ChevronRight />} size="lg" fullWidth iconPosition="right">
+          <Button onClick={onSave} icon={<Icons.ChevronRight />} size="lg" fullWidth iconPosition="right" data-testid="wizard-show-preview">
             Vorschau anzeigen
           </Button>
         </div>

--- a/src/features/tournament-creation/TournamentPreview.tsx
+++ b/src/features/tournament-creation/TournamentPreview.tsx
@@ -380,10 +380,10 @@ export const TournamentPreview: React.FC<TournamentPreviewProps> = ({
 
         {/* Aktionen */}
         <div style={actionsStyle} className="tournament-actions">
-          <Button variant="secondary" onClick={onEdit}>
+          <Button variant="secondary" onClick={onEdit} data-testid="preview-edit">
             Bearbeiten
           </Button>
-          <Button variant="secondary" onClick={() => void handleExportPDF()}>
+          <Button variant="secondary" onClick={() => void handleExportPDF()} data-testid="preview-export-pdf">
             PDF Exportieren
           </Button>
           <Button
@@ -394,6 +394,7 @@ export const TournamentPreview: React.FC<TournamentPreviewProps> = ({
               padding: '14px 32px',
               fontWeight: cssVars.fontWeights.bold,
             }}
+            data-testid="preview-publish"
           >
             Turnier freigeben
           </Button>

--- a/src/features/tournament-creation/components/ModeSelection.tsx
+++ b/src/features/tournament-creation/components/ModeSelection.tsx
@@ -14,6 +14,7 @@ interface ModeButtonProps {
   subtitle: string;
   disabled?: boolean;
   badge?: string;
+  testId?: string;
 }
 
 const ModeButton: React.FC<ModeButtonProps> = ({
@@ -23,6 +24,7 @@ const ModeButton: React.FC<ModeButtonProps> = ({
   subtitle,
   disabled = false,
   badge,
+  testId,
 }) => {
   const buttonStyle: CSSProperties = {
     padding: '20px',
@@ -46,6 +48,7 @@ const ModeButton: React.FC<ModeButtonProps> = ({
       style={buttonStyle}
       disabled={disabled}
       title={disabled ? 'Dieses Feature wird in einer zukünftigen Version verfügbar sein' : undefined}
+      data-testid={testId}
     >
       {badge && (
         <span style={{
@@ -96,6 +99,7 @@ export const ModeSelection: React.FC<ModeSelectionProps> = ({
           onClick={() => onModeChange('classic')}
           title="Klassisches Hallenturnier"
           subtitle="Gruppen + Finalrunde"
+          testId="wizard-mode-classic"
         />
         <ModeButton
           isSelected={selectedMode === 'miniFussball'}
@@ -104,6 +108,7 @@ export const ModeSelection: React.FC<ModeSelectionProps> = ({
           subtitle="Feldrotation, mehrere Felder"
           disabled={true}
           badge="Coming Soon"
+          testId="wizard-mode-miniFussball"
         />
       </div>
     </div>

--- a/src/features/tournament-creation/components/SportSelector.tsx
+++ b/src/features/tournament-creation/components/SportSelector.tsx
@@ -72,6 +72,7 @@ const SportCard: React.FC<SportCardProps> = ({
       }}
       role="radio"
       aria-checked={isSelected}
+      data-testid={`wizard-sport-${sport.id}`}
     >
       <div style={{ fontSize: cssVars.fontSizes.xxl, marginBottom: '12px' }}>
         {sport.icon}


### PR DESCRIPTION
## Summary
- Add comprehensive `data-testid` attributes to Tournament Creation Wizard for E2E testing
- All interactive elements now have unique, predictable test IDs

## Changes
| File | Test IDs Added |
|------|---------------|
| Step1_SportAndType | `wizard-type-classic`, `wizard-type-bambini` |
| SportSelector | `wizard-sport-{id}` (dynamic) |
| ModeSelection | `wizard-mode-classic`, `wizard-mode-miniFussball` |
| Step2_ModeAndSystem | `wizard-reset-tournament` |
| Step4_Teams | `wizard-add-team`, `wizard-generate-teams`, `wizard-auto-assign-groups`, `wizard-remove-team-{id}` |
| Step5_Overview | `wizard-show-preview` |
| TournamentPreview | `preview-edit`, `preview-export-pdf`, `preview-publish` |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)