### PR TITLE
refactor(auth): auth cleanup, error handling, unit tests & Zod hardening

### DIFF
--- a/src/core/generators/__tests__/playoffGenerator.test.ts
+++ b/src/core/generators/__tests__/playoffGenerator.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generatePlayoffMatches,
+  presetHasSemifinals,
+  presetHasQuarterfinals,
+  getExpectedMatchCount,
+} from '../playoffGenerator';
+import type { PlayoffMatch } from '../playoffGenerator';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getMatchIds(matches: PlayoffMatch[]): string[] {
+  return matches.map(m => m.id);
+}
+
+function assertDependsOnConsistency(matches: PlayoffMatch[]): void {
+  const ids = new Set(getMatchIds(matches));
+  for (const match of matches) {
+    if (match.dependsOn) {
+      for (const dep of match.dependsOn) {
+        expect(ids.has(dep), `${match.id} depends on ${dep} which doesn't exist`).toBe(true);
+      }
+    }
+  }
+}
+
+// =============================================================================
+// preset: 'none'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=none', () => {
+  it('returns empty array', () => {
+    expect(generatePlayoffMatches(2, { preset: 'none' })).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Edge case: < 2 groups
+// =============================================================================
+
+describe('generatePlayoffMatches with < 2 groups', () => {
+  it('returns empty array for 1 group', () => {
+    expect(generatePlayoffMatches(1, { preset: 'top-4' })).toEqual([]);
+  });
+
+  it('returns empty array for 0 groups', () => {
+    expect(generatePlayoffMatches(0, { preset: 'final-only' })).toEqual([]);
+  });
+});
+
+// =============================================================================
+// preset: 'final-only'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=final-only', () => {
+  it('generates 1 final match for 2 groups', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'final-only' });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe('final');
+    expect(matches[0].home).toBe('group-a-1st');
+    expect(matches[0].away).toBe('group-b-1st');
+    expect(matches[0].rank).toBe(1);
+  });
+
+  it('generates 1 final match for 4 groups (simplified)', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'final-only' });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe('final');
+  });
+});
+
+// =============================================================================
+// preset: 'top-4'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=top-4', () => {
+  it('generates 4 matches for 2 groups (2 semis + 3rd + final)', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-4' });
+    expect(matches).toHaveLength(4);
+
+    const ids = getMatchIds(matches);
+    expect(ids).toContain('semi1');
+    expect(ids).toContain('semi2');
+    expect(ids).toContain('third-place');
+    expect(ids).toContain('final');
+  });
+
+  it('uses cross-seeding for 2 groups', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-4' });
+    const semi1 = matches.find(m => m.id === 'semi1')!;
+    const semi2 = matches.find(m => m.id === 'semi2')!;
+
+    // Cross: A2 vs B1, A1 vs B2
+    expect(semi1.home).toBe('group-a-2nd');
+    expect(semi1.away).toBe('group-b-1st');
+    expect(semi2.home).toBe('group-a-1st');
+    expect(semi2.away).toBe('group-b-2nd');
+  });
+
+  it('final depends on both semifinals', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-4' });
+    const final = matches.find(m => m.id === 'final')!;
+    expect(final.dependsOn).toContain('semi1');
+    expect(final.dependsOn).toContain('semi2');
+    expect(final.home).toBe('semi1-winner');
+    expect(final.away).toBe('semi2-winner');
+  });
+
+  it('third place depends on both semifinals', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-4' });
+    const thirdPlace = matches.find(m => m.id === 'third-place')!;
+    expect(thirdPlace.dependsOn).toContain('semi1');
+    expect(thirdPlace.dependsOn).toContain('semi2');
+    expect(thirdPlace.home).toBe('semi1-loser');
+    expect(thirdPlace.away).toBe('semi2-loser');
+    expect(thirdPlace.rank).toBe(3);
+  });
+
+  it('has consistent dependsOn references', () => {
+    assertDependsOnConsistency(generatePlayoffMatches(2, { preset: 'top-4' }));
+  });
+});
+
+// =============================================================================
+// preset: 'top-8'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=top-8', () => {
+  it('falls back to top-4 for 2 groups', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-8' });
+    // Same as top-4
+    expect(matches).toHaveLength(4);
+    expect(getMatchIds(matches)).toContain('semi1');
+    expect(getMatchIds(matches)).not.toContain('qf1');
+  });
+
+  it('generates quarterfinals + semis + placements for 4 groups', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'top-8' });
+
+    const ids = getMatchIds(matches);
+    // 4 QF + 2 SF + place56 + place78 + third + final = 10
+    expect(ids).toContain('qf1');
+    expect(ids).toContain('qf2');
+    expect(ids).toContain('qf3');
+    expect(ids).toContain('qf4');
+    expect(ids).toContain('semi1');
+    expect(ids).toContain('semi2');
+    expect(ids).toContain('place56');
+    expect(ids).toContain('place78');
+    expect(ids).toContain('third-place');
+    expect(ids).toContain('final');
+    expect(matches).toHaveLength(10);
+  });
+
+  it('cross-seeds quarterfinals for 4 groups', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'top-8' });
+    const qf1 = matches.find(m => m.id === 'qf1')!;
+    const qf4 = matches.find(m => m.id === 'qf4')!;
+
+    expect(qf1.home).toBe('group-a-1st');
+    expect(qf1.away).toBe('group-d-2nd');
+    expect(qf4.home).toBe('group-d-1st');
+    expect(qf4.away).toBe('group-a-2nd');
+  });
+
+  it('semifinals depend on quarterfinals', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'top-8' });
+    const semi1 = matches.find(m => m.id === 'semi1')!;
+    expect(semi1.dependsOn).toContain('qf1');
+    expect(semi1.dependsOn).toContain('qf4');
+    expect(semi1.home).toBe('qf1-winner');
+    expect(semi1.away).toBe('qf4-winner');
+  });
+
+  it('placement matches for places 5-8', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'top-8' });
+    const place56 = matches.find(m => m.id === 'place56')!;
+    const place78 = matches.find(m => m.id === 'place78')!;
+
+    expect(place56.rank).toEqual([5, 6]);
+    expect(place56.home).toBe('qf1-loser');
+    expect(place56.away).toBe('qf2-loser');
+    expect(place78.rank).toEqual([7, 8]);
+    expect(place78.home).toBe('qf3-loser');
+    expect(place78.away).toBe('qf4-loser');
+  });
+
+  it('has consistent dependsOn references', () => {
+    assertDependsOnConsistency(generatePlayoffMatches(4, { preset: 'top-8' }));
+  });
+});
+
+// =============================================================================
+// preset: 'top-16'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=top-16', () => {
+  it('falls back to top-8 for < 8 groups', () => {
+    const matchesFor4 = generatePlayoffMatches(4, { preset: 'top-16' });
+    const matchesTop8 = generatePlayoffMatches(4, { preset: 'top-8' });
+    expect(matchesFor4).toEqual(matchesTop8);
+  });
+
+  it('falls back to top-4 for 2 groups', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'top-16' });
+    expect(matches).toHaveLength(4);
+    expect(getMatchIds(matches)).toContain('semi1');
+  });
+
+  it('generates full R16 bracket for 8 groups', () => {
+    const matches = generatePlayoffMatches(8, { preset: 'top-16' });
+    const ids = getMatchIds(matches);
+
+    // 8 R16 + 4 QF + 2 SF + third + final = 16
+    expect(matches).toHaveLength(16);
+    expect(ids.filter(id => id.startsWith('r16-'))).toHaveLength(8);
+    expect(ids.filter(id => id.startsWith('qf'))).toHaveLength(4);
+    expect(ids).toContain('semi1');
+    expect(ids).toContain('semi2');
+    expect(ids).toContain('third-place');
+    expect(ids).toContain('final');
+  });
+
+  it('R16 uses mirror seeding (A1 vs H2, B1 vs G2, ...)', () => {
+    const matches = generatePlayoffMatches(8, { preset: 'top-16' });
+    const r161 = matches.find(m => m.id === 'r16-1')!;
+    const r168 = matches.find(m => m.id === 'r16-8')!;
+
+    expect(r161.home).toBe('group-a-1st');
+    expect(r161.away).toBe('group-h-2nd');
+    expect(r168.home).toBe('group-h-1st');
+    expect(r168.away).toBe('group-a-2nd');
+  });
+
+  it('QF depends on R16 matches', () => {
+    const matches = generatePlayoffMatches(8, { preset: 'top-16' });
+    const qf1 = matches.find(m => m.id === 'qf1')!;
+    expect(qf1.dependsOn).toContain('r16-1');
+    expect(qf1.dependsOn).toContain('r16-8');
+    expect(qf1.home).toBe('r16-1-winner');
+    expect(qf1.away).toBe('r16-8-winner');
+  });
+
+  it('has consistent dependsOn references', () => {
+    assertDependsOnConsistency(generatePlayoffMatches(8, { preset: 'top-16' }));
+  });
+});
+
+// =============================================================================
+// preset: 'all-places'
+// =============================================================================
+
+describe('generatePlayoffMatches preset=all-places', () => {
+  it('generates all placement matches for 2 groups (default groupSizes)', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' });
+    const ids = getMatchIds(matches);
+
+    // 2 semis + place78 + place56 + third + final = 6
+    expect(ids).toContain('semi1');
+    expect(ids).toContain('semi2');
+    expect(ids).toContain('place78-direct');
+    expect(ids).toContain('place56-direct');
+    expect(ids).toContain('third-place');
+    expect(ids).toContain('final');
+    expect(matches).toHaveLength(6);
+  });
+
+  it('skips place78 when groups have < 4 teams', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' }, { A: 3, B: 3 });
+    const ids = getMatchIds(matches);
+
+    expect(ids).not.toContain('place78-direct');
+    expect(ids).toContain('place56-direct');
+    // 2 semis + place56 + third + final = 5
+    expect(matches).toHaveLength(5);
+  });
+
+  it('skips both placement matches when groups have < 3 teams', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' }, { A: 2, B: 2 });
+    const ids = getMatchIds(matches);
+
+    expect(ids).not.toContain('place78-direct');
+    expect(ids).not.toContain('place56-direct');
+    // 2 semis + third + final = 4
+    expect(matches).toHaveLength(4);
+  });
+
+  it('place56 uses 3rd place from each group', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' });
+    const place56 = matches.find(m => m.id === 'place56-direct')!;
+
+    expect(place56.home).toBe('group-a-3rd');
+    expect(place56.away).toBe('group-b-3rd');
+    expect(place56.rank).toEqual([5, 6]);
+  });
+
+  it('place78 uses 4th place from each group', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' });
+    const place78 = matches.find(m => m.id === 'place78-direct')!;
+
+    expect(place78.home).toBe('group-a-4th');
+    expect(place78.away).toBe('group-b-4th');
+    expect(place78.rank).toEqual([7, 8]);
+  });
+
+  it('final depends on all placement matches', () => {
+    const matches = generatePlayoffMatches(2, { preset: 'all-places' });
+    const final = matches.find(m => m.id === 'final')!;
+
+    expect(final.dependsOn).toContain('semi1');
+    expect(final.dependsOn).toContain('semi2');
+    expect(final.dependsOn).toContain('third-place');
+    expect(final.dependsOn).toContain('place56-direct');
+    expect(final.dependsOn).toContain('place78-direct');
+  });
+
+  it('falls back to top-8 for 4+ groups', () => {
+    const matches = generatePlayoffMatches(4, { preset: 'all-places' });
+    const matchesTop8 = generatePlayoffMatches(4, { preset: 'top-8' });
+    expect(matches).toEqual(matchesTop8);
+  });
+
+  it('falls back to top-4 for 3 groups', () => {
+    const matches = generatePlayoffMatches(3, { preset: 'all-places' });
+    const matchesTop4 = generatePlayoffMatches(3, { preset: 'top-4' });
+    expect(matches).toEqual(matchesTop4);
+  });
+
+  it('has consistent dependsOn references', () => {
+    assertDependsOnConsistency(generatePlayoffMatches(2, { preset: 'all-places' }));
+  });
+});
+
+// =============================================================================
+// presetHasSemifinals
+// =============================================================================
+
+describe('presetHasSemifinals', () => {
+  it('returns true for top-4, top-8, all-places', () => {
+    expect(presetHasSemifinals('top-4')).toBe(true);
+    expect(presetHasSemifinals('top-8')).toBe(true);
+    expect(presetHasSemifinals('all-places')).toBe(true);
+  });
+
+  it('returns false for none, final-only, top-16', () => {
+    expect(presetHasSemifinals('none')).toBe(false);
+    expect(presetHasSemifinals('final-only')).toBe(false);
+    expect(presetHasSemifinals('top-16')).toBe(false);
+  });
+});
+
+// =============================================================================
+// presetHasQuarterfinals
+// =============================================================================
+
+describe('presetHasQuarterfinals', () => {
+  it('returns true for top-8, all-places', () => {
+    expect(presetHasQuarterfinals('top-8')).toBe(true);
+    expect(presetHasQuarterfinals('all-places')).toBe(true);
+  });
+
+  it('returns false for none, final-only, top-4, top-16', () => {
+    expect(presetHasQuarterfinals('none')).toBe(false);
+    expect(presetHasQuarterfinals('final-only')).toBe(false);
+    expect(presetHasQuarterfinals('top-4')).toBe(false);
+    expect(presetHasQuarterfinals('top-16')).toBe(false);
+  });
+});
+
+// =============================================================================
+// getExpectedMatchCount
+// =============================================================================
+
+describe('getExpectedMatchCount', () => {
+  it('returns 0 for none', () => {
+    expect(getExpectedMatchCount('none', 2)).toBe(0);
+  });
+
+  it('returns 1 for final-only', () => {
+    expect(getExpectedMatchCount('final-only', 2)).toBe(1);
+  });
+
+  it('returns 4 for top-4 with 2 groups', () => {
+    expect(getExpectedMatchCount('top-4', 2)).toBe(4);
+  });
+
+  it('returns 10 for top-8 with 4 groups', () => {
+    expect(getExpectedMatchCount('top-8', 4)).toBe(10);
+  });
+
+  it('returns 16 for top-16 with 8 groups', () => {
+    expect(getExpectedMatchCount('top-16', 8)).toBe(16);
+  });
+
+  it('returns 6 for all-places with 2 groups (default sizes)', () => {
+    expect(getExpectedMatchCount('all-places', 2)).toBe(6);
+  });
+});

--- a/src/core/generators/__tests__/refereeAssigner.test.ts
+++ b/src/core/generators/__tests__/refereeAssigner.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import { assignReferees, getRefereeDisplayName, isValidFinalsReferee } from '../refereeAssigner';
+import type { Team, Match, RefereeConfig } from '../../../types/tournament';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface TestMatch {
+  id: string;
+  field: number;
+  slot?: number;
+  referee?: number;
+  teamA?: string;
+  teamB?: string;
+  homeTeam?: string;
+  awayTeam?: string;
+}
+
+function createMatch(overrides: Partial<TestMatch> & { id: string }): TestMatch {
+  return { field: 1, slot: 0, ...overrides };
+}
+
+function createTeams(count: number): Team[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `team-${i + 1}`,
+    name: `Team ${i + 1}`,
+  }));
+}
+
+// =============================================================================
+// assignReferees — mode: 'none'
+// =============================================================================
+
+describe('assignReferees mode=none', () => {
+  it('returns matches unchanged', () => {
+    const matches = [
+      createMatch({ id: 'm1', teamA: 'Team 1', teamB: 'Team 2' }),
+      createMatch({ id: 'm2', teamA: 'Team 3', teamB: 'Team 4' }),
+    ];
+    const config: RefereeConfig = { mode: 'none' };
+    const result = assignReferees(matches, createTeams(4), config);
+    expect(result).toEqual(matches);
+  });
+});
+
+// =============================================================================
+// assignReferees — mode: 'organizer'
+// =============================================================================
+
+describe('assignReferees mode=organizer', () => {
+  it('assigns referees with round-robin distribution', () => {
+    const matches = Array.from({ length: 6 }, (_, i) =>
+      createMatch({ id: `m${i + 1}`, slot: i, field: 1 })
+    );
+    const config: RefereeConfig = {
+      mode: 'organizer',
+      numberOfReferees: 2,
+      maxConsecutiveMatches: 1,
+    };
+    const result = assignReferees(matches, createTeams(4), config);
+
+    // Every match should have a referee assigned
+    for (const m of result) {
+      expect(m.referee).toBeDefined();
+      expect(m.referee).toBeGreaterThanOrEqual(1);
+      expect(m.referee).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('respects maxConsecutiveMatches constraint', () => {
+    const matches = Array.from({ length: 4 }, (_, i) =>
+      createMatch({ id: `m${i + 1}`, slot: i, field: 1 })
+    );
+    const config: RefereeConfig = {
+      mode: 'organizer',
+      numberOfReferees: 2,
+      maxConsecutiveMatches: 1,
+    };
+    const result = assignReferees(matches, createTeams(4), config);
+
+    // No referee should have two consecutive slots (maxConsecutive=1 means 1 slot break needed)
+    for (let i = 1; i < result.length; i++) {
+      const currentSlot = result[i].slot ?? 0;
+      const previousSlot = result[i - 1].slot ?? 0;
+      if (currentSlot - previousSlot < 1) {
+        continue; // same slot, skip
+      }
+      // Adjacent slots should have different referees
+      if (currentSlot - previousSlot === 1) {
+        expect(result[i].referee).not.toBe(result[i - 1].referee);
+      }
+    }
+  });
+
+  it('balances workload across referees', () => {
+    const matches = Array.from({ length: 8 }, (_, i) =>
+      createMatch({ id: `m${i + 1}`, slot: i, field: 1 })
+    );
+    const config: RefereeConfig = {
+      mode: 'organizer',
+      numberOfReferees: 2,
+      maxConsecutiveMatches: 1,
+    };
+    const result = assignReferees(matches, createTeams(4), config);
+
+    const workload = [0, 0];
+    for (const m of result) {
+      if (m.referee) {
+        workload[m.referee - 1]++;
+      }
+    }
+    // Difference should be at most 1
+    expect(Math.abs(workload[0] - workload[1])).toBeLessThanOrEqual(1);
+  });
+
+  it('preserves manual assignments', () => {
+    const matches = [
+      createMatch({ id: 'm1', slot: 0, field: 1 }),
+      createMatch({ id: 'm2', slot: 1, field: 1 }),
+      createMatch({ id: 'm3', slot: 2, field: 1 }),
+    ];
+    const config: RefereeConfig = {
+      mode: 'organizer',
+      numberOfReferees: 2,
+      maxConsecutiveMatches: 1,
+      manualAssignments: { m2: 99 },
+    };
+    const result = assignReferees(matches, createTeams(4), config);
+
+    expect(result.find(m => m.id === 'm2')!.referee).toBe(99);
+  });
+
+  it('defaults to 2 referees when numberOfReferees not set', () => {
+    const matches = Array.from({ length: 4 }, (_, i) =>
+      createMatch({ id: `m${i + 1}`, slot: i, field: 1 })
+    );
+    const config: RefereeConfig = { mode: 'organizer' };
+    const result = assignReferees(matches, createTeams(4), config);
+
+    const refNumbers = new Set(result.map(m => m.referee));
+    // Should only use refs 1 and 2
+    for (const ref of refNumbers) {
+      expect(ref).toBeGreaterThanOrEqual(1);
+      expect(ref).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+// =============================================================================
+// assignReferees — mode: 'teams'
+// =============================================================================
+
+describe('assignReferees mode=teams', () => {
+  it('assigns previous home team as referee for next match on same field', () => {
+    const teams = createTeams(4);
+    const matches = [
+      createMatch({ id: 'm1', slot: 0, field: 1, teamA: 'Team 1', teamB: 'Team 2' }),
+      createMatch({ id: 'm2', slot: 1, field: 1, teamA: 'Team 3', teamB: 'Team 4' }),
+    ];
+    const config: RefereeConfig = { mode: 'teams' };
+    const result = assignReferees(matches, teams, config);
+
+    // First match: no previous match, so no referee
+    expect(result.find(m => m.id === 'm1')!.referee).toBeUndefined();
+    // Second match: Team 1 (index 0 + 1 = 1) was home in previous match
+    expect(result.find(m => m.id === 'm2')!.referee).toBe(1);
+  });
+
+  it('handles ScheduledMatch format (homeTeam/awayTeam)', () => {
+    const teams = createTeams(4);
+    const matches = [
+      createMatch({ id: 'm1', slot: 0, field: 1, homeTeam: 'Team 1', awayTeam: 'Team 2' }),
+      createMatch({ id: 'm2', slot: 1, field: 1, homeTeam: 'Team 3', awayTeam: 'Team 4' }),
+    ];
+    const config: RefereeConfig = { mode: 'teams' };
+    const result = assignReferees(matches, teams, config);
+
+    expect(result.find(m => m.id === 'm2')!.referee).toBe(1);
+  });
+
+  it('assigns separately per field', () => {
+    const teams = createTeams(4);
+    const matches = [
+      createMatch({ id: 'm1', slot: 0, field: 1, teamA: 'Team 1', teamB: 'Team 2' }),
+      createMatch({ id: 'm2', slot: 0, field: 2, teamA: 'Team 3', teamB: 'Team 4' }),
+      createMatch({ id: 'm3', slot: 1, field: 1, teamA: 'Team 3', teamB: 'Team 4' }),
+      createMatch({ id: 'm4', slot: 1, field: 2, teamA: 'Team 1', teamB: 'Team 2' }),
+    ];
+    const config: RefereeConfig = { mode: 'teams' };
+    const result = assignReferees(matches, teams, config);
+
+    // Field 1: previous home was Team 1 → ref = 1
+    expect(result.find(m => m.id === 'm3')!.referee).toBe(1);
+    // Field 2: previous home was Team 3 → ref = 3
+    expect(result.find(m => m.id === 'm4')!.referee).toBe(3);
+  });
+
+  it('preserves manual assignments in teams mode', () => {
+    const teams = createTeams(4);
+    const matches = [
+      createMatch({ id: 'm1', slot: 0, field: 1, teamA: 'Team 1', teamB: 'Team 2' }),
+      createMatch({ id: 'm2', slot: 1, field: 1, teamA: 'Team 3', teamB: 'Team 4' }),
+    ];
+    const config: RefereeConfig = {
+      mode: 'teams',
+      manualAssignments: { m2: 42 },
+    };
+    const result = assignReferees(matches, teams, config);
+
+    expect(result.find(m => m.id === 'm2')!.referee).toBe(42);
+  });
+});
+
+// =============================================================================
+// getRefereeDisplayName
+// =============================================================================
+
+describe('getRefereeDisplayName', () => {
+  it('returns "-" when refereeNumber is undefined', () => {
+    expect(getRefereeDisplayName(undefined, { mode: 'organizer' })).toBe('-');
+  });
+
+  it('returns custom name from refereeNames', () => {
+    const config: RefereeConfig = {
+      mode: 'organizer',
+      refereeNames: { 1: 'Max Mustermann' },
+    };
+    expect(getRefereeDisplayName(1, config)).toBe('Max Mustermann');
+  });
+
+  it('returns team name in teams mode', () => {
+    const teams = createTeams(3);
+    const config: RefereeConfig = { mode: 'teams' };
+    expect(getRefereeDisplayName(2, config, teams)).toBe('Team 2');
+  });
+
+  it('returns number as string when no config matches', () => {
+    expect(getRefereeDisplayName(5, { mode: 'organizer' })).toBe('5');
+  });
+
+  it('returns number as string when config is undefined', () => {
+    expect(getRefereeDisplayName(3, undefined)).toBe('3');
+  });
+});
+
+// =============================================================================
+// isValidFinalsReferee
+// =============================================================================
+
+describe('isValidFinalsReferee', () => {
+  const teams = createTeams(4);
+  const match: Match = {
+    id: 'final',
+    round: 1,
+    field: 1,
+    teamA: 'Team 1',
+    teamB: 'Team 2',
+  };
+
+  it('returns false when finalsRefereeMode is "none"', () => {
+    const config: RefereeConfig = { mode: 'organizer', finalsRefereeMode: 'none' };
+    expect(isValidFinalsReferee(match, 3, config, teams)).toBe(false);
+  });
+
+  it('returns false when finalsRefereeMode is undefined', () => {
+    const config: RefereeConfig = { mode: 'organizer' };
+    expect(isValidFinalsReferee(match, 3, config, teams)).toBe(false);
+  });
+
+  it('returns false when referee team is playing in the match', () => {
+    const config: RefereeConfig = { mode: 'teams', finalsRefereeMode: 'neutralTeams' };
+    // Team 1 (index 0, referee number 1) is playing
+    expect(isValidFinalsReferee(match, 1, config, teams)).toBe(false);
+  });
+
+  it('returns true for neutral team referee', () => {
+    const config: RefereeConfig = { mode: 'teams', finalsRefereeMode: 'neutralTeams' };
+    // Team 3 (referee number 3) is not playing
+    expect(isValidFinalsReferee(match, 3, config, teams)).toBe(true);
+  });
+});

--- a/src/core/generators/__tests__/scheduleHelpers.test.ts
+++ b/src/core/generators/__tests__/scheduleHelpers.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseStartTime,
+  addMinutes,
+  formatTime,
+  calculateTotalMatchDuration,
+  determineFinalPhase,
+  resolveTeamName,
+  translatePlaceholder,
+  createInitialStandings,
+  scheduleMatches,
+} from '../scheduleHelpers';
+import type { Match, Team, TournamentGroup } from '../../../types/tournament';
+
+// =============================================================================
+// parseStartTime
+// =============================================================================
+
+describe('parseStartTime', () => {
+  it('parses ISO date format (YYYY-MM-DD)', () => {
+    const result = parseStartTime('2026-03-15', '09:00');
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(2); // March = 2
+    expect(result.getDate()).toBe(15);
+    expect(result.getHours()).toBe(9);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('parses German date format (DD.MM.YYYY)', () => {
+    const result = parseStartTime('15.03.2026', '14:30');
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(2);
+    expect(result.getDate()).toBe(15);
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  it('falls back to today for unrecognized format', () => {
+    const now = new Date();
+    const result = parseStartTime('unknown', '10:00');
+    expect(result.getFullYear()).toBe(now.getFullYear());
+    expect(result.getHours()).toBe(10);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('handles time slot with single-digit hours', () => {
+    const result = parseStartTime('2026-01-01', '9:05');
+    expect(result.getHours()).toBe(9);
+    expect(result.getMinutes()).toBe(5);
+  });
+
+  it('sets seconds and milliseconds to 0', () => {
+    const result = parseStartTime('2026-01-01', '12:00');
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+});
+
+// =============================================================================
+// addMinutes
+// =============================================================================
+
+describe('addMinutes', () => {
+  it('adds positive minutes', () => {
+    const base = new Date(2026, 0, 1, 10, 0);
+    const result = addMinutes(base, 30);
+    expect(result.getHours()).toBe(10);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  it('adds negative minutes', () => {
+    const base = new Date(2026, 0, 1, 10, 30);
+    const result = addMinutes(base, -15);
+    expect(result.getHours()).toBe(10);
+    expect(result.getMinutes()).toBe(15);
+  });
+
+  it('crosses hour boundary', () => {
+    const base = new Date(2026, 0, 1, 10, 45);
+    const result = addMinutes(base, 30);
+    expect(result.getHours()).toBe(11);
+    expect(result.getMinutes()).toBe(15);
+  });
+
+  it('does not mutate original date', () => {
+    const base = new Date(2026, 0, 1, 10, 0);
+    const originalTime = base.getTime();
+    addMinutes(base, 30);
+    expect(base.getTime()).toBe(originalTime);
+  });
+});
+
+// =============================================================================
+// formatTime
+// =============================================================================
+
+describe('formatTime', () => {
+  it('formats with zero-padded hours and minutes', () => {
+    expect(formatTime(new Date(2026, 0, 1, 9, 5))).toBe('09:05');
+  });
+
+  it('formats midnight as 00:00', () => {
+    expect(formatTime(new Date(2026, 0, 1, 0, 0))).toBe('00:00');
+  });
+
+  it('formats afternoon time', () => {
+    expect(formatTime(new Date(2026, 0, 1, 14, 30))).toBe('14:30');
+  });
+});
+
+// =============================================================================
+// calculateTotalMatchDuration
+// =============================================================================
+
+describe('calculateTotalMatchDuration', () => {
+  it('returns gameDuration for 1 period', () => {
+    expect(calculateTotalMatchDuration(10, 1, 2)).toBe(10);
+  });
+
+  it('adds halftime breaks for 2 periods', () => {
+    // 10 min game + 1 break * 2 min = 12
+    expect(calculateTotalMatchDuration(10, 2, 2)).toBe(12);
+  });
+
+  it('adds multiple breaks for 3 periods', () => {
+    // 15 min game + 2 breaks * 3 min = 21
+    expect(calculateTotalMatchDuration(15, 3, 3)).toBe(21);
+  });
+
+  it('returns gameDuration for 0 periods (edge case)', () => {
+    expect(calculateTotalMatchDuration(10, 0, 5)).toBe(10);
+  });
+});
+
+// =============================================================================
+// determineFinalPhase
+// =============================================================================
+
+describe('determineFinalPhase', () => {
+  const baseMatch: Match = {
+    id: 'test',
+    round: 1,
+    field: 1,
+    teamA: 'A',
+    teamB: 'B',
+  };
+
+  it('returns "final" when finalType is set', () => {
+    expect(determineFinalPhase({ ...baseMatch, finalType: 'thirdPlace' })).toBe('final');
+  });
+
+  it('detects roundOf16 from match id', () => {
+    expect(determineFinalPhase({ ...baseMatch, id: 'r16-1' })).toBe('roundOf16');
+  });
+
+  it('detects quarterfinal from match id', () => {
+    expect(determineFinalPhase({ ...baseMatch, id: 'qf1' })).toBe('quarterfinal');
+  });
+
+  it('detects semifinal from match id containing "sf"', () => {
+    expect(determineFinalPhase({ ...baseMatch, id: 'sf-1' })).toBe('semifinal');
+  });
+
+  it('detects semifinal from match id containing "semi"', () => {
+    expect(determineFinalPhase({ ...baseMatch, id: 'semi1' })).toBe('semifinal');
+  });
+
+  it('defaults to "final" for unknown id patterns', () => {
+    expect(determineFinalPhase({ ...baseMatch, id: 'final' })).toBe('final');
+  });
+});
+
+// =============================================================================
+// translatePlaceholder
+// =============================================================================
+
+describe('translatePlaceholder', () => {
+  it('translates group placeholder to German', () => {
+    const result = translatePlaceholder('group-a-1st', 'de');
+    expect(result).toBe('Gruppe A - 1. Platz');
+  });
+
+  it('translates group placeholder to English', () => {
+    const result = translatePlaceholder('group-b-2nd', 'en');
+    expect(result).toBe('Gruppe B - 2nd Place');
+  });
+
+  it('uses custom group name when provided', () => {
+    const groups: TournamentGroup[] = [
+      { id: 'A', customName: 'Lions' },
+      { id: 'B', customName: 'Tigers' },
+    ];
+    const result = translatePlaceholder('group-a-1st', 'de', groups);
+    expect(result).toBe('Lions - 1. Platz');
+  });
+
+  it('translates final placeholders (German)', () => {
+    expect(translatePlaceholder('semi1-winner', 'de')).toBe('Sieger HF 1');
+    expect(translatePlaceholder('qf1-loser', 'de')).toBe('Verlierer VF 1');
+  });
+
+  it('translates final placeholders (English)', () => {
+    expect(translatePlaceholder('semi1-winner', 'en')).toBe('Winner SF 1');
+    expect(translatePlaceholder('qf2-winner', 'en')).toBe('Winner QF 2');
+  });
+
+  it('returns original placeholder for unknown strings', () => {
+    expect(translatePlaceholder('unknown-thing', 'de')).toBe('unknown-thing');
+  });
+
+  it('handles 3rd/4th ordinal suffixes in English', () => {
+    const result = translatePlaceholder('group-c-3rd', 'en');
+    expect(result).toBe('Gruppe C - 3rd Place');
+  });
+
+  it('handles 4th ordinal suffix in English', () => {
+    const result = translatePlaceholder('group-d-4th', 'en');
+    expect(result).toBe('Gruppe D - 4th Place');
+  });
+});
+
+// =============================================================================
+// resolveTeamName
+// =============================================================================
+
+describe('resolveTeamName', () => {
+  const teamMap = new Map([
+    ['team-1', 'FC Bayern'],
+    ['team-2', 'BVB Dortmund'],
+  ]);
+
+  it('resolves known team ID to name', () => {
+    expect(resolveTeamName('team-1', teamMap, 'de')).toBe('FC Bayern');
+  });
+
+  it('falls back to translatePlaceholder for unknown ID', () => {
+    expect(resolveTeamName('group-a-1st', teamMap, 'de')).toBe('Gruppe A - 1. Platz');
+  });
+
+  it('passes groups through to translatePlaceholder', () => {
+    const groups: TournamentGroup[] = [{ id: 'A', customName: 'Wolves' }];
+    expect(resolveTeamName('group-a-1st', teamMap, 'en', groups)).toBe('Wolves - 1st Place');
+  });
+});
+
+// =============================================================================
+// createInitialStandings
+// =============================================================================
+
+describe('createInitialStandings', () => {
+  it('creates standings with all zeros for each team', () => {
+    const teams: Team[] = [
+      { id: 't1', name: 'Team A' },
+      { id: 't2', name: 'Team B' },
+    ];
+    const standings = createInitialStandings(teams);
+
+    expect(standings).toHaveLength(2);
+    expect(standings[0].team).toBe(teams[0]);
+    expect(standings[0].played).toBe(0);
+    expect(standings[0].won).toBe(0);
+    expect(standings[0].drawn).toBe(0);
+    expect(standings[0].lost).toBe(0);
+    expect(standings[0].goalsFor).toBe(0);
+    expect(standings[0].goalsAgainst).toBe(0);
+    expect(standings[0].goalDifference).toBe(0);
+    expect(standings[0].points).toBe(0);
+  });
+
+  it('returns empty array for empty teams', () => {
+    expect(createInitialStandings([])).toEqual([]);
+  });
+});
+
+// =============================================================================
+// scheduleMatches
+// =============================================================================
+
+describe('scheduleMatches', () => {
+  const teamMap = new Map([
+    ['t1', 'Team A'],
+    ['t2', 'Team B'],
+    ['t3', 'Team C'],
+    ['t4', 'Team D'],
+  ]);
+
+  it('schedules matches with correct times and numbers', () => {
+    const matches: Match[] = [
+      { id: 'm1', round: 1, field: 1, teamA: 't1', teamB: 't2', slot: 0 },
+      { id: 'm2', round: 1, field: 2, teamA: 't3', teamB: 't4', slot: 0 },
+      { id: 'm3', round: 2, field: 1, teamA: 't1', teamB: 't3', slot: 1 },
+    ];
+
+    const result = scheduleMatches({
+      matches,
+      startTime: new Date(2026, 0, 1, 10, 0),
+      numberOfFields: 2,
+      gameDuration: 10,
+      breakDuration: 2,
+      gamePeriods: 1,
+      halftimeBreak: 0,
+      phase: 'groupStage',
+      teamMap,
+      locale: 'de',
+      startMatchNumber: 1,
+    });
+
+    expect(result).toHaveLength(3);
+    // First slot: 10:00
+    expect(result[0].time).toBe('10:00');
+    expect(result[0].matchNumber).toBe(1);
+    expect(result[0].homeTeam).toBe('Team A');
+    expect(result[0].awayTeam).toBe('Team B');
+    expect(result[1].time).toBe('10:00');
+    expect(result[1].matchNumber).toBe(2);
+    // Second slot: 10:00 + 10 (game) + 2 (break) = 10:12
+    expect(result[2].time).toBe('10:12');
+    expect(result[2].matchNumber).toBe(3);
+  });
+
+  it('calculates duration including halftime breaks', () => {
+    const matches: Match[] = [
+      { id: 'm1', round: 1, field: 1, teamA: 't1', teamB: 't2', slot: 0 },
+    ];
+
+    const result = scheduleMatches({
+      matches,
+      startTime: new Date(2026, 0, 1, 10, 0),
+      numberOfFields: 1,
+      gameDuration: 12,
+      breakDuration: 3,
+      gamePeriods: 2,
+      halftimeBreak: 2,
+      phase: 'groupStage',
+      teamMap,
+      locale: 'de',
+      startMatchNumber: 1,
+    });
+
+    // 12 min game + 1 break * 2 min halftime = 14 min total
+    expect(result[0].duration).toBe(14);
+  });
+
+  it('uses round-based sorting when slot is undefined', () => {
+    const matches: Match[] = [
+      { id: 'm2', round: 2, field: 1, teamA: 't3', teamB: 't4' },
+      { id: 'm1', round: 1, field: 1, teamA: 't1', teamB: 't2' },
+    ];
+
+    const result = scheduleMatches({
+      matches,
+      startTime: new Date(2026, 0, 1, 10, 0),
+      numberOfFields: 1,
+      gameDuration: 10,
+      breakDuration: 2,
+      gamePeriods: 1,
+      halftimeBreak: 0,
+      phase: 'groupStage',
+      teamMap,
+      locale: 'de',
+      startMatchNumber: 1,
+    });
+
+    // Round 1 (slot=0) should come first
+    expect(result[0].homeTeam).toBe('Team A');
+    expect(result[1].homeTeam).toBe('Team C');
+  });
+
+  it('sets phase to groupStage or detects final phase', () => {
+    const matches: Match[] = [
+      { id: 'semi1', round: 1, field: 1, teamA: 't1', teamB: 't2', isFinal: true, slot: 0 },
+    ];
+
+    const result = scheduleMatches({
+      matches,
+      startTime: new Date(2026, 0, 1, 10, 0),
+      numberOfFields: 1,
+      gameDuration: 10,
+      breakDuration: 2,
+      gamePeriods: 1,
+      halftimeBreak: 0,
+      phase: 'final',
+      teamMap,
+      locale: 'de',
+      startMatchNumber: 1,
+    });
+
+    expect(result[0].phase).toBe('semifinal');
+  });
+});

--- a/src/core/models/schemas/CommonSchemas.ts
+++ b/src/core/models/schemas/CommonSchemas.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+// =============================================================================
+// Team Trainer Schema
+// =============================================================================
+
+export const TeamTrainerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  inviteStatus: z.enum(['pending', 'sent', 'accepted']),
+  inviteToken: z.string().optional(),
+  inviteSentAt: z.string().optional(),
+  acceptedAt: z.string().optional(),
+  createdAt: z.string(),
+})
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- passthrough for forward-compatibility
+  .passthrough();
+
+// =============================================================================
+// Tournament Group Schema
+// =============================================================================
+
+export const TournamentGroupSchema = z.object({
+  id: z.string(),
+  customName: z.string().optional(),
+  shortCode: z.string().optional(),
+  allowedFieldIds: z.array(z.string()).optional(),
+})
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- passthrough for forward-compatibility
+  .passthrough();
+
+// =============================================================================
+// Tournament Field Schema
+// =============================================================================
+
+export const TournamentFieldSchema = z.object({
+  id: z.string(),
+  defaultName: z.string(),
+  customName: z.string().optional(),
+  shortCode: z.string().optional(),
+})
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- passthrough for forward-compatibility
+  .passthrough();
+
+// =============================================================================
+// Runtime Match Event Schema
+// =============================================================================
+
+const RuntimeMatchEventPayloadSchema = z.object({
+  teamId: z.string().optional(),
+  teamName: z.string().optional(),
+  direction: z.enum(['INC', 'DEC']).optional(),
+  newHomeScore: z.number().optional(),
+  newAwayScore: z.number().optional(),
+  toStatus: z.enum(['NOT_STARTED', 'RUNNING', 'PAUSED', 'FINISHED']).optional(),
+  playerNumber: z.number().optional(),
+  assists: z.array(z.number()).optional(),
+  penaltyDuration: z.number().optional(),
+  playersOut: z.array(z.number()).optional(),
+  playersIn: z.array(z.number()).optional(),
+  cardType: z.enum(['YELLOW', 'RED']).optional(),
+})
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- passthrough for forward-compatibility
+  .passthrough();
+
+export const RuntimeMatchEventSchema = z.object({
+  id: z.string(),
+  matchId: z.string().optional(),
+  timestampSeconds: z.number(),
+  type: z.enum(['GOAL', 'RESULT_EDIT', 'STATUS_CHANGE', 'YELLOW_CARD', 'RED_CARD', 'TIME_PENALTY', 'SUBSTITUTION', 'FOUL']),
+  payload: RuntimeMatchEventPayloadSchema,
+  scoreAfter: z.object({
+    home: z.number(),
+    away: z.number(),
+  }),
+  incomplete: z.boolean().optional(),
+})
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- passthrough for forward-compatibility
+  .passthrough();

--- a/src/core/models/schemas/MutationItemSchema.ts
+++ b/src/core/models/schemas/MutationItemSchema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const MutationItemSchema = z.object({
+  id: z.string(),
+  type: z.enum([
+    'SAVE_TOURNAMENT',
+    'DELETE_TOURNAMENT',
+    'UPDATE_MATCH',
+    'UPDATE_MATCHES',
+    'UPDATE_TOURNAMENT_METADATA',
+  ]),
+  payload: z.unknown(),
+  timestamp: z.number(),
+  retryCount: z.number(),
+});
+
+export const FailedMutationItemSchema = MutationItemSchema.extend({
+  failedAt: z.number(),
+  lastError: z.string().optional(),
+});

--- a/src/core/models/schemas/TournamentSchema.ts
+++ b/src/core/models/schemas/TournamentSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TeamTrainerSchema, TournamentGroupSchema, TournamentFieldSchema, RuntimeMatchEventSchema } from './CommonSchemas';
 
 const TeamLogoSchema = z.object({
     type: z.enum(['url', 'base64', 'initials']),
@@ -21,7 +22,7 @@ export const TeamSchema = z.object({
     removedAt: z.string().optional(),
     logo: TeamLogoSchema.optional(),
     colors: TeamColorsSchema.optional(),
-    trainers: z.array(z.any()).optional(),
+    trainers: z.array(TeamTrainerSchema).optional(),
 });
 
 export const MatchSchema = z.object({
@@ -51,7 +52,7 @@ export const MatchSchema = z.object({
     decidedBy: z.string().optional(),
     skippedReason: z.string().optional(),
     skippedAt: z.string().optional(),
-    events: z.array(z.any()).optional(), // Persist match events (scorers, cards, etc.)
+    events: z.array(RuntimeMatchEventSchema).optional(),
 });
 
 // Handling Date: JSON has strings. Our application assumes Date objects for some fields?
@@ -69,8 +70,8 @@ export const TournamentSchema = z.object({
     // Data
     teams: z.array(TeamSchema),
     matches: z.array(MatchSchema),
-    groups: z.array(z.any()).optional(),
-    fields: z.array(z.any()).optional(),
+    groups: z.array(TournamentGroupSchema).optional(),
+    fields: z.array(TournamentFieldSchema).optional(),
 
     // Config
     sport: z.string(),

--- a/src/core/models/schemas/__tests__/CommonSchemas.test.ts
+++ b/src/core/models/schemas/__tests__/CommonSchemas.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TeamTrainerSchema,
+  TournamentGroupSchema,
+  TournamentFieldSchema,
+  RuntimeMatchEventSchema,
+} from '../CommonSchemas';
+
+// =============================================================================
+// TeamTrainerSchema
+// =============================================================================
+
+describe('TeamTrainerSchema', () => {
+  it('validates a complete trainer', () => {
+    const trainer = {
+      id: 't1',
+      name: 'Max Mustermann',
+      email: 'max@example.com',
+      phone: '+49123456',
+      inviteStatus: 'accepted',
+      inviteToken: 'abc123',
+      inviteSentAt: '2026-01-01T00:00:00Z',
+      acceptedAt: '2026-01-02T00:00:00Z',
+      createdAt: '2025-12-01T00:00:00Z',
+    };
+    expect(TeamTrainerSchema.parse(trainer)).toMatchObject(trainer);
+  });
+
+  it('validates minimal trainer (only required fields)', () => {
+    const trainer = { id: 't1', name: 'Anna', inviteStatus: 'pending', createdAt: '2026-01-01T00:00:00Z' };
+    const result = TeamTrainerSchema.parse(trainer);
+    expect(result.id).toBe('t1');
+    expect(result.email).toBeUndefined();
+  });
+
+  it('rejects invalid inviteStatus', () => {
+    const trainer = { id: 't1', name: 'X', inviteStatus: 'invalid', createdAt: '2026-01-01' };
+    expect(() => TeamTrainerSchema.parse(trainer)).toThrow();
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() => TeamTrainerSchema.parse({ id: 't1' })).toThrow();
+  });
+
+  it('preserves unknown fields (passthrough)', () => {
+    const trainer = { id: 't1', name: 'X', inviteStatus: 'pending', createdAt: '2026-01-01', futureField: 42 };
+    const result = TeamTrainerSchema.parse(trainer);
+    expect((result as Record<string, unknown>).futureField).toBe(42);
+  });
+});
+
+// =============================================================================
+// TournamentGroupSchema
+// =============================================================================
+
+describe('TournamentGroupSchema', () => {
+  it('validates a complete group', () => {
+    const group = { id: 'A', customName: 'Lions', shortCode: 'LI', allowedFieldIds: ['field-1', 'field-2'] };
+    expect(TournamentGroupSchema.parse(group)).toMatchObject(group);
+  });
+
+  it('validates minimal group (only id)', () => {
+    const result = TournamentGroupSchema.parse({ id: 'B' });
+    expect(result.id).toBe('B');
+    expect(result.customName).toBeUndefined();
+  });
+
+  it('rejects missing id', () => {
+    expect(() => TournamentGroupSchema.parse({ customName: 'X' })).toThrow();
+  });
+
+  it('preserves unknown fields (passthrough)', () => {
+    const result = TournamentGroupSchema.parse({ id: 'A', extra: true });
+    expect((result as Record<string, unknown>).extra).toBe(true);
+  });
+});
+
+// =============================================================================
+// TournamentFieldSchema
+// =============================================================================
+
+describe('TournamentFieldSchema', () => {
+  it('validates a complete field', () => {
+    const field = { id: 'field-1', defaultName: 'Feld 1', customName: 'Halle Nord', shortCode: 'HN' };
+    expect(TournamentFieldSchema.parse(field)).toMatchObject(field);
+  });
+
+  it('validates minimal field', () => {
+    const result = TournamentFieldSchema.parse({ id: 'field-1', defaultName: 'Feld 1' });
+    expect(result.id).toBe('field-1');
+    expect(result.customName).toBeUndefined();
+  });
+
+  it('rejects missing defaultName', () => {
+    expect(() => TournamentFieldSchema.parse({ id: 'field-1' })).toThrow();
+  });
+});
+
+// =============================================================================
+// RuntimeMatchEventSchema
+// =============================================================================
+
+describe('RuntimeMatchEventSchema', () => {
+  it('validates a GOAL event', () => {
+    const event = {
+      id: 'e1',
+      matchId: 'm1',
+      timestampSeconds: 120,
+      type: 'GOAL',
+      payload: {
+        teamId: 't1',
+        teamName: 'Team A',
+        direction: 'INC',
+        newHomeScore: 1,
+        newAwayScore: 0,
+        playerNumber: 7,
+      },
+      scoreAfter: { home: 1, away: 0 },
+    };
+    expect(RuntimeMatchEventSchema.parse(event)).toMatchObject(event);
+  });
+
+  it('validates a STATUS_CHANGE event', () => {
+    const event = {
+      id: 'e2',
+      timestampSeconds: 0,
+      type: 'STATUS_CHANGE',
+      payload: { toStatus: 'RUNNING' },
+      scoreAfter: { home: 0, away: 0 },
+    };
+    const result = RuntimeMatchEventSchema.parse(event);
+    expect(result.type).toBe('STATUS_CHANGE');
+    expect(result.payload.toStatus).toBe('RUNNING');
+  });
+
+  it('validates a YELLOW_CARD event with incomplete flag', () => {
+    const event = {
+      id: 'e3',
+      timestampSeconds: 300,
+      type: 'YELLOW_CARD',
+      payload: { teamId: 't2', playerNumber: 10, cardType: 'YELLOW' },
+      scoreAfter: { home: 0, away: 0 },
+      incomplete: true,
+    };
+    const result = RuntimeMatchEventSchema.parse(event);
+    expect(result.incomplete).toBe(true);
+  });
+
+  it('rejects invalid event type', () => {
+    const event = {
+      id: 'e1',
+      timestampSeconds: 0,
+      type: 'INVALID_TYPE',
+      payload: {},
+      scoreAfter: { home: 0, away: 0 },
+    };
+    expect(() => RuntimeMatchEventSchema.parse(event)).toThrow();
+  });
+
+  it('rejects missing scoreAfter', () => {
+    const event = {
+      id: 'e1',
+      timestampSeconds: 0,
+      type: 'GOAL',
+      payload: {},
+    };
+    expect(() => RuntimeMatchEventSchema.parse(event)).toThrow();
+  });
+
+  it('preserves unknown payload fields (passthrough)', () => {
+    const event = {
+      id: 'e1',
+      timestampSeconds: 0,
+      type: 'GOAL',
+      payload: { futurePayloadField: 'test' },
+      scoreAfter: { home: 0, away: 0 },
+    };
+    const result = RuntimeMatchEventSchema.parse(event);
+    expect((result.payload as Record<string, unknown>).futurePayloadField).toBe('test');
+  });
+});

--- a/src/core/models/schemas/__tests__/MutationItemSchema.test.ts
+++ b/src/core/models/schemas/__tests__/MutationItemSchema.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { MutationItemSchema, FailedMutationItemSchema } from '../MutationItemSchema';
+
+// =============================================================================
+// MutationItemSchema
+// =============================================================================
+
+describe('MutationItemSchema', () => {
+  it('validates a valid SAVE_TOURNAMENT item', () => {
+    const item = {
+      id: 'abc-123',
+      type: 'SAVE_TOURNAMENT',
+      payload: { id: 't1', title: 'Test' },
+      timestamp: Date.now(),
+      retryCount: 0,
+    };
+    expect(MutationItemSchema.parse(item)).toMatchObject(item);
+  });
+
+  it('validates all mutation types', () => {
+    const types = ['SAVE_TOURNAMENT', 'DELETE_TOURNAMENT', 'UPDATE_MATCH', 'UPDATE_MATCHES', 'UPDATE_TOURNAMENT_METADATA'] as const;
+    for (const type of types) {
+      const item = { id: '1', type, payload: null, timestamp: 0, retryCount: 0 };
+      expect(() => MutationItemSchema.parse(item)).not.toThrow();
+    }
+  });
+
+  it('rejects invalid mutation type', () => {
+    const item = { id: '1', type: 'INVALID_TYPE', payload: null, timestamp: 0, retryCount: 0 };
+    expect(() => MutationItemSchema.parse(item)).toThrow();
+  });
+
+  it('rejects missing id', () => {
+    const item = { type: 'SAVE_TOURNAMENT', payload: null, timestamp: 0, retryCount: 0 };
+    expect(() => MutationItemSchema.parse(item)).toThrow();
+  });
+
+  it('rejects non-numeric timestamp', () => {
+    const item = { id: '1', type: 'SAVE_TOURNAMENT', payload: null, timestamp: 'not-a-number', retryCount: 0 };
+    expect(() => MutationItemSchema.parse(item)).toThrow();
+  });
+
+  it('accepts any payload (z.unknown)', () => {
+    const items = [
+      { id: '1', type: 'SAVE_TOURNAMENT', payload: null, timestamp: 0, retryCount: 0 },
+      { id: '2', type: 'DELETE_TOURNAMENT', payload: 'tour-id', timestamp: 0, retryCount: 0 },
+      { id: '3', type: 'UPDATE_MATCH', payload: { tournamentId: 't1', update: {} }, timestamp: 0, retryCount: 0 },
+    ];
+    for (const item of items) {
+      expect(() => MutationItemSchema.parse(item)).not.toThrow();
+    }
+  });
+});
+
+// =============================================================================
+// FailedMutationItemSchema
+// =============================================================================
+
+describe('FailedMutationItemSchema', () => {
+  it('validates a failed item with lastError', () => {
+    const item = {
+      id: 'f1',
+      type: 'SAVE_TOURNAMENT',
+      payload: { id: 't1' },
+      timestamp: 1000,
+      retryCount: 5,
+      failedAt: 2000,
+      lastError: 'Network error',
+    };
+    expect(FailedMutationItemSchema.parse(item)).toMatchObject(item);
+  });
+
+  it('validates a failed item without lastError', () => {
+    const item = {
+      id: 'f1',
+      type: 'DELETE_TOURNAMENT',
+      payload: 'tour-1',
+      timestamp: 1000,
+      retryCount: 5,
+      failedAt: 2000,
+    };
+    const result = FailedMutationItemSchema.parse(item);
+    expect(result.lastError).toBeUndefined();
+  });
+
+  it('rejects missing failedAt', () => {
+    const item = {
+      id: 'f1',
+      type: 'SAVE_TOURNAMENT',
+      payload: null,
+      timestamp: 1000,
+      retryCount: 5,
+    };
+    expect(() => FailedMutationItemSchema.parse(item)).toThrow();
+  });
+});

--- a/src/core/models/schemas/__tests__/TournamentSchema.test.ts
+++ b/src/core/models/schemas/__tests__/TournamentSchema.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { TeamSchema, MatchSchema, TournamentSchema } from '../TournamentSchema';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createMinimalTournament(overrides?: Record<string, unknown>) {
+  return {
+    id: 'tour-1',
+    title: 'Test Tournament',
+    sport: 'hallenfussball',
+    sportId: 'hallenfussball',
+    tournamentType: 'group',
+    mode: 'standard',
+    teams: [],
+    matches: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TeamSchema
+// =============================================================================
+
+describe('TeamSchema', () => {
+  it('validates a team with trainers', () => {
+    const team = {
+      id: 't1',
+      name: 'FC Bayern',
+      group: 'A',
+      trainers: [
+        { id: 'tr1', name: 'Max', inviteStatus: 'pending', createdAt: '2026-01-01' },
+      ],
+    };
+    const result = TeamSchema.parse(team);
+    expect(result.trainers).toHaveLength(1);
+    expect(result.trainers![0].name).toBe('Max');
+  });
+
+  it('rejects team with invalid trainer inviteStatus', () => {
+    const team = {
+      id: 't1',
+      name: 'FC Bayern',
+      trainers: [
+        { id: 'tr1', name: 'Max', inviteStatus: 'bad-status', createdAt: '2026-01-01' },
+      ],
+    };
+    expect(() => TeamSchema.parse(team)).toThrow();
+  });
+
+  it('accepts team without trainers', () => {
+    const result = TeamSchema.parse({ id: 't1', name: 'BVB' });
+    expect(result.trainers).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// MatchSchema
+// =============================================================================
+
+describe('MatchSchema', () => {
+  it('validates a match with events', () => {
+    const match = {
+      id: 'm1',
+      round: 1,
+      field: 1,
+      teamA: 't1',
+      teamB: 't2',
+      events: [
+        {
+          id: 'e1',
+          timestampSeconds: 120,
+          type: 'GOAL',
+          payload: { teamId: 't1', direction: 'INC' },
+          scoreAfter: { home: 1, away: 0 },
+        },
+      ],
+    };
+    const result = MatchSchema.parse(match);
+    expect(result.events).toHaveLength(1);
+    expect(result.events![0].type).toBe('GOAL');
+  });
+
+  it('rejects match with invalid event type', () => {
+    const match = {
+      id: 'm1',
+      round: 1,
+      field: 1,
+      teamA: 't1',
+      teamB: 't2',
+      events: [
+        { id: 'e1', timestampSeconds: 0, type: 'INVALID', payload: {}, scoreAfter: { home: 0, away: 0 } },
+      ],
+    };
+    expect(() => MatchSchema.parse(match)).toThrow();
+  });
+
+  it('accepts match without events', () => {
+    const result = MatchSchema.parse({ id: 'm1', round: 1, field: 1, teamA: 't1', teamB: 't2' });
+    expect(result.events).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// TournamentSchema — groups & fields
+// =============================================================================
+
+describe('TournamentSchema groups/fields', () => {
+  it('validates tournament with typed groups', () => {
+    const tournament = createMinimalTournament({
+      groups: [
+        { id: 'A', customName: 'Lions', shortCode: 'LI' },
+        { id: 'B' },
+      ],
+    });
+    const result = TournamentSchema.parse(tournament);
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups![0].id).toBe('A');
+    expect(result.groups![0].customName).toBe('Lions');
+  });
+
+  it('rejects groups with missing id', () => {
+    const tournament = createMinimalTournament({
+      groups: [{ customName: 'NoId' }],
+    });
+    expect(() => TournamentSchema.parse(tournament)).toThrow();
+  });
+
+  it('validates tournament with typed fields', () => {
+    const tournament = createMinimalTournament({
+      fields: [
+        { id: 'field-1', defaultName: 'Feld 1', customName: 'Halle Nord' },
+      ],
+    });
+    const result = TournamentSchema.parse(tournament);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields![0].defaultName).toBe('Feld 1');
+  });
+
+  it('rejects fields with missing defaultName', () => {
+    const tournament = createMinimalTournament({
+      fields: [{ id: 'field-1' }],
+    });
+    expect(() => TournamentSchema.parse(tournament)).toThrow();
+  });
+
+  it('preserves unknown top-level fields (passthrough)', () => {
+    const tournament = createMinimalTournament({ customTopLevel: 'preserved' });
+    const result = TournamentSchema.parse(tournament);
+    expect((result as Record<string, unknown>).customTopLevel).toBe('preserved');
+  });
+});
+
+// =============================================================================
+// TournamentSchema — full round-trip
+// =============================================================================
+
+describe('TournamentSchema round-trip', () => {
+  it('validates a complete tournament with all sub-schemas', () => {
+    const tournament = createMinimalTournament({
+      teams: [
+        {
+          id: 't1',
+          name: 'FC Bayern',
+          group: 'A',
+          trainers: [{ id: 'tr1', name: 'Coach', inviteStatus: 'accepted', createdAt: '2026-01-01' }],
+        },
+      ],
+      matches: [
+        {
+          id: 'm1',
+          round: 1,
+          field: 1,
+          teamA: 't1',
+          teamB: 't2',
+          events: [
+            { id: 'e1', timestampSeconds: 60, type: 'GOAL', payload: { teamId: 't1' }, scoreAfter: { home: 1, away: 0 } },
+          ],
+        },
+      ],
+      groups: [{ id: 'A', customName: 'Gruppe A' }],
+      fields: [{ id: 'field-1', defaultName: 'Feld 1' }],
+    });
+
+    const result = TournamentSchema.parse(tournament);
+    expect(result.teams).toHaveLength(1);
+    expect(result.matches).toHaveLength(1);
+    expect(result.groups).toHaveLength(1);
+    expect(result.fields).toHaveLength(1);
+    expect(result.teams[0].trainers![0].inviteStatus).toBe('accepted');
+    expect(result.matches[0].events![0].type).toBe('GOAL');
+  });
+
+  it('defaults status to draft', () => {
+    const result = TournamentSchema.parse(createMinimalTournament());
+    expect(result.status).toBe('draft');
+  });
+});

--- a/src/core/repositories/__tests__/liveMatchMappers.test.ts
+++ b/src/core/repositories/__tests__/liveMatchMappers.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect } from 'vitest';
+import type { Tables } from '../../../types/supabase';
+import {
+  mapTeamToLiveTeamInfo,
+  mapMatchEventFromSupabase,
+  mapMatchEventToSupabase,
+  mapLiveMatchFromSupabase,
+  mapLiveMatchToSupabase,
+  isMatchActive,
+  clearLiveState,
+} from '../liveMatchMappers';
+
+// =============================================================================
+// Test Data Factories
+// =============================================================================
+
+type TeamRow = Tables<'teams'>;
+type MatchRow = Tables<'matches'>;
+type MatchEventRow = Tables<'match_events'>;
+
+function createTeamRow(overrides: Partial<TeamRow> = {}): TeamRow {
+  return {
+    id: 'team-1',
+    name: 'FC Test',
+    tournament_id: 'tournament-1',
+    group_letter: null,
+    is_removed: null,
+    removed_at: null,
+    removed_reason: null,
+    logo_path: null,
+    logo_background_color: null,
+    color_primary: null,
+    color_secondary: null,
+    contact_name: null,
+    contact_email: null,
+    contact_phone: null,
+    sort_order: null,
+    created_at: null,
+    updated_at: null,
+    version: null,
+    ...overrides,
+  };
+}
+
+function createMatchRow(overrides: Partial<MatchRow & { live_state?: unknown }> = {}): MatchRow {
+  return {
+    id: 'match-1',
+    tournament_id: 'tournament-1',
+    round: 1,
+    field: 1,
+    slot: null,
+    team_a_id: null,
+    team_b_id: null,
+    team_a_placeholder: null,
+    team_b_placeholder: null,
+    score_a: null,
+    score_b: null,
+    group_letter: null,
+    is_final: null,
+    final_type: null,
+    label: null,
+    scheduled_start: null,
+    match_number: null,
+    phase: null,
+    referee_number: null,
+    referee_team_id: null,
+    match_status: null,
+    actual_start: null,
+    actual_end: null,
+    timer_start_time: null,
+    timer_paused_at: null,
+    timer_elapsed_seconds: null,
+    overtime_score_a: null,
+    overtime_score_b: null,
+    penalty_score_a: null,
+    penalty_score_b: null,
+    decided_by: null,
+    skipped_reason: null,
+    skipped_at: null,
+    duration_minutes: null,
+    last_modified_by: null,
+    created_at: null,
+    updated_at: null,
+    version: null,
+    ...overrides,
+  } as MatchRow;
+}
+
+function createEventRow(overrides: Partial<MatchEventRow> = {}): MatchEventRow {
+  return {
+    id: 'event-1',
+    match_id: 'match-1',
+    timestamp_seconds: 120,
+    type: 'GOAL',
+    payload: { team: 'home', delta: 1 },
+    score_home: 1,
+    score_away: 0,
+    team_id: null,
+    player_id: null,
+    period: null,
+    incomplete: null,
+    is_deleted: null,
+    created_at: null,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TEAM INFO MAPPER
+// =============================================================================
+
+describe('mapTeamToLiveTeamInfo', () => {
+  it('returns TBD for null team', () => {
+    const info = mapTeamToLiveTeamInfo(null);
+
+    expect(info.id).toBe('');
+    expect(info.name).toBe('TBD');
+    expect(info.logo).toBeUndefined();
+    expect(info.colors).toBeUndefined();
+  });
+
+  it('maps team with logo', () => {
+    const team = createTeamRow({
+      logo_path: 'https://example.com/logo.png',
+      logo_background_color: '#ffffff',
+    });
+    const info = mapTeamToLiveTeamInfo(team);
+
+    expect(info.id).toBe('team-1');
+    expect(info.name).toBe('FC Test');
+    expect(info.logo).toEqual({
+      type: 'url',
+      value: 'https://example.com/logo.png',
+      backgroundColor: '#ffffff',
+    });
+  });
+
+  it('maps team with colors', () => {
+    const team = createTeamRow({
+      color_primary: '#ff0000',
+      color_secondary: '#0000ff',
+    });
+    const info = mapTeamToLiveTeamInfo(team);
+
+    expect(info.colors).toEqual({
+      primary: '#ff0000',
+      secondary: '#0000ff',
+    });
+  });
+
+  it('uses defaults for missing secondary color', () => {
+    const team = createTeamRow({ color_primary: '#ff0000' });
+    const info = mapTeamToLiveTeamInfo(team);
+
+    expect(info.colors?.primary).toBe('#ff0000');
+    expect(info.colors?.secondary).toBe('#ffffff');
+  });
+
+  it('has no colors when both are null', () => {
+    const team = createTeamRow();
+    const info = mapTeamToLiveTeamInfo(team);
+
+    expect(info.colors).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// EVENT MAPPERS
+// =============================================================================
+
+describe('mapMatchEventFromSupabase', () => {
+  it('maps GOAL event', () => {
+    const row = createEventRow({
+      type: 'GOAL',
+      payload: { team: 'home', delta: 1, playerNumber: 7 },
+      score_home: 1,
+      score_away: 0,
+    });
+    const event = mapMatchEventFromSupabase(row);
+
+    expect(event.id).toBe('event-1');
+    expect(event.matchId).toBe('match-1');
+    expect(event.timestampSeconds).toBe(120);
+    expect(event.type).toBe('GOAL');
+    expect(event.payload.team).toBe('home');
+    expect(event.payload.delta).toBe(1);
+    expect(event.payload.playerNumber).toBe(7);
+    expect(event.scoreAfter).toEqual({ home: 1, away: 0 });
+  });
+
+  it('maps STATUS_CHANGE event', () => {
+    const row = createEventRow({
+      type: 'STATUS_CHANGE',
+      payload: { toStatus: 'RUNNING' },
+    });
+    const event = mapMatchEventFromSupabase(row);
+
+    expect(event.type).toBe('STATUS_CHANGE');
+    expect(event.payload.toStatus).toBe('RUNNING');
+  });
+
+  it('handles null payload', () => {
+    const row = createEventRow({ payload: null as unknown as MatchEventRow['payload'] });
+    const event = mapMatchEventFromSupabase(row);
+
+    expect(event.payload.team).toBeUndefined();
+    expect(event.payload.delta).toBeUndefined();
+  });
+});
+
+describe('mapMatchEventToSupabase', () => {
+  it('maps event to DB row', () => {
+    const event = {
+      id: 'event-1',
+      matchId: 'match-1',
+      timestampSeconds: 120,
+      type: 'GOAL' as const,
+      payload: { team: 'home' as const, delta: 1 },
+      scoreAfter: { home: 1, away: 0 },
+    };
+    const row = mapMatchEventToSupabase(event, 'match-1');
+
+    expect(row.id).toBe('event-1');
+    expect(row.match_id).toBe('match-1');
+    expect(row.timestamp_seconds).toBe(120);
+    expect(row.type).toBe('GOAL');
+    expect(row.score_home).toBe(1);
+    expect(row.score_away).toBe(0);
+    expect(row.team_id).toBeNull();
+    expect(row.player_id).toBeNull();
+    expect(row.period).toBeNull();
+    expect(row.incomplete).toBe(false);
+    expect(row.is_deleted).toBe(false);
+  });
+});
+
+// =============================================================================
+// LIVE MATCH MAPPERS
+// =============================================================================
+
+describe('mapLiveMatchFromSupabase', () => {
+  it('maps minimal match', () => {
+    const matchRow = createMatchRow({
+      match_number: 1,
+      match_status: 'not_started',
+    });
+    const teamsMap = new Map<string, TeamRow>();
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+
+    expect(liveMatch.id).toBe('match-1');
+    expect(liveMatch.number).toBe(1);
+    expect(liveMatch.status).toBe('NOT_STARTED');
+    expect(liveMatch.homeScore).toBe(0);
+    expect(liveMatch.awayScore).toBe(0);
+    expect(liveMatch.homeTeam.name).toBe('TBD');
+    expect(liveMatch.awayTeam.name).toBe('TBD');
+    expect(liveMatch.events).toEqual([]);
+    expect(liveMatch.version).toBe(1);
+  });
+
+  it('maps status correctly (all variants)', () => {
+    const statuses = [
+      ['not_started', 'NOT_STARTED'],
+      ['running', 'RUNNING'],
+      ['paused', 'PAUSED'],
+      ['finished', 'FINISHED'],
+    ] as const;
+
+    const teamsMap = new Map<string, TeamRow>();
+    for (const [dbStatus, frontendStatus] of statuses) {
+      const matchRow = createMatchRow({ match_status: dbStatus });
+      const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+      expect(liveMatch.status).toBe(frontendStatus);
+    }
+  });
+
+  it('maps teams from teamsMap', () => {
+    const matchRow = createMatchRow({
+      team_a_id: 'team-a',
+      team_b_id: 'team-b',
+    });
+    const teamsMap = new Map<string, TeamRow>([
+      ['team-a', createTeamRow({ id: 'team-a', name: 'Alpha' })],
+      ['team-b', createTeamRow({ id: 'team-b', name: 'Beta' })],
+    ]);
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+
+    expect(liveMatch.homeTeam.name).toBe('Alpha');
+    expect(liveMatch.awayTeam.name).toBe('Beta');
+  });
+
+  it('sorts events by timestamp and filters deleted', () => {
+    const events = [
+      createEventRow({ id: 'e3', timestamp_seconds: 300, is_deleted: null }),
+      createEventRow({ id: 'e1', timestamp_seconds: 60, is_deleted: null }),
+      createEventRow({ id: 'e2', timestamp_seconds: 180, is_deleted: true }),
+    ];
+    const matchRow = createMatchRow();
+    const teamsMap = new Map<string, TeamRow>();
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, events, teamsMap);
+
+    expect(liveMatch.events).toHaveLength(2);
+    expect(liveMatch.events[0].id).toBe('e1');
+    expect(liveMatch.events[1].id).toBe('e3');
+  });
+
+  it('parses live_state JSONB', () => {
+    const matchRow = createMatchRow({
+      match_status: 'running',
+      live_state: {
+        elapsedSeconds: 120,
+        durationSeconds: 600,
+        playPhase: 'regular',
+        refereeName: 'SR1',
+      },
+    } as Partial<MatchRow>);
+    const teamsMap = new Map<string, TeamRow>();
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+
+    expect(liveMatch.elapsedSeconds).toBe(120);
+    expect(liveMatch.durationSeconds).toBe(600);
+    expect(liveMatch.playPhase).toBe('regular');
+    expect(liveMatch.refereeName).toBe('SR1');
+  });
+
+  it('maps tournament phase', () => {
+    const matchRow = createMatchRow({ phase: 'semifinal' });
+    const teamsMap = new Map<string, TeamRow>();
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+
+    expect(liveMatch.tournamentPhase).toBe('semifinal');
+  });
+
+  it('maps tiebreaker scores from match row', () => {
+    const matchRow = createMatchRow({
+      overtime_score_a: 1,
+      overtime_score_b: 0,
+      penalty_score_a: 4,
+      penalty_score_b: 3,
+    });
+    const teamsMap = new Map<string, TeamRow>();
+
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], teamsMap);
+
+    expect(liveMatch.overtimeScoreA).toBe(1);
+    expect(liveMatch.overtimeScoreB).toBe(0);
+    expect(liveMatch.penaltyScoreA).toBe(4);
+    expect(liveMatch.penaltyScoreB).toBe(3);
+  });
+});
+
+describe('mapLiveMatchToSupabase', () => {
+  it('maps status to DB format', () => {
+    const liveMatch = mapLiveMatchFromSupabase(
+      createMatchRow({ match_status: 'running', score_a: 2, score_b: 1 }),
+      [],
+      new Map()
+    );
+    const { matchUpdate } = mapLiveMatchToSupabase(liveMatch);
+
+    expect(matchUpdate.match_status).toBe('running');
+    expect(matchUpdate.score_a).toBe(2);
+    expect(matchUpdate.score_b).toBe(1);
+    expect(matchUpdate.updated_at).toBeDefined();
+  });
+
+  it('clears live_state when FINISHED', () => {
+    const liveMatch = mapLiveMatchFromSupabase(
+      createMatchRow({ match_status: 'finished' }),
+      [],
+      new Map()
+    );
+    const { matchUpdate } = mapLiveMatchToSupabase(liveMatch);
+
+    expect(matchUpdate.live_state).toBeNull();
+  });
+
+  it('preserves live_state when not finished', () => {
+    const matchRow = createMatchRow({
+      match_status: 'running',
+      live_state: { elapsedSeconds: 120, durationSeconds: 600 },
+    } as Partial<MatchRow>);
+    const liveMatch = mapLiveMatchFromSupabase(matchRow, [], new Map());
+    const { matchUpdate } = mapLiveMatchToSupabase(liveMatch);
+
+    expect(matchUpdate.live_state).not.toBeNull();
+    expect(matchUpdate.live_state?.elapsedSeconds).toBe(120);
+    expect(matchUpdate.live_state?.durationSeconds).toBe(600);
+  });
+
+  it('filters new events not in existingEventIds', () => {
+    const events = [
+      createEventRow({ id: 'old-event', timestamp_seconds: 60 }),
+      createEventRow({ id: 'new-event', timestamp_seconds: 120 }),
+    ];
+    const liveMatch = mapLiveMatchFromSupabase(
+      createMatchRow({ match_status: 'running' }),
+      events,
+      new Map()
+    );
+    const existingIds = new Set(['old-event']);
+    const { newEvents } = mapLiveMatchToSupabase(liveMatch, existingIds);
+
+    expect(newEvents).toHaveLength(1);
+    expect(newEvents[0].id).toBe('new-event');
+  });
+
+  it('returns all events as new when no existingEventIds', () => {
+    const events = [
+      createEventRow({ id: 'e1', timestamp_seconds: 60 }),
+      createEventRow({ id: 'e2', timestamp_seconds: 120 }),
+    ];
+    const liveMatch = mapLiveMatchFromSupabase(
+      createMatchRow({ match_status: 'running' }),
+      events,
+      new Map()
+    );
+    const { newEvents } = mapLiveMatchToSupabase(liveMatch);
+
+    expect(newEvents).toHaveLength(2);
+  });
+});
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+describe('isMatchActive', () => {
+  it('returns true for running match', () => {
+    expect(isMatchActive(createMatchRow({ match_status: 'running' }))).toBe(true);
+  });
+
+  it('returns true for paused match', () => {
+    expect(isMatchActive(createMatchRow({ match_status: 'paused' }))).toBe(true);
+  });
+
+  it('returns false for finished match', () => {
+    expect(isMatchActive(createMatchRow({ match_status: 'finished' }))).toBe(false);
+  });
+
+  it('returns false for not_started without live_state', () => {
+    expect(isMatchActive(createMatchRow({ match_status: 'not_started' }))).toBe(false);
+  });
+
+  it('returns true for not_started WITH live_state (initialized)', () => {
+    const row = createMatchRow({
+      match_status: 'not_started',
+      live_state: { elapsedSeconds: 0 },
+    } as Partial<MatchRow>);
+    expect(isMatchActive(row)).toBe(true);
+  });
+});
+
+describe('clearLiveState', () => {
+  it('returns object with null live_state', () => {
+    expect(clearLiveState()).toEqual({ live_state: null });
+  });
+});

--- a/src/core/repositories/__tests__/supabaseMappers.test.ts
+++ b/src/core/repositories/__tests__/supabaseMappers.test.ts
@@ -1,0 +1,690 @@
+import { describe, it, expect } from 'vitest';
+import type { Database } from '../../../types/supabase';
+import {
+  mapTeamFromSupabase,
+  mapTeamToSupabase,
+  mapMatchFromSupabase,
+  mapMatchToSupabase,
+  mapMatchUpdateToSupabase,
+  mapTournamentFromSupabase,
+  mapTournamentToSupabase,
+} from '../supabaseMappers';
+
+// =============================================================================
+// Test Data Factories
+// =============================================================================
+
+type TeamRow = Database['public']['Tables']['teams']['Row'];
+type MatchRow = Database['public']['Tables']['matches']['Row'];
+type TournamentRow = Database['public']['Tables']['tournaments']['Row'];
+
+function createTeamRow(overrides: Partial<TeamRow> = {}): TeamRow {
+  return {
+    id: 'team-1',
+    name: 'FC Test',
+    tournament_id: 'tournament-1',
+    group_letter: null,
+    is_removed: null,
+    removed_at: null,
+    removed_reason: null,
+    logo_path: null,
+    logo_background_color: null,
+    color_primary: null,
+    color_secondary: null,
+    contact_name: null,
+    contact_email: null,
+    contact_phone: null,
+    sort_order: null,
+    created_at: null,
+    updated_at: null,
+    version: null,
+    ...overrides,
+  };
+}
+
+function createMatchRow(overrides: Partial<MatchRow> = {}): MatchRow {
+  return {
+    id: 'match-1',
+    tournament_id: 'tournament-1',
+    round: 1,
+    field: 1,
+    slot: null,
+    team_a_id: null,
+    team_b_id: null,
+    team_a_placeholder: null,
+    team_b_placeholder: null,
+    score_a: null,
+    score_b: null,
+    group_letter: null,
+    is_final: null,
+    final_type: null,
+    label: null,
+    scheduled_start: null,
+    match_number: null,
+    phase: null,
+    referee_number: null,
+    referee_team_id: null,
+    match_status: null,
+    actual_start: null,
+    actual_end: null,
+    timer_start_time: null,
+    timer_paused_at: null,
+    timer_elapsed_seconds: null,
+    overtime_score_a: null,
+    overtime_score_b: null,
+    penalty_score_a: null,
+    penalty_score_b: null,
+    decided_by: null,
+    skipped_reason: null,
+    skipped_at: null,
+    duration_minutes: null,
+    last_modified_by: null,
+    created_at: null,
+    updated_at: null,
+    version: null,
+    ...overrides,
+  };
+}
+
+function createTournamentRow(overrides: Partial<TournamentRow> = {}): TournamentRow {
+  return {
+    id: 'tournament-1',
+    owner_id: 'user-1',
+    title: 'Test Turnier',
+    status: 'draft',
+    sport: 'football-indoor',
+    tournament_type: 'classic',
+    date: '2026-01-15',
+    start_time: '14:00',
+    location_name: 'Sporthalle Test',
+    location_street: null,
+    location_city: null,
+    location_postal_code: null,
+    location_country: null,
+    number_of_fields: 2,
+    number_of_teams: 8,
+    number_of_groups: 2,
+    group_phase_duration: 10,
+    group_phase_break: 2,
+    final_round_duration: 12,
+    final_round_break: 3,
+    point_system: { win: 3, draw: 1, loss: 0 },
+    finals_config: null,
+    referee_config: null,
+    config: {},
+    is_public: null,
+    share_code: null,
+    completed_at: null,
+    deleted_at: null,
+    last_modified_by: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    version: 1,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TEAM MAPPER TESTS
+// =============================================================================
+
+describe('mapTeamFromSupabase', () => {
+  it('maps minimal team row', () => {
+    const row = createTeamRow();
+    const team = mapTeamFromSupabase(row);
+
+    expect(team.id).toBe('team-1');
+    expect(team.name).toBe('FC Test');
+    expect(team.group).toBeUndefined();
+    expect(team.isRemoved).toBeUndefined();
+    expect(team.logo).toBeUndefined();
+    expect(team.colors).toBeUndefined();
+  });
+
+  it('maps team with logo', () => {
+    const row = createTeamRow({
+      logo_path: 'https://example.com/logo.png',
+      logo_background_color: '#ffffff',
+    });
+    const team = mapTeamFromSupabase(row);
+
+    expect(team.logo).toEqual({
+      type: 'url',
+      value: 'https://example.com/logo.png',
+      backgroundColor: '#ffffff',
+    });
+  });
+
+  it('maps team with colors', () => {
+    const row = createTeamRow({
+      color_primary: '#ff0000',
+      color_secondary: '#0000ff',
+    });
+    const team = mapTeamFromSupabase(row);
+
+    expect(team.colors).toEqual({
+      primary: '#ff0000',
+      secondary: '#0000ff',
+    });
+  });
+
+  it('maps team with only primary color', () => {
+    const row = createTeamRow({ color_primary: '#ff0000' });
+    const team = mapTeamFromSupabase(row);
+
+    expect(team.colors).toEqual({
+      primary: '#ff0000',
+      secondary: undefined,
+    });
+  });
+
+  it('maps group and isRemoved', () => {
+    const row = createTeamRow({
+      group_letter: 'A',
+      is_removed: true,
+      removed_at: '2026-01-10T12:00:00Z',
+    });
+    const team = mapTeamFromSupabase(row);
+
+    expect(team.group).toBe('A');
+    expect(team.isRemoved).toBe(true);
+    expect(team.removedAt).toBe('2026-01-10T12:00:00Z');
+  });
+});
+
+describe('mapTeamToSupabase', () => {
+  it('maps minimal team', () => {
+    const row = mapTeamToSupabase(
+      { id: 'team-1', name: 'FC Test' },
+      'tournament-1'
+    );
+
+    expect(row.id).toBe('team-1');
+    expect(row.tournament_id).toBe('tournament-1');
+    expect(row.name).toBe('FC Test');
+    expect(row.group_letter).toBeNull();
+    expect(row.is_removed).toBe(false);
+    expect(row.owner_id).toBeNull();
+    expect(row.is_public).toBe(false);
+  });
+
+  it('maps team with owner and public flag', () => {
+    const row = mapTeamToSupabase(
+      { id: 'team-1', name: 'FC Test', group: 'B' },
+      'tournament-1',
+      'user-1',
+      true
+    );
+
+    expect(row.owner_id).toBe('user-1');
+    expect(row.is_public).toBe(true);
+    expect(row.group_letter).toBe('B');
+  });
+
+  it('maps logo (only url type)', () => {
+    const row = mapTeamToSupabase(
+      {
+        id: 'team-1',
+        name: 'FC Test',
+        logo: { type: 'url', value: 'https://example.com/logo.png', backgroundColor: '#fff' },
+      },
+      'tournament-1'
+    );
+
+    expect(row.logo_path).toBe('https://example.com/logo.png');
+    expect(row.logo_background_color).toBe('#fff');
+  });
+
+  it('does not map non-url logo types', () => {
+    const row = mapTeamToSupabase(
+      {
+        id: 'team-1',
+        name: 'FC Test',
+        logo: { type: 'initials', value: 'FT' },
+      },
+      'tournament-1'
+    );
+
+    expect(row.logo_path).toBeNull();
+  });
+});
+
+// =============================================================================
+// MATCH MAPPER TESTS
+// =============================================================================
+
+describe('mapMatchFromSupabase', () => {
+  it('resolves team names via teamIdToName map', () => {
+    const teamIdToName = new Map([
+      ['team-a-id', 'Team Alpha'],
+      ['team-b-id', 'Team Beta'],
+    ]);
+    const row = createMatchRow({
+      team_a_id: 'team-a-id',
+      team_b_id: 'team-b-id',
+    });
+    const match = mapMatchFromSupabase(row, teamIdToName);
+
+    expect(match.teamA).toBe('Team Alpha');
+    expect(match.teamB).toBe('Team Beta');
+  });
+
+  it('falls back to placeholder when team ID not in map', () => {
+    const row = createMatchRow({
+      team_a_id: 'unknown-id',
+      team_a_placeholder: '1. Gruppe A',
+      team_b_id: null,
+      team_b_placeholder: '2. Gruppe B',
+    });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.teamA).toBe('1. Gruppe A');
+    expect(match.teamB).toBe('2. Gruppe B');
+  });
+
+  it('falls back to TBD when no ID and no placeholder', () => {
+    const row = createMatchRow({
+      team_a_id: null,
+      team_a_placeholder: null,
+      team_b_id: null,
+      team_b_placeholder: null,
+    });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.teamA).toBe('TBD');
+    expect(match.teamB).toBe('TBD');
+  });
+
+  it('constructs Date from scheduled_start time string', () => {
+    const row = createMatchRow({ scheduled_start: '14:30:00' });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.scheduledTime).toBeInstanceOf(Date);
+    expect(match.scheduledTime!.getHours()).toBe(14);
+    expect(match.scheduledTime!.getMinutes()).toBe(30);
+  });
+
+  it('returns undefined scheduledTime when scheduled_start is null', () => {
+    const row = createMatchRow({ scheduled_start: null });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.scheduledTime).toBeUndefined();
+  });
+
+  it('maps match status with default', () => {
+    const row = createMatchRow({ match_status: 'live' });
+    const match = mapMatchFromSupabase(row, new Map());
+    expect(match.matchStatus).toBe('live');
+
+    const rowDefault = createMatchRow({ match_status: null });
+    const matchDefault = mapMatchFromSupabase(rowDefault, new Map());
+    expect(matchDefault.matchStatus).toBe('scheduled');
+  });
+
+  it('maps all score/timer fields', () => {
+    const row = createMatchRow({
+      score_a: 3,
+      score_b: 1,
+      timer_start_time: '2026-01-15T14:30:00Z',
+      timer_paused_at: '2026-01-15T14:35:00Z',
+      timer_elapsed_seconds: 300,
+      overtime_score_a: 1,
+      overtime_score_b: 0,
+      penalty_score_a: 4,
+      penalty_score_b: 3,
+      decided_by: 'penalty',
+    });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.scoreA).toBe(3);
+    expect(match.scoreB).toBe(1);
+    expect(match.timerStartTime).toBe('2026-01-15T14:30:00Z');
+    expect(match.timerPausedAt).toBe('2026-01-15T14:35:00Z');
+    expect(match.timerElapsedSeconds).toBe(300);
+    expect(match.overtimeScoreA).toBe(1);
+    expect(match.overtimeScoreB).toBe(0);
+    expect(match.penaltyScoreA).toBe(4);
+    expect(match.penaltyScoreB).toBe(3);
+    expect(match.decidedBy).toBe('penalty');
+  });
+
+  it('maps final match fields', () => {
+    const row = createMatchRow({
+      is_final: true,
+      final_type: 'semifinal',
+      label: 'Halbfinale 1',
+      phase: 'semifinal',
+      match_number: 13,
+    });
+    const match = mapMatchFromSupabase(row, new Map());
+
+    expect(match.isFinal).toBe(true);
+    expect(match.finalType).toBe('semifinal');
+    expect(match.label).toBe('Halbfinale 1');
+    expect(match.phase).toBe('semifinal');
+    expect(match.matchNumber).toBe(13);
+  });
+});
+
+describe('mapMatchToSupabase', () => {
+  it('resolves team names to IDs', () => {
+    const teamNameToId = new Map([
+      ['Team Alpha', 'team-a-id'],
+      ['Team Beta', 'team-b-id'],
+    ]);
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: 'Team Alpha', teamB: 'Team Beta' },
+      'tournament-1',
+      teamNameToId
+    );
+
+    expect(row.team_a_id).toBe('team-a-id');
+    expect(row.team_b_id).toBe('team-b-id');
+    expect(row.team_a_placeholder).toBeNull();
+    expect(row.team_b_placeholder).toBeNull();
+  });
+
+  it('uses placeholder when team name not in map', () => {
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: '1. Gruppe A', teamB: '2. Gruppe B' },
+      'tournament-1',
+      new Map()
+    );
+
+    expect(row.team_a_id).toBeNull();
+    expect(row.team_b_id).toBeNull();
+    expect(row.team_a_placeholder).toBe('1. Gruppe A');
+    expect(row.team_b_placeholder).toBe('2. Gruppe B');
+  });
+
+  it('serializes Date scheduledTime to time string', () => {
+    const date = new Date('2026-01-15T14:30:00');
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: 'A', teamB: 'B', scheduledTime: date },
+      'tournament-1',
+      new Map()
+    );
+
+    expect(row.scheduled_start).toMatch(/14:30:00/);
+  });
+
+  it('serializes string scheduledTime', () => {
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: 'A', teamB: 'B', scheduledTime: '15:00:00' as unknown as Date },
+      'tournament-1',
+      new Map()
+    );
+
+    expect(row.scheduled_start).toBe('15:00:00');
+  });
+
+  it('maps owner_id and is_public for RLS', () => {
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: 'A', teamB: 'B' },
+      'tournament-1',
+      new Map(),
+      'user-1',
+      true
+    );
+
+    expect(row.owner_id).toBe('user-1');
+    expect(row.is_public).toBe(true);
+  });
+
+  it('defaults phase to groupStage', () => {
+    const row = mapMatchToSupabase(
+      { id: 'match-1', round: 1, field: 1, teamA: 'A', teamB: 'B' },
+      'tournament-1',
+      new Map()
+    );
+
+    expect(row.phase).toBe('groupStage');
+  });
+});
+
+describe('mapMatchUpdateToSupabase', () => {
+  it('maps partial score update', () => {
+    const update = mapMatchUpdateToSupabase({ scoreA: 2, scoreB: 1 });
+
+    expect(update.score_a).toBe(2);
+    expect(update.score_b).toBe(1);
+    expect(update.updated_at).toBeDefined();
+  });
+
+  it('maps status update', () => {
+    const update = mapMatchUpdateToSupabase({ matchStatus: 'running' });
+
+    expect(update.match_status).toBe('running');
+  });
+
+  it('always sets updated_at even for empty update', () => {
+    const update = mapMatchUpdateToSupabase({});
+
+    expect(update.updated_at).toBeDefined();
+    expect(typeof update.updated_at).toBe('string');
+  });
+
+  it('maps team changes with teamNameToId', () => {
+    const teamNameToId = new Map([['FC Alpha', 'alpha-id']]);
+    const update = mapMatchUpdateToSupabase(
+      { teamA: 'FC Alpha', teamB: 'Unknown Team' },
+      teamNameToId
+    );
+
+    expect(update.team_a_id).toBe('alpha-id');
+    expect(update.team_a_placeholder).toBeNull();
+    expect(update.team_b_id).toBeNull();
+    expect(update.team_b_placeholder).toBe('Unknown Team');
+  });
+
+  it('does not map team changes without teamNameToId', () => {
+    const update = mapMatchUpdateToSupabase({ teamA: 'FC Alpha' });
+
+    expect(update.team_a_id).toBeUndefined();
+    expect(update.team_a_placeholder).toBeUndefined();
+  });
+
+  it('maps all timer and tiebreaker fields', () => {
+    const update = mapMatchUpdateToSupabase({
+      timerStartTime: '2026-01-15T14:30:00Z',
+      timerPausedAt: '2026-01-15T14:35:00Z',
+      timerElapsedSeconds: 300,
+      overtimeScoreA: 1,
+      overtimeScoreB: 0,
+      penaltyScoreA: 4,
+      penaltyScoreB: 3,
+      decidedBy: 'penalty',
+      finishedAt: '2026-01-15T14:45:00Z',
+      skippedReason: 'Team not present',
+      skippedAt: '2026-01-15T14:00:00Z',
+    });
+
+    expect(update.timer_start_time).toBe('2026-01-15T14:30:00Z');
+    expect(update.timer_paused_at).toBe('2026-01-15T14:35:00Z');
+    expect(update.timer_elapsed_seconds).toBe(300);
+    expect(update.overtime_score_a).toBe(1);
+    expect(update.overtime_score_b).toBe(0);
+    expect(update.penalty_score_a).toBe(4);
+    expect(update.penalty_score_b).toBe(3);
+    expect(update.decided_by).toBe('penalty');
+    expect(update.actual_end).toBe('2026-01-15T14:45:00Z');
+    expect(update.skipped_reason).toBe('Team not present');
+    expect(update.skipped_at).toBe('2026-01-15T14:00:00Z');
+  });
+});
+
+// =============================================================================
+// TOURNAMENT MAPPER TESTS
+// =============================================================================
+
+describe('mapTournamentFromSupabase', () => {
+  it('maps minimal tournament without teams/matches', () => {
+    const row = createTournamentRow();
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.id).toBe('tournament-1');
+    expect(tournament.title).toBe('Test Turnier');
+    expect(tournament.status).toBe('draft');
+    expect(tournament.sport).toBe('football-indoor');
+    expect(tournament.numberOfFields).toBe(2);
+    expect(tournament.numberOfTeams).toBe(8);
+    expect(tournament.teams).toEqual([]);
+    expect(tournament.matches).toEqual([]);
+  });
+
+  it('maps teams and matches', () => {
+    const row = createTournamentRow();
+    const teamRows = [
+      createTeamRow({ id: 'team-1', name: 'Alpha' }),
+      createTeamRow({ id: 'team-2', name: 'Beta' }),
+    ];
+    const matchRows = [
+      createMatchRow({
+        id: 'match-1',
+        team_a_id: 'team-1',
+        team_b_id: 'team-2',
+        match_number: 1,
+      }),
+    ];
+
+    const tournament = mapTournamentFromSupabase(row, teamRows, matchRows);
+
+    expect(tournament.teams).toHaveLength(2);
+    expect(tournament.matches).toHaveLength(1);
+    expect(tournament.matches[0].teamA).toBe('Alpha');
+    expect(tournament.matches[0].teamB).toBe('Beta');
+  });
+
+  it('uses default point system when null', () => {
+    const row = createTournamentRow({ point_system: null as unknown as Database['public']['Tables']['tournaments']['Row']['point_system'] });
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.pointSystem).toEqual({ win: 3, draw: 1, loss: 0 });
+  });
+
+  it('parses custom point system', () => {
+    const row = createTournamentRow({
+      point_system: { win: 2, draw: 1, loss: 0 },
+    });
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.pointSystem).toEqual({ win: 2, draw: 1, loss: 0 });
+  });
+
+  it('maps location fields', () => {
+    const row = createTournamentRow({
+      location_name: 'Sporthalle',
+      location_street: 'Hauptstr. 1',
+      location_city: 'Berlin',
+      location_postal_code: '10115',
+      location_country: 'Deutschland',
+    });
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.location).toEqual({
+      name: 'Sporthalle',
+      street: 'Hauptstr. 1',
+      city: 'Berlin',
+      postalCode: '10115',
+      country: 'Deutschland',
+    });
+  });
+
+  it('parses config JSON fields', () => {
+    const row = createTournamentRow({
+      config: {
+        mode: 'bambini',
+        gamePeriods: 2,
+        halftimeBreak: 3,
+        isKidsTournament: true,
+        organizer: 'SV Test',
+        sportId: 'football-indoor',
+      },
+    });
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.mode).toBe('bambini');
+    expect(tournament.gamePeriods).toBe(2);
+    expect(tournament.halftimeBreak).toBe(3);
+    expect(tournament.isKidsTournament).toBe(true);
+    expect(tournament.organizer).toBe('SV Test');
+    expect(tournament.sportId).toBe('football-indoor');
+  });
+
+  it('maps version and timestamps', () => {
+    const row = createTournamentRow({
+      version: 5,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-10T12:00:00Z',
+      deleted_at: '2026-01-15T00:00:00Z',
+      completed_at: '2026-01-14T18:00:00Z',
+    });
+    const tournament = mapTournamentFromSupabase(row, [], []);
+
+    expect(tournament.version).toBe(5);
+    expect(tournament.createdAt).toBe('2026-01-01T00:00:00Z');
+    expect(tournament.updatedAt).toBe('2026-01-10T12:00:00Z');
+    expect(tournament.deletedAt).toBe('2026-01-15T00:00:00Z');
+    expect(tournament.completedAt).toBe('2026-01-14T18:00:00Z');
+  });
+});
+
+describe('mapTournamentToSupabase', () => {
+  it('returns tournament row, team rows, and match rows', () => {
+    const tournament = mapTournamentFromSupabase(
+      createTournamentRow(),
+      [createTeamRow({ id: 'team-1', name: 'Alpha' })],
+      [createMatchRow({ id: 'match-1', team_a_id: 'team-1' })]
+    );
+
+    const result = mapTournamentToSupabase(tournament, 'user-1');
+
+    expect(result.tournamentRow).toBeDefined();
+    expect(result.teamRows).toHaveLength(1);
+    expect(result.matchRows).toHaveLength(1);
+  });
+
+  it('sets owner_id on tournament row', () => {
+    const tournament = mapTournamentFromSupabase(createTournamentRow(), [], []);
+    const result = mapTournamentToSupabase(tournament, 'user-1');
+
+    expect(result.tournamentRow.owner_id).toBe('user-1');
+  });
+
+  it('preserves config fields in JSON', () => {
+    const tournament = mapTournamentFromSupabase(
+      createTournamentRow({
+        config: {
+          mode: 'bambini',
+          isKidsTournament: true,
+          organizer: 'SV Test',
+        },
+      }),
+      [],
+      []
+    );
+
+    const result = mapTournamentToSupabase(tournament, 'user-1');
+    const config = result.tournamentRow.config as Record<string, unknown>;
+
+    expect(config.mode).toBe('bambini');
+    expect(config.isKidsTournament).toBe(true);
+    expect(config.organizer).toBe('SV Test');
+  });
+
+  it('builds team name to ID map for match conversion', () => {
+    const teamRows = [
+      createTeamRow({ id: 'team-a', name: 'Alpha' }),
+      createTeamRow({ id: 'team-b', name: 'Beta' }),
+    ];
+    const matchRows = [
+      createMatchRow({ id: 'match-1', team_a_id: 'team-a', team_b_id: 'team-b' }),
+    ];
+    const tournament = mapTournamentFromSupabase(createTournamentRow(), teamRows, matchRows);
+    const result = mapTournamentToSupabase(tournament, 'user-1');
+
+    // Match rows should have team IDs resolved
+    expect(result.matchRows[0].team_a_id).toBe('team-a');
+    expect(result.matchRows[0].team_b_id).toBe('team-b');
+  });
+});

--- a/src/core/services/__tests__/MutationQueue.test.ts
+++ b/src/core/services/__tests__/MutationQueue.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MutationQueue } from '../MutationQueue';
+import type { MutationItem, FailedMutationItem } from '../MutationQueue';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Mock safeStorage
+const mockStorage = new Map<string, string>();
+vi.mock('../../utils/safeStorage', () => ({
+  safeLocalStorage: {
+    getItem: vi.fn((key: string) => mockStorage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { mockStorage.set(key, value); }),
+    removeItem: vi.fn((key: string) => { mockStorage.delete(key); }),
+  },
+}));
+
+// Mock sentry
+vi.mock('../../../lib/sentry', () => ({
+  captureFeatureError: vi.fn(),
+}));
+
+// Mock idGenerator
+let idCounter = 0;
+vi.mock('../../../utils/idGenerator', () => ({
+  generateUniqueId: vi.fn(() => `mock-id-${++idCounter}`),
+}));
+
+// Mock SupabaseRepository
+function createMockRepo() {
+  return {
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    updateMatch: vi.fn().mockResolvedValue(undefined),
+    updateMatches: vi.fn().mockResolvedValue(undefined),
+    updateTournamentMetadata: vi.fn().mockResolvedValue(undefined),
+    // Other methods not used by MutationQueue
+    get: vi.fn(),
+    getAll: vi.fn(),
+    getById: vi.fn(),
+  };
+}
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+let mockRepo: ReturnType<typeof createMockRepo>;
+let onlineSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockStorage.clear();
+  idCounter = 0;
+  mockRepo = createMockRepo();
+  // Default: navigator.onLine = true
+  onlineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+});
+
+// Helper to create a queue without auto-processing
+function createQueue(opts?: { online?: boolean; preloadQueue?: MutationItem[]; preloadFailed?: FailedMutationItem[] }) {
+  if (opts?.online === false) {
+    onlineSpy.mockReturnValue(false);
+  }
+  if (opts?.preloadQueue) {
+    mockStorage.set('mutation_queue_v1', JSON.stringify(opts.preloadQueue));
+  }
+  if (opts?.preloadFailed) {
+    mockStorage.set('mutation_queue_failed_v1', JSON.stringify(opts.preloadFailed));
+  }
+   
+  return new MutationQueue(mockRepo as any);
+}
+
+// =============================================================================
+// Constructor & Loading
+// =============================================================================
+
+describe('MutationQueue constructor', () => {
+  it('initializes with empty queue', () => {
+    const queue = createQueue({ online: false });
+    expect(queue.getPendingCount()).toBe(0);
+    expect(queue.getFailedCount()).toBe(0);
+  });
+
+  it('loads existing queue from localStorage', () => {
+    const items: MutationItem[] = [
+      { id: 'item-1', type: 'SAVE_TOURNAMENT', payload: { id: 't1' }, timestamp: 1000, retryCount: 0 },
+    ];
+    const queue = createQueue({ online: false, preloadQueue: items });
+    expect(queue.getPendingCount()).toBe(1);
+  });
+
+  it('loads failed queue from localStorage', () => {
+    const items: FailedMutationItem[] = [
+      { id: 'f1', type: 'SAVE_TOURNAMENT', payload: { id: 't1' }, timestamp: 1000, retryCount: 5, failedAt: 2000, lastError: 'test' },
+    ];
+    const queue = createQueue({ online: false, preloadFailed: items });
+    expect(queue.getFailedCount()).toBe(1);
+  });
+
+  it('handles corrupted localStorage gracefully', () => {
+    mockStorage.set('mutation_queue_v1', 'not-valid-json');
+    const queue = createQueue({ online: false });
+    expect(queue.getPendingCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// enqueue
+// =============================================================================
+
+describe('MutationQueue enqueue', () => {
+  it('adds item to queue and persists', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1', title: 'Test' });
+
+    expect(queue.getPendingCount()).toBe(1);
+    // Check localStorage was updated
+    const stored = JSON.parse(mockStorage.get('mutation_queue_v1') ?? '[]') as MutationItem[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0].type).toBe('SAVE_TOURNAMENT');
+  });
+
+  it('triggers process when online', async () => {
+    const queue = createQueue({ online: true });
+    queue.enqueue('DELETE_TOURNAMENT', 'tour-123');
+
+    // Wait for async processing
+    await vi.waitFor(() => {
+      expect(mockRepo.delete).toHaveBeenCalledWith('tour-123');
+    });
+  });
+
+  it('does not trigger process when offline', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+
+    expect(mockRepo.save).not.toHaveBeenCalled();
+    expect(queue.getPendingCount()).toBe(1);
+  });
+});
+
+// =============================================================================
+// Coalescing
+// =============================================================================
+
+describe('MutationQueue coalescing', () => {
+  it('coalesces SAVE_TOURNAMENT with same ID', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1', title: 'Version 1' });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1', title: 'Version 2' });
+
+    expect(queue.getPendingCount()).toBe(1);
+    const stored = JSON.parse(mockStorage.get('mutation_queue_v1') ?? '[]') as MutationItem[];
+    expect(stored[0].payload.title).toBe('Version 2');
+  });
+
+  it('coalesces UPDATE_TOURNAMENT_METADATA with same ID', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('UPDATE_TOURNAMENT_METADATA', { tournamentId: 't1', metadata: { title: 'V1' } });
+    queue.enqueue('UPDATE_TOURNAMENT_METADATA', { tournamentId: 't1', metadata: { title: 'V2' } });
+
+    expect(queue.getPendingCount()).toBe(1);
+  });
+
+  it('does NOT coalesce DELETE_TOURNAMENT', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('DELETE_TOURNAMENT', 'tour-1');
+    queue.enqueue('DELETE_TOURNAMENT', 'tour-1');
+
+    expect(queue.getPendingCount()).toBe(2);
+  });
+
+  it('does NOT coalesce UPDATE_MATCH', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('UPDATE_MATCH', { tournamentId: 't1', update: { matchId: 'm1' } });
+    queue.enqueue('UPDATE_MATCH', { tournamentId: 't1', update: { matchId: 'm1' } });
+
+    expect(queue.getPendingCount()).toBe(2);
+  });
+
+  it('does not coalesce SAVE_TOURNAMENT with different IDs', () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1', title: 'A' });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't2', title: 'B' });
+
+    expect(queue.getPendingCount()).toBe(2);
+  });
+});
+
+// =============================================================================
+// process
+// =============================================================================
+
+describe('MutationQueue process', () => {
+  it('processes items sequentially via executeMutation', async () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+    queue.enqueue('DELETE_TOURNAMENT', 'tour-2');
+
+    // Go online and process
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    expect(mockRepo.save).toHaveBeenCalledWith({ id: 't1' });
+    expect(mockRepo.delete).toHaveBeenCalledWith('tour-2');
+    expect(queue.getPendingCount()).toBe(0);
+  });
+
+  it('calls correct repo method for UPDATE_MATCH', async () => {
+    const queue = createQueue({ online: false });
+    const payload = { tournamentId: 't1', update: { matchId: 'm1', scoreA: 1 } };
+    queue.enqueue('UPDATE_MATCH', payload);
+
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    expect(mockRepo.updateMatch).toHaveBeenCalledWith('t1', { matchId: 'm1', scoreA: 1 });
+  });
+
+  it('calls correct repo method for UPDATE_MATCHES', async () => {
+    const queue = createQueue({ online: false });
+    const payload = { tournamentId: 't1', updates: [{ matchId: 'm1' }, { matchId: 'm2' }] };
+    queue.enqueue('UPDATE_MATCHES', payload);
+
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    expect(mockRepo.updateMatches).toHaveBeenCalledWith('t1', [{ matchId: 'm1' }, { matchId: 'm2' }]);
+  });
+
+  it('calls correct repo method for UPDATE_TOURNAMENT_METADATA', async () => {
+    const queue = createQueue({ online: false });
+    const payload = { tournamentId: 't1', metadata: { title: 'New Title' } };
+    queue.enqueue('UPDATE_TOURNAMENT_METADATA', payload);
+
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    expect(mockRepo.updateTournamentMetadata).toHaveBeenCalledWith('t1', { title: 'New Title' });
+  });
+
+  it('skips processing when offline', async () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+
+    await queue.process();
+    expect(mockRepo.save).not.toHaveBeenCalled();
+    expect(queue.getPendingCount()).toBe(1);
+  });
+
+  it('stops processing when queue is empty', async () => {
+    const queue = createQueue({ online: true });
+    // No items enqueued
+    await queue.process();
+    expect(mockRepo.save).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Error handling & Dead Letter
+// =============================================================================
+
+describe('MutationQueue error handling', () => {
+  it('increments retryCount on failure and stops processing', async () => {
+    const queue = createQueue({ online: false });
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+
+    mockRepo.save.mockRejectedValueOnce(new Error('network'));
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    // Item stays in queue with incremented retry count
+    expect(queue.getPendingCount()).toBe(1);
+    const stored = JSON.parse(mockStorage.get('mutation_queue_v1') ?? '[]') as MutationItem[];
+    expect(stored[0].retryCount).toBe(1);
+  });
+
+  it('moves to dead-letter after MAX_RETRIES (5)', async () => {
+    const items: MutationItem[] = [
+      { id: 'item-1', type: 'SAVE_TOURNAMENT', payload: { id: 't1' }, timestamp: 1000, retryCount: 4 },
+    ];
+    const queue = createQueue({ online: false, preloadQueue: items });
+
+    mockRepo.save.mockRejectedValueOnce(new Error('permanent'));
+    onlineSpy.mockReturnValue(true);
+    await queue.process();
+
+    // Moved from pending to failed
+    expect(queue.getPendingCount()).toBe(0);
+    expect(queue.getFailedCount()).toBe(1);
+    const failed = queue.getFailedMutations();
+    expect(failed[0].lastError).toBe('permanent');
+  });
+});
+
+// =============================================================================
+// Dead Letter Queue management
+// =============================================================================
+
+describe('MutationQueue dead letter management', () => {
+  const failedItem: FailedMutationItem = {
+    id: 'f1',
+    type: 'SAVE_TOURNAMENT',
+    payload: { id: 't1' },
+    timestamp: 1000,
+    retryCount: 5,
+    failedAt: 2000,
+    lastError: 'test error',
+  };
+
+  it('getFailedMutations returns a copy', () => {
+    const queue = createQueue({ online: false, preloadFailed: [failedItem] });
+    const failed = queue.getFailedMutations();
+    expect(failed).toHaveLength(1);
+    // Mutating the returned array should not affect internal state
+    failed.pop();
+    expect(queue.getFailedCount()).toBe(1);
+  });
+
+  it('retryFailedMutation moves item back to queue', () => {
+    const queue = createQueue({ online: false, preloadFailed: [failedItem] });
+    const result = queue.retryFailedMutation('f1');
+
+    expect(result).toBe(true);
+    expect(queue.getFailedCount()).toBe(0);
+    expect(queue.getPendingCount()).toBe(1);
+  });
+
+  it('retryFailedMutation returns false for unknown id', () => {
+    const queue = createQueue({ online: false, preloadFailed: [failedItem] });
+    expect(queue.retryFailedMutation('unknown')).toBe(false);
+  });
+
+  it('retryAllFailed moves all items back', () => {
+    const items: FailedMutationItem[] = [
+      { ...failedItem, id: 'f1' },
+      { ...failedItem, id: 'f2' },
+    ];
+    const queue = createQueue({ online: false, preloadFailed: items });
+    const count = queue.retryAllFailed();
+
+    expect(count).toBe(2);
+    expect(queue.getFailedCount()).toBe(0);
+    expect(queue.getPendingCount()).toBe(2);
+  });
+
+  it('retryAllFailed returns 0 when nothing failed', () => {
+    const queue = createQueue({ online: false });
+    expect(queue.retryAllFailed()).toBe(0);
+  });
+
+  it('clearFailedMutation removes specific item', () => {
+    const queue = createQueue({ online: false, preloadFailed: [failedItem] });
+    const result = queue.clearFailedMutation('f1');
+
+    expect(result).toBe(true);
+    expect(queue.getFailedCount()).toBe(0);
+  });
+
+  it('clearFailedMutation returns false for unknown id', () => {
+    const queue = createQueue({ online: false });
+    expect(queue.clearFailedMutation('unknown')).toBe(false);
+  });
+
+  it('clearAllFailed removes everything', () => {
+    const items: FailedMutationItem[] = [
+      { ...failedItem, id: 'f1' },
+      { ...failedItem, id: 'f2' },
+      { ...failedItem, id: 'f3' },
+    ];
+    const queue = createQueue({ online: false, preloadFailed: items });
+    const count = queue.clearAllFailed();
+
+    expect(count).toBe(3);
+    expect(queue.getFailedCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// Subscribe / Unsubscribe
+// =============================================================================
+
+describe('MutationQueue subscribe', () => {
+  it('notifies listener on enqueue', () => {
+    const queue = createQueue({ online: false });
+    const listener = vi.fn();
+    queue.subscribe(listener);
+
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+    expect(listener).toHaveBeenCalledWith({ pendingCount: 1, failedCount: 0 });
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const queue = createQueue({ online: false });
+    const listener = vi.fn();
+    const unsub = queue.subscribe(listener);
+    unsub();
+
+    queue.enqueue('SAVE_TOURNAMENT', { id: 't1' });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('getStatus returns current counts', () => {
+    const failedItem: FailedMutationItem = {
+      id: 'f1', type: 'SAVE_TOURNAMENT', payload: {}, timestamp: 0, retryCount: 5, failedAt: 0,
+    };
+    const pendingItem: MutationItem = {
+      id: 'p1', type: 'DELETE_TOURNAMENT', payload: 'x', timestamp: 0, retryCount: 0,
+    };
+    const queue = createQueue({ online: false, preloadQueue: [pendingItem], preloadFailed: [failedItem] });
+
+    const status = queue.getStatus();
+    expect(status.pendingCount).toBe(1);
+    expect(status.failedCount).toBe(1);
+  });
+});

--- a/src/core/services/__tests__/RetryService.test.ts
+++ b/src/core/services/__tests__/RetryService.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  RetryService,
+  createAuthRetryService,
+  createNetworkRetryService,
+  isTransientError,
+} from '../RetryService';
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// Constructor & Config
+// =============================================================================
+
+describe('RetryService constructor & config', () => {
+  it('uses default config when none provided', () => {
+    const service = new RetryService();
+    const config = service.getConfig();
+    expect(config.maxAttempts).toBe(3);
+    expect(config.baseDelay).toBe(1000);
+    expect(config.maxDelay).toBe(30000);
+    expect(config.backoffFactor).toBe(2);
+  });
+
+  it('merges partial config with defaults', () => {
+    const service = new RetryService({ maxAttempts: 5 });
+    const config = service.getConfig();
+    expect(config.maxAttempts).toBe(5);
+    expect(config.baseDelay).toBe(1000); // default
+  });
+
+  it('updateConfig merges into existing config', () => {
+    const service = new RetryService();
+    service.updateConfig({ maxDelay: 5000 });
+    expect(service.getConfig().maxDelay).toBe(5000);
+    expect(service.getConfig().maxAttempts).toBe(3); // unchanged
+  });
+});
+
+// =============================================================================
+// getState & reset
+// =============================================================================
+
+describe('RetryService state', () => {
+  it('initial state is clean', () => {
+    const service = new RetryService();
+    const state = service.getState();
+    expect(state.attempt).toBe(0);
+    expect(state.isRetrying).toBe(false);
+    expect(state.lastError).toBeNull();
+    expect(state.nextRetryAt).toBeNull();
+  });
+
+  it('reset clears state after failure', async () => {
+    const service = new RetryService({ maxAttempts: 1 });
+    const promise = service.execute(() => Promise.reject(new Error('fail')));
+    await expect(promise).rejects.toThrow('fail');
+
+    service.reset();
+    const state = service.getState();
+    expect(state.attempt).toBe(0);
+    expect(state.isRetrying).toBe(false);
+  });
+});
+
+// =============================================================================
+// execute — success
+// =============================================================================
+
+describe('RetryService execute — success', () => {
+  it('returns result on first attempt', async () => {
+    const service = new RetryService();
+    const result = await service.execute(() => Promise.resolve('ok'));
+    expect(result).toBe('ok');
+  });
+
+  it('calls onSuccess with result and attempt count', async () => {
+    const service = new RetryService();
+    const onSuccess = vi.fn();
+    await service.execute(() => Promise.resolve(42), { onSuccess });
+    expect(onSuccess).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('state shows not retrying after success', async () => {
+    const service = new RetryService();
+    await service.execute(() => Promise.resolve('done'));
+    expect(service.getState().isRetrying).toBe(false);
+    expect(service.getState().lastError).toBeNull();
+  });
+});
+
+// =============================================================================
+// execute — retry then success
+// =============================================================================
+
+describe('RetryService execute — retry then success', () => {
+  it('retries on failure and succeeds on second attempt', async () => {
+    const service = new RetryService({ maxAttempts: 3, baseDelay: 100, backoffFactor: 1 });
+    let callCount = 0;
+    const operation = () => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error('transient'));
+      }
+      return Promise.resolve('success');
+    };
+
+    const promise = service.execute(operation);
+    await vi.advanceTimersByTimeAsync(200);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(callCount).toBe(2);
+  });
+
+  it('calls onRetry with attempt, error, and delay', async () => {
+    const service = new RetryService({ maxAttempts: 3, baseDelay: 1000, backoffFactor: 2 });
+    let callCount = 0;
+    const onRetry = vi.fn();
+    const operation = () => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error('fail'));
+      }
+      return Promise.resolve('ok');
+    };
+
+    const promise = service.execute(operation, { onRetry });
+    await vi.advanceTimersByTimeAsync(1500);
+    await promise;
+
+    expect(onRetry).toHaveBeenCalledOnce();
+    expect(onRetry).toHaveBeenCalledWith(1, expect.any(Error), 1000);
+  });
+});
+
+// =============================================================================
+// execute — all retries exhausted
+// =============================================================================
+
+describe('RetryService execute — exhausted', () => {
+  it('throws last error when all attempts fail', async () => {
+    const service = new RetryService({ maxAttempts: 2, baseDelay: 100, backoffFactor: 1 });
+    const onExhausted = vi.fn();
+
+    let caughtError: Error | undefined;
+    const promise = service.execute(() => Promise.reject(new Error('always fail')), { onExhausted })
+      .catch((e: Error) => { caughtError = e; });
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    expect(caughtError?.message).toBe('always fail');
+    expect(onExhausted).toHaveBeenCalledWith(expect.any(Error), 2);
+  });
+
+  it('state reflects last error after exhaustion', async () => {
+    const service = new RetryService({ maxAttempts: 1 });
+    try {
+      await service.execute(() => Promise.reject(new Error('boom')));
+    } catch {
+      // expected
+    }
+    expect(service.getState().lastError?.message).toBe('boom');
+    expect(service.getState().isRetrying).toBe(false);
+  });
+});
+
+// =============================================================================
+// shouldRetry option
+// =============================================================================
+
+describe('RetryService shouldRetry', () => {
+  it('does not retry when shouldRetry returns false', async () => {
+    const service = new RetryService({ maxAttempts: 3, baseDelay: 100 });
+    let callCount = 0;
+    const onExhausted = vi.fn();
+
+    const promise = service.execute(
+      () => {
+        callCount++;
+        return Promise.reject(new Error('non-retriable'));
+      },
+      {
+        shouldRetry: () => false,
+        onExhausted,
+      }
+    );
+
+    await expect(promise).rejects.toThrow('non-retriable');
+    expect(callCount).toBe(1);
+    expect(onExhausted).toHaveBeenCalledWith(expect.any(Error), 1);
+  });
+});
+
+// =============================================================================
+// AbortSignal
+// =============================================================================
+
+describe('RetryService AbortSignal', () => {
+  it('throws DOMException with name AbortError when signal is already aborted', async () => {
+    const service = new RetryService();
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await service.execute(() => Promise.resolve('ok'), { signal: controller.signal });
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect((error as DOMException).name).toBe('AbortError');
+    }
+  });
+
+  it('throws when signal is aborted during delay', async () => {
+    const service = new RetryService({ maxAttempts: 3, baseDelay: 5000 });
+    const controller = new AbortController();
+    let callCount = 0;
+
+    const promise = service.execute(
+      () => {
+        callCount++;
+        return Promise.reject(new Error('fail'));
+      },
+      { signal: controller.signal }
+    );
+
+    // First attempt fails immediately, then delay starts.
+    // Advance a bit (not enough to resolve the delay), then abort.
+    await vi.advanceTimersByTimeAsync(100);
+    controller.abort();
+
+    try {
+      await promise;
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect((error as DOMException).name).toBe('AbortError');
+    }
+    // Only the first call should have happened before abort
+    expect(callCount).toBe(1);
+  });
+});
+
+// =============================================================================
+// Exponential backoff
+// =============================================================================
+
+describe('RetryService exponential backoff', () => {
+  it('calculates delays: 1s, 2s, 4s with backoffFactor=2', async () => {
+    const service = new RetryService({ maxAttempts: 4, baseDelay: 1000, backoffFactor: 2, maxDelay: 30000 });
+    const delays: number[] = [];
+    const onRetry = (_attempt: number, _error: Error, delay: number) => {
+      delays.push(delay);
+    };
+
+    let caughtError: Error | undefined;
+    const promise = service.execute(() => Promise.reject(new Error('fail')), { onRetry })
+      .catch((e: Error) => { caughtError = e; });
+
+    // Advance enough time for all retries (1s + 2s + 4s = 7s)
+    await vi.advanceTimersByTimeAsync(8000);
+    await promise;
+
+    expect(caughtError).toBeDefined();
+    expect(delays).toEqual([1000, 2000, 4000]);
+  });
+
+  it('caps delay at maxDelay', async () => {
+    const service = new RetryService({ maxAttempts: 4, baseDelay: 1000, backoffFactor: 10, maxDelay: 5000 });
+    const delays: number[] = [];
+    const onRetry = (_attempt: number, _error: Error, delay: number) => {
+      delays.push(delay);
+    };
+
+    let caughtError: Error | undefined;
+    const promise = service.execute(() => Promise.reject(new Error('fail')), { onRetry })
+      .catch((e: Error) => { caughtError = e; });
+
+    // Advance enough for all retries (1s + 5s + 5s = 11s)
+    await vi.advanceTimersByTimeAsync(15000);
+    await promise;
+
+    expect(caughtError).toBeDefined();
+    // delay 1: 1000*10^0 = 1000
+    // delay 2: 1000*10^1 = 10000 -> capped at 5000
+    // delay 3: 1000*10^2 = 100000 -> capped at 5000
+    expect(delays).toEqual([1000, 5000, 5000]);
+  });
+});
+
+// =============================================================================
+// Factory functions
+// =============================================================================
+
+describe('Factory functions', () => {
+  it('createAuthRetryService has correct config', () => {
+    const service = createAuthRetryService();
+    const config = service.getConfig();
+    expect(config.maxAttempts).toBe(3);
+    expect(config.baseDelay).toBe(2000);
+    expect(config.maxDelay).toBe(30000);
+  });
+
+  it('createNetworkRetryService has correct config', () => {
+    const service = createNetworkRetryService();
+    const config = service.getConfig();
+    expect(config.maxAttempts).toBe(5);
+    expect(config.baseDelay).toBe(1000);
+    expect(config.maxDelay).toBe(60000);
+  });
+});
+
+// =============================================================================
+// isTransientError
+// =============================================================================
+
+describe('isTransientError', () => {
+  it('detects network errors', () => {
+    expect(isTransientError(new Error('network error occurred'))).toBe(true);
+  });
+
+  it('detects timeout errors', () => {
+    expect(isTransientError(new Error('Request timeout'))).toBe(true);
+  });
+
+  it('detects "Failed to fetch"', () => {
+    expect(isTransientError(new Error('Failed to fetch'))).toBe(true);
+  });
+
+  it('detects ECONNRESET', () => {
+    expect(isTransientError(new Error('ECONNRESET'))).toBe(true);
+  });
+
+  it('returns false for non-transient errors', () => {
+    expect(isTransientError(new Error('Not found'))).toBe(false);
+    expect(isTransientError(new Error('Validation failed'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Auth refactoring**: Extracted LoginDialogs, RegisterDialogs, OfflineBanner, PasswordInput as shared components. Added onBlur validation via `useRegisterForm` hook. Removed unused `sessionService.ts`.
- **Error handling**: Typed error hierarchy (`AppError`, `NetworkError`, `AuthError`, `ValidationError`, `StorageError`), Sentry integration via `captureFeatureError`, `ErrorBoundary` improvements, retry logic hardened in `RetryService` and repositories.
- **261 new unit tests**: Mapper tests (supabaseMappers, liveMatchMappers), generator tests (scheduleHelpers, refereeAssigner, playoffGenerator), service tests (RetryService, MutationQueue), schema tests (CommonSchemas, TournamentSchema, MutationItemSchema), typed error tests.
- **Zod schema hardening**: Replaced 4x `z.any()` in TournamentSchema with typed schemas (`TeamTrainerSchema`, `RuntimeMatchEventSchema`, `TournamentGroupSchema`, `TournamentFieldSchema`). Added `MutationItemSchema` with boundary validation in `MutationQueue.load()` and `LocalStorageRepository`.

## Test plan
- [x] All 830 tests passing (`npx vitest run`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)