### PR TITLE
feat(findings): Findings-Backlog-System with deterministic /finding-fix DAG

### DIFF
--- a/.claude/commands/finding-fix.md
+++ b/.claude/commands/finding-fix.md
@@ -1,0 +1,28 @@
+---
+description: Fix a single finding from docs/findings/INDEX.md by ID
+---
+
+# Finding-Fix Command
+
+Du wendest einen Fix für ein Finding aus dem Findings-Backlog an.
+
+## Aufgabe
+
+Argument: $ARGUMENTS (Finding-ID, z.B. `F-042`)
+
+## Schritte
+
+1. Lade die Datei `docs/findings/$ARGUMENTS.md`
+2. Lese das Frontmatter (severity, file, model_routing, acceptance_criteria)
+3. Rufe `python3 -m findings.finding_fix $ARGUMENTS` auf (aus dem Repo-Root, mit PYTHONPATH=scripts)
+4. Wenn `Tests pass: True` und `Fallback used: False`: melde Erfolg
+5. Wenn `Fallback used: True`: erkläre dass Sovereign nicht reichte und Haiku übernahm
+6. Wenn `Tests pass: False` oder `Path-resolution: failed`:
+   - markiere im Frontmatter `status: requires_human_check`
+   - melde an User mit konkretem Hinweis was geprüft werden muss
+
+## Wichtig
+
+- Niemals `severity: critical` Findings ohne Mensch-Review committen
+- Bei `model_routing: claude-opus-*` immer Diff dem User zeigen vor Commit
+- Logs landen in `.claude/logs/finding-fixes.jsonl`

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -1,0 +1,29 @@
+# Findings Backlog
+
+> Auto-managed by `scripts/findings/extract_findings.py` and `/finding-fix`.
+> Last sync: <pending — first extraction>
+
+| ID | Sev | Area | Title | File | Effort | Status |
+|----|-----|------|-------|------|--------|--------|
+
+## Stats
+
+- Total: 0
+- Critical: 0 / High: 0 / Medium: 0 / Low: 0
+- Open: 0 / In-Progress: 0 / Fixed: 0 / Archived: 0
+
+## Workflow
+
+1. **Extract:** `python3 scripts/findings/extract_findings.py reviews/`
+2. **Status:** `python3 scripts/findings/findings_status.py`
+3. **Fix:** `/finding-fix F-001`  (Slash-Command in Claude Code)
+4. **Routing-Stats (after 4 weeks):** `python3 scripts/findings/findings_routing_stats.py`
+
+## Severity Legend
+
+| | Stufe | SLA |
+|--|-------|-----|
+| ⚫ | critical | <24 h |
+| 🔴 | high | <1 Woche |
+| 🟠 | medium | <1 Monat |
+| 🟡 | low | Backlog |

--- a/docs/findings/_TEMPLATE.md
+++ b/docs/findings/_TEMPLATE.md
@@ -1,0 +1,37 @@
+---
+id: F-XXX
+severity: medium
+area: architecture | security | data | perf | ux | a11y | testing | doc | other
+title: <Kurzer Titel>
+file: src/<path>
+lines: <optional, e.g. 42-58>
+effort: <optional, e.g. 30m, 2h>
+status: open
+source: reviews/<source-review-file>.md
+detected: YYYY-MM-DD
+fixed_at: null
+fixed_in_commit: null
+related: []
+parent: null
+model_routing: null  # optional override (e.g. claude-opus-4-6)
+acceptance_criteria:
+  - AK 1
+  - AK 2
+stale: false
+---
+
+# <Title>
+
+## Problem
+<1-2 sentences describing what's wrong>
+
+## Reproduktion
+<concrete grep/ls/test command to observe the issue>
+
+## Vorgeschlagener Fix
+<code-snippet or natural-language description>
+
+## Akzeptanzkriterien
+- [ ] AK 1
+- [ ] AK 2
+- [ ] Test schreibt explizit Anti-Regression

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     "test:a11y": "playwright test tests/e2e/usability/accessibility.spec.ts",
     "prepare": "husky",
     "analyze": "npm run build && open dist/stats.html",
-    "tokens:check": "node scripts/check-design-token-sync.cjs"
+    "tokens:check": "node scripts/check-design-token-sync.cjs",
+    "findings:extract": "PYTHONPATH=scripts python3 -m findings.extract_findings reviews/ --findings-dir docs/findings",
+    "findings:status": "PYTHONPATH=scripts python3 -m findings.findings_status docs/findings/",
+    "findings:fix": "PYTHONPATH=scripts python3 -m findings.finding_fix",
+    "findings:routing-stats": "PYTHONPATH=scripts python3 -m findings.findings_routing_stats",
+    "findings:validate-freshness": "PYTHONPATH=scripts python3 -m findings.validate_review_freshness"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "hallenfussball-findings"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+  "pydantic>=2.0",
+  "requests>=2.31",
+  "anthropic>=0.40",
+  "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-mock>=3.10"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/findings"]
+pythonpath = ["scripts"]
+markers = [
+  "integration: requires AI Hub auth (skipped in CI without secret)",
+]

--- a/reviews/code-review-agents.py
+++ b/reviews/code-review-agents.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+"""
+Code Review mit parallelen Qwen Thinking-Agents.
+
+12 spezialisierte Agents mit fokussierten Verzeichnissen fuer tiefe Analyse.
+Nutzt qwen-3.5-122b-sovereign ueber adesso AI Hub (Thinking Mode).
+
+Nutzung:
+  python reviews/code-review-agents.py                    # Alle 12 Agents
+  python reviews/code-review-agents.py --agent security   # Nur Security
+  python reviews/code-review-agents.py --list             # Agents anzeigen
+  python reviews/code-review-agents.py --batch 6          # In 2 Wellen a 6
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+# ── Config ──────────────────────────────────────────────────────
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+REVIEWS_DIR = PROJECT_ROOT / "reviews"
+REVIEWS_DIR.mkdir(exist_ok=True)
+
+API_BASE = os.environ.get("ADESSO_AI_HUB_BASE_URL", "https://adesso-ai-hub.3asabc.de/v1")
+API_KEY = os.environ.get("ADESSO_AI_HUB_API_KEY", "")
+MODEL = "qwen-3.5-122b-sovereign"
+MAX_TOKENS = 32000
+TIMEOUT = 600  # 10 Minuten pro Agent (Thinking braucht laenger)
+
+# Dateien die NICHT reviewed werden sollen
+EXCLUDE_PATTERNS = {
+    "node_modules", "dist", ".git", ".husky", ".vercel", ".gemini",
+    "playwright-report", "test-reports", "test-results", "coverage",
+    "package-lock.json", ".DS_Store", "ci_logs.txt",
+}
+
+INCLUDE_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".css", ".html", ".json", ".sql", ".yaml", ".yml"}
+
+# Common suffix appended to every agent system prompt (D18, D19).
+COMMON_SYSTEM_SUFFIX = """
+
+KRITISCHE METHODIK-REGELN (D19, Sichtfeld-Beschränkung):
+
+Du siehst nur die Dateien aus deinen `focus_dirs`. Du hast KEINEN Überblick über das gesamte Repo.
+
+- Wenn du etwas vermisst (z.B. "Playoff-Logik fehlt komplett"):
+  formuliere als "Zu prüfen ob X außerhalb meines Scopes existiert" — NICHT als Critical Finding.
+  Severity solcher Aussagen: HÖCHSTENS Low (zu verifizieren).
+
+- Wenn du Code-Snippets als Beispiel zeigst, markiere klar dass es DEINE Beschreibung ist,
+  nicht der echte Code. Halluzinationen vermeiden: KEINE erfundenen Pfade.
+
+KONSERVATIVE SEVERITY-EINSTUFUNG:
+
+- critical: NUR Security-Lücken oder Datenverlust-Risiken
+- high: Architektur-Verletzungen oder User-treffende Bugs
+- medium: Code-Smells mit echtem Impact
+- low: Polish, Wartbarkeit, "zu prüfen ob"-Aussagen
+
+SELF_CHECK vor dem Output (D18):
+
+[ ] Habe ich alle in meinem prompt aufgelisteten Punkte abgearbeitet?
+[ ] Sind alle Datei-Pfade vollständig (z.B. `src/foo/bar.ts:42`)?
+[ ] Habe ich Severity konservativ vergeben?
+[ ] Habe ich "fehlt komplett"-Aussagen als Low + zu-prüfen markiert?
+"""
+
+# ── Agent-Definitionen (12 Agents) ─────────────────────────────
+
+AGENTS = {
+    # ── 1. Architektur ──
+    "architecture": {
+        "name": "Architektur & Schichtenmodell",
+        "focus_dirs": ["src/core", "src/types", "src/contexts", "src/lib", "src/config"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein erfahrener Software-Architekt. Analysiere die Architektur dieser React/TypeScript PWA.
+
+<think>
+Analysiere systematisch:
+1. Schichtenarchitektur — Core (Models/Repositories/Services/Generators) vs. Features vs. Components. Ist die Trennung sauber?
+2. Dependency Flow — Importiert Core jemals aus Features/Components? Zirkulaere Imports?
+3. Repository Pattern — LocalStorageRepository vs. SupabaseRepository. Sind die Abstraktionen korrekt? Kann man leicht wechseln?
+4. Type System — Zod-Schemas als Runtime-Validierung + TypeScript-Typen. Sind sie konsistent? Gibt es Doppel-Definitionen?
+5. Configuration — Wie werden Sport-Configs, Feature-Flags, Umgebungen verwaltet?
+6. Error Handling Strategie — Konsistentes Pattern oder ad-hoc?
+7. Abhaengigkeiten — God-Objects? Zuviele Verantwortlichkeiten in einzelnen Dateien?
+8. Barrel Exports / Index Files — Sauber oder chaotisch?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Staerken** (was gut geloest ist)
+- **Architektur-Probleme** (mit Schweregrad: Critical/High/Medium/Low und Datei-Referenz)
+- **Konkrete Verbesserungsvorschlaege** (mit Code-Beispielen wo sinnvoll)
+- **Bewertung** (1-10 Skala)""",
+    },
+
+    # ── 2. Supabase & Daten ──
+    "supabase_data": {
+        "name": "Supabase, Datenbank & Sync",
+        "focus_dirs": ["supabase", "src/core/repositories", "src/core/storage", "src/core/sync", "src/core/realtime", "src/features/sync", "src/features/collaboration"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Supabase/PostgreSQL-Experte. Analysiere die Datenbank-Architektur, Auth und Realtime-Integration.
+
+<think>
+Pruefe systematisch:
+1. Database Schema — Migrationen konsistent? Fremdschluessel? Indizes? Constraints?
+2. Row Level Security (RLS) — Policies korrekt? Luecken (Bypass moeglich)?
+3. Auth Integration — Wie wird Auth in der App genutzt? Token-Handling?
+4. Realtime Subscriptions — Effizient? Cleanup bei Unmount? Conflict Resolution?
+5. LocalStorage ↔ Supabase Sync — Wie funktioniert die Synchronisation? Offline-First?
+6. Data Migration — Gibt es ein Schema-Migrations-Konzept fuer bestehende LocalStorage-Daten?
+7. Repository Pattern — Sind die Repositories gut abstrahiert? Koennte man Supabase austauschen?
+8. Connection Handling — Pooling? Retry? Error Recovery?
+9. Edge Functions — Gibt es welche? Sicherheit?
+10. Storage — File Uploads? Policies?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Kritische DB/Auth-Probleme** (RLS-Luecken, Schema-Fehler)
+- **Sync-Probleme** (Konflikte, Datenverlust-Risiken)
+- **Optimierungspotenzial** (Queries, Indizes, Subscriptions)
+- **Positive Patterns**
+- **Supabase Score** (1-10)""",
+    },
+
+    # ── 3. Security ──
+    "security": {
+        "name": "Security & Datenschutz",
+        "focus_dirs": ["src/features/auth", "supabase", "src/lib", "public", "src/core/storage"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Application Security Engineer. Fuehre ein Security-Audit dieser PWA durch.
+
+<think>
+Pruefe systematisch (OWASP Top 10 + PWA-spezifisch):
+1. Authentication — Supabase Auth korrekt implementiert? Session-Management? Token-Refresh?
+2. Authorization — RLS-Policies? Client-Side Route Guards reichen NICHT als Schutz!
+3. Input Validation — Zod-Schemas lueckenlos? XSS-Vektoren in User-Input? dangerouslySetInnerHTML?
+4. Client-Side Storage — Sensible Daten in LocalStorage/IndexedDB? Verschluesselung?
+5. API-Key Exposure — Supabase anon key im Client ist OK, aber: sind service_role keys exponiert?
+6. Service Worker Security — Cache-Poisoning? Update-Mechanismus? Integrity?
+7. Secrets Management — .env.local Handling, .env.example, Vercel-Config
+8. Dependency Security — bekannte CVEs in package.json Dependencies?
+9. CSRF/Clickjacking — PWA-spezifische Angriffsvektoren, Frame-Busting
+10. Content Security Policy — Header gesetzt (vercel.json)? Script-Src, Style-Src?
+11. Datenschutz/DSGVO — Welche personenbezogenen Daten? Consent? Loeschkonzept?
+12. Deep Link Security — URL-basierte Tournamentfreigabe? Token-Guessing?
+</think>
+
+Gib ein strukturiertes Security-Report mit:
+- **Kritische Findings** (sofort beheben)
+- **Hohe Findings** (vor naechstem Release)
+- **Mittlere Findings** (in Backlog)
+- **Empfehlungen** (Hardening)
+- **Security Score** (1-10)""",
+    },
+
+    # ── 4. Tournament Creation Flow ──
+    "tournament_creation": {
+        "name": "Turnier-Erstellung (Wizard Flow)",
+        "focus_dirs": ["src/features/tournament-creation", "src/core/generators", "src/core/models"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein QA-Engineer und UX-Spezialist. Analysiere den Turnier-Erstellungs-Wizard.
+
+<think>
+Pruefe systematisch:
+1. Wizard-Schritte — Welche Schritte gibt es? Reihenfolge logisch?
+2. Validierung — Werden alle Eingaben validiert? Fehlermeldungen klar?
+3. Zurueck-Navigation — Kann man Schritte zurueckgehen ohne Datenverlust?
+4. Team-Verwaltung — Hinzufuegen, Entfernen, Umbenennen. Edge Cases?
+5. Spielplan-Generierung — Algorithmus korrekt? Fairness (gleiche Anzahl Spiele, ausgewogene Gegner)?
+6. Gruppen-Modus — Gruppenaufteilung fair? Topfverlosung?
+7. Turnier-Formate — Welche werden unterstuetzt? (Jeder-gegen-Jeden, Gruppen+Playoff, Schweizer System?)
+8. Sport-Konfiguration — Verschiedene Sportarten? Regelwerke?
+9. Freilose (Bye) — Korrekt bei ungerader Teamzahl?
+10. Persistierung — Wird Zwischenstand gespeichert? Was passiert bei Browser-Absturz im Wizard?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Logik-Fehler** im Wizard oder Generator
+- **Fehlende Validierungen** (Pflichtfelder, Grenzwerte)
+- **UX-Probleme** im Wizard-Flow
+- **Edge Cases** die nicht abgedeckt sind
+- **Tournament Creation Score** (1-10)""",
+    },
+
+    # ── 5. Live-Cockpit & Match Management ──
+    "live_cockpit": {
+        "name": "Live-Cockpit & Spielsteuerung",
+        "focus_dirs": ["src/features/schedule-editor", "src/features/monitor-display", "src/features/tournament-management", "src/components/schedule"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein QA-Engineer spezialisiert auf Realtime-Anwendungen. Analysiere das Live-Cockpit fuer Spielsteuerung.
+
+<think>
+Pruefe systematisch:
+1. Timer-Logik — Start/Stop/Pause korrekt? Was bei Browser-Tab-Wechsel? Drift-Kompensation?
+2. Tor-Erfassung — Eingabe, Korrektur, Undo. Race Conditions bei schneller Eingabe?
+3. Spielstand-Updates — Realtime-Sync? Was bei Netzwerk-Ausfall waehrend des Spiels?
+4. Gleichzeitige Bearbeitung — Kann ein zweiter Nutzer Tore eintragen? Konflikte?
+5. Ergebnis-Berechnung — Punkte, Tordifferenz, Direkter Vergleich, Fairplay. Alles korrekt?
+6. Tabellenstand — Live-Aktualisierung? Sortierung korrekt bei Punktgleichheit?
+7. Spielplan-Ansicht — Uebersichtlich? Filter? Suche? Farbkodierung?
+8. Monitor/Anzeigetafel — Was sehen Zuschauer? Auto-Refresh? Darstellung bei verschiedenen Screens?
+9. Spielreihenfolge — Stimmt die Reihenfolge mit dem generierten Spielplan ueberein?
+10. Fehl-Tipp-Schutz — Bestaetigung bei Tor-Eingabe? Undo-Zeitfenster?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Kritische Timing-Bugs** (Timer, Sync, Race Conditions)
+- **Logik-Fehler** (Berechnung, Sortierung)
+- **UX-Probleme** unter Zeitdruck (Halle = Stress-Szenario)
+- **Positive Patterns**
+- **Live-Cockpit Score** (1-10)""",
+    },
+
+    # ── 6. Tournament Admin & Playoffs ──
+    "tournament_admin": {
+        "name": "Turnier-Admin & Playoff-Logik",
+        # D20: include playoff*.ts explicitly so cross-cutting code is in scope
+        "focus_dirs": [
+            "src/features/tournament-admin",
+            "src/core/generators",  # already covers playoff*.ts via rglob
+            "src/core/generators/playoffGenerator.ts",
+            "src/core/generators/playoffResolver.ts",
+            "src/core/generators/playoffScheduler.ts",
+            "src/core/services",
+            "src/core/models",
+        ],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Domain-Experte fuer Turniersoftware. Analysiere Admin-Features und Playoff-Logik.
+
+<think>
+Pruefe systematisch:
+1. Playoff-Bracket — Generation korrekt? Seeding fair (1. vs Letzter)?
+2. Tiebreaker-Regeln — Was bei Punktgleichheit? Direkter Vergleich → Tordifferenz → Torverhaeltnis → Los?
+3. Bye-Handling — Freilose in Playoffs korrekt? Automatischer Sieg ohne Ergebnis?
+4. Team-Zurueckziehung — Was passiert wenn ein Team mitten im Turnier ausscheidet?
+5. Nachtraegliche Aenderungen — Ergebnis-Korrektur nach Spielende? Auswirkung auf Tabelle?
+6. Turnier-Abbruch — Kann ein Turnier vorzeitig beendet werden? Endstand?
+7. Spielplan-Regenerierung — Kann der Spielplan nach Start geaendert werden?
+8. Multi-Gruppen → Playoff — Uebergang korrekt? Kreuzspiele?
+9. Dritter-Platz-Spiel — Optional? Korrekt integriert?
+10. Export — PDF-Spielplan, Ergebnisse. Vollstaendig und korrekt?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Logik-Fehler** (falsche Berechnung, falsches Bracket)
+- **Fehlende Edge Cases**
+- **Inkonsistenzen** zwischen Gruppen- und Playoff-Phase
+- **Admin-UX-Probleme**
+- **Tournament Admin Score** (1-10)""",
+    },
+
+    # ── 7. Components & UI Library ──
+    "components_ui": {
+        "name": "UI-Komponenten & Design System",
+        "focus_dirs": ["src/components/ui", "src/design-tokens", "src/styles"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Frontend-Architect mit Fokus auf Component Libraries. Analysiere die UI-Komponenten.
+
+<think>
+Pruefe systematisch:
+1. Component API — Props konsistent? Defaults sinnvoll? Typisierung?
+2. Composability — Sind Komponenten zusammensetzbar oder monolithisch?
+3. Design Tokens — Werden sie konsistent genutzt? Hardcodierte Werte?
+4. Accessibility — ARIA Labels, Rollen, Keyboard-Support, Focus Management
+5. Responsive Design — Breakpoints, Container Queries, Mobile-First?
+6. Theming — Dark Mode? Custom Themes? CSS Variables?
+7. Animation — Smooth Transitions? Reduced Motion Support?
+8. Form Components — Validation-Integration, Error States, Loading States
+9. Reusability — Koennen Komponenten projektuebergreifend genutzt werden?
+10. Storybook/Docs — Dokumentation der Komponenten? Playground?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Inkonsistenzen** (verschiedene Patterns fuer gleiche Dinge)
+- **Accessibility-Verstoesse** (WCAG 2.1 AA)
+- **Design-Token-Verstoesse** (hardcodierte Farben/Groessen)
+- **Verbesserungsvorschlaege**
+- **UI Component Score** (1-10)""",
+    },
+
+    # ── 8. Hooks & State Management ──
+    "hooks_state": {
+        "name": "Hooks, State & Context",
+        "focus_dirs": ["src/hooks", "src/contexts", "src/core/contexts"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein React-Experte spezialisiert auf State Management und Custom Hooks. Analysiere alle Hooks und Contexts.
+
+<think>
+Pruefe systematisch:
+1. Custom Hooks — Naming (use*), Rueckgabewerte, Fehlerbehandlung
+2. Context Architecture — Wie viele Contexts? Verschachtelt? Provider Hell?
+3. Re-Render Optimierung — useMemo, useCallback korrekt? Oder unnoetige Wrapping?
+4. Side Effects — useEffect Cleanup? Dependency Arrays korrekt? Race Conditions?
+5. Hook Composition — Werden Hooks aus anderen Hooks zusammengebaut? Zu tief verschachtelt?
+6. State Colocation — State nah an der Nutzung oder zu weit oben (Prop Drilling)?
+7. Derived State — Wird State abgeleitet statt dupliziert?
+8. Hook Dependencies — Stabile Referenzen? Closures korrekt?
+9. Error Boundaries — Integration mit Hook-Fehlern?
+10. Performance — Hooks die bei jedem Render neue Objekte/Arrays erzeugen?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Re-Render-Probleme** (unnoetige Renders durch schlechte Deps)
+- **Memory Leaks** (fehlender Cleanup)
+- **Anti-Patterns** (Rules of Hooks Verstoesse, God-Hooks)
+- **Positive Patterns**
+- **State Management Score** (1-10)""",
+    },
+
+    # ── 9. Performance & Bundle ──
+    "performance": {
+        "name": "Performance, Bundle & PWA",
+        "focus_dirs": ["vite.config.ts", "vercel.json", "package.json", "public", "src/main.tsx", "src/App.tsx", "src/core/storage"],
+        "max_chars": 120000,
+        "prompt": """Du bist ein Web Performance Engineer. Analysiere Performance, Bundle-Size und PWA-Verhalten.
+
+<think>
+Pruefe systematisch:
+1. Bundle Size — Code Splitting korrekt? Lazy Loading fuer Routes? Dynamic Imports?
+2. Vite Config — Build-Optimierungen? Chunk-Splitting? Rollup-Config?
+3. Tree Shaking — Werden nur genutzte Exports importiert? Barrel-Export-Probleme?
+4. Asset Optimization — Bilder komprimiert? Fonts (WOFF2)? Preloading?
+5. PWA Config — Manifest vollstaendig? Icons? Splash? Install-Prompt?
+6. Service Worker — Caching-Strategie? Precache? Runtime Cache? Update-Flow?
+7. Offline-Faehigkeit — Funktioniert die App offline? Was fehlt offline?
+8. Runtime Performance — Grosse Listen virtualisiert? Timer effizient?
+9. Memory Leaks — Event Listener, Subscriptions, Intervals — Cleanup?
+10. Lighthouse-Einschaetzung — LCP, FID, CLS aus dem Code heraus bewerten
+11. Network — Waterfall? Prefetching? HTTP/2 Push?
+12. Vercel Config — Headers, Redirects, Edge Functions?
+</think>
+
+Gib ein strukturiertes Performance-Report mit:
+- **Critical Issues** (spuerbare Verzoegerungen, fehlende Offline-Funktion)
+- **Bundle-Optimierungen** (mit geschaetztem Size-Impact)
+- **PWA-Luecken** (fehlende Offline-Features, Install-Flow)
+- **Positive Patterns**
+- **Performance Score** (1-10)""",
+    },
+
+    # ── 10. Testing & QA ──
+    "testing": {
+        "name": "Testing & Qualitaetssicherung",
+        "focus_dirs": ["src/test", "src/test-data", "src/utils/__tests__", "src/design-tokens/__tests__", "vitest.config.ts", "playwright.config.ts", "eslint.config.js"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein QA-Lead und Testing-Experte. Analysiere die gesamte Test-Strategie.
+
+<think>
+Pruefe systematisch:
+1. Test-Pyramide — Verhaeltnis Unit/Integration/E2E? Richtige Balance?
+2. Testabdeckung — Welche Module sind getestet? Welche fehlen komplett?
+3. Unit Tests — Vitest-Setup korrekt? Mocking sinnvoll? Assertions aussagekraeftig?
+4. E2E Tests — Playwright-Setup? Selektoren stabil? Flaky Tests?
+5. Test-Daten — Fixtures/Factories? Hardcodierte Werte?
+6. Edge Cases — Werden Grenzfaelle getestet? (0 Teams, 1 Team, 100 Teams)
+7. Async Testing — Timer, Realtime, Network — korrekt gemockt?
+8. Snapshot Tests — Werden sie genutzt? Sinnvoll oder Rauschen?
+9. CI/CD — Laeuft Test-Suite automatisch? Performance der Suite?
+10. Test-Qualitaet — Testen Tests das Richtige? False Positives?
+</think>
+
+Gib ein strukturiertes Testing-Report mit:
+- **Testluecken** (ungetestete kritische Pfade)
+- **Test-Qualitaetsprobleme** (fragile Tests, schlechte Assertions)
+- **Fehlende Test-Typen** (z.B. kein Accessibility-Testing)
+- **Empfehlungen** priorisiert nach Impact
+- **Testing Score** (1-10)""",
+    },
+
+    # ── 11. i18n & Accessibility ──
+    "i18n_a11y": {
+        "name": "Internationalisierung & Barrierefreiheit",
+        "focus_dirs": ["src/i18n", "src/components", "src/screens"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein i18n- und Accessibility-Experte. Analysiere Mehrsprachigkeit und Barrierefreiheit.
+
+<think>
+Pruefe systematisch:
+i18n:
+1. Uebersetzungsdateien — Alle Keys vorhanden? Fehlende Uebersetzungen?
+2. Hardcodierte Strings — Text direkt in JSX statt ueber i18n?
+3. Pluralisierung — Korrekte Plural-Regeln? (1 Tor vs. 2 Tore)
+4. Datumsformate — Lokalisiert? Zeitzone-Handling?
+5. Zahlenformate — Dezimaltrennzeichen, Tausendertrennzeichen?
+6. RTL-Support — Layout-Anpassungen fuer RTL-Sprachen?
+7. Sprach-Erkennung — Browser-Sprache? Fallback?
+
+Accessibility:
+8. Semantisches HTML — <button> statt <div onClick>? Landmarks?
+9. ARIA — Labels, Roles, Live Regions (fuer Timer-Updates!), Announcements
+10. Keyboard Navigation — Tab-Reihenfolge? Focus Traps in Modals? Skip Links?
+11. Screenreader — Werden Spielstaende vorgelesen? Timer-Updates?
+12. Farb-Kontraste — Ausreichend (4.5:1 normal, 3:1 gross)?
+13. Motion — Reduced Motion respektiert?
+14. Touch Targets — Mindestens 48x48px? Abstand zwischen Targets?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **i18n-Luecken** (fehlende Keys, hardcodierte Strings)
+- **WCAG 2.1 AA Verstoesse** (mit Schweregrad)
+- **Screenreader-Probleme** (besonders bei Live-Daten)
+- **Positive Patterns**
+- **i18n Score** (1-10) und **Accessibility Score** (1-10)""",
+    },
+
+    # ── 12. Code Quality & Patterns ──
+    "code_quality": {
+        "name": "Code-Qualitaet & TypeScript-Patterns",
+        "focus_dirs": ["src/utils", "src/lib", "src/types", "src/constants", "src/services", "src/core/utils"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Senior TypeScript/React Developer. Analysiere Code-Qualitaet, Patterns und Wartbarkeit.
+
+<think>
+Pruefe systematisch:
+1. TypeScript Strict Mode — any-Casts? as-Casts? Non-Null Assertions (!)? Strict Flags?
+2. Type Definitions — Sind Types gut modelliert? Union Types vs. Enums? Branded Types?
+3. Utility Functions — DRY? Richtige Abstraktion? Oder Over-Engineering?
+4. Constants — Magic Numbers? Magic Strings? Enum-artige Konstanten?
+5. Error Handling — try/catch konsistent? Custom Error Types? Error Boundaries?
+6. Naming Conventions — Konsistent? Sprechend? Deutsch/Englisch gemischt?
+7. Code Smells — Lange Funktionen (>50 LOC)? Deep Nesting? Switch-Ketten?
+8. DRY-Verstoesse — Copy-Paste-Code? Fehlende Abstraktionen?
+9. ESLint-Config — Welche Regeln aktiv? Passend fuer React/TS?
+10. Dead Code — Ungenutzte Exports, Imports, Funktionen?
+</think>
+
+Gib ein strukturiertes Quality-Report mit:
+- **Code Smells** (mit Schweregrad und Datei-Referenz)
+- **TypeScript-Verstoesse** (any, unsafe casts)
+- **Naming-Inkonsistenzen**
+- **Positive Patterns** (vorbildlicher Code)
+- **Refactoring-Empfehlungen** (priorisiert)
+- **Code Quality Score** (1-10)""",
+    },
+
+    # ── 13. Screens & Navigation ──
+    "screens_navigation": {
+        "name": "Screens, Routing & Navigation",
+        "focus_dirs": ["src/screens", "src/App.tsx", "src/main.tsx", "src/features/settings"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein React Router-Experte und UX-Engineer. Analysiere Screens, Routing und Navigation.
+
+<think>
+Pruefe systematisch:
+1. Route-Struktur — Hierarchie logisch? Nested Routes? Lazy Loading?
+2. Navigation Flow — Kann der User von ueberall zurueck? Breadcrumbs? History?
+3. Deep Links — Funktionieren direkte URLs zu Turnieren/Spielen? Sharing?
+4. Route Guards — Auth-geschuetzte Routes? Redirect bei fehlender Berechtigung?
+5. 404 Handling — Was bei unbekannten Routes?
+6. Screen Layouts — Konsistentes Layout? Header/Footer/Navigation?
+7. Page Transitions — Smooth? Loading States beim Routenwechsel?
+8. URL-Design — Sprechende URLs? Query Parameters sinnvoll?
+9. Back-Button — Funktioniert der Browser-Zurueck-Button korrekt?
+10. Settings — Einstellungen persistent? Validierung? UX?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Routing-Probleme** (fehlende Guards, broken Links)
+- **Navigation-UX-Probleme** (Sackgassen, fehlende Zurueck-Moeglichkeit)
+- **Deep-Link-Luecken**
+- **Positive Patterns**
+- **Navigation Score** (1-10)""",
+    },
+
+    # ── 14. Sport-Konfiguration & Datenmodell ──
+    "sport_config": {
+        "name": "Sport-Konfiguration & Datenmodell",
+        "focus_dirs": ["src/config/sports", "src/core/models", "src/types", "data", "src/constants"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Domain-Experte fuer Sportturnier-Software. Analysiere das Datenmodell und die Sport-Konfiguration.
+
+<think>
+Pruefe systematisch:
+1. Datenmodell — Tournament, Team, Match, Group, Playoff. Vollstaendig? Konsistent?
+2. Sport-Konfiguration — Welche Sportarten? Unterschiedliche Regeln (Spielzeit, Punkte, Tiebreaker)?
+3. Zod-Schemas — Runtime-Validierung korrekt? Deckt alle Edge Cases ab?
+4. Enums/Constants — Turnier-Status, Match-Status, Spielmodi — konsistent definiert?
+5. Daten-Migration — Gibt es Versioning? Was bei Schema-Aenderungen?
+6. Type Guards — Discriminated Unions korrekt? Exhaustive Checks?
+7. Domain Events — Werden Zustandsuebergaenge modelliert? (z.B. Match: scheduled → running → finished)
+8. Erweiterbarkeit — Kann man leicht neue Sportarten/Modi hinzufuegen?
+9. Serialisierung — JSON-Kompatibilitaet? Date-Handling?
+10. Invarianten — Werden Geschaeftsregeln im Modell erzwungen? (z.B. min 2 Teams, max Teams)
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Modell-Probleme** (fehlende Constraints, Inkonsistenzen)
+- **Schema-Luecken** (unvalidierte Eingaben)
+- **Erweiterbarkeits-Probleme**
+- **Positive Patterns**
+- **Datenmodell Score** (1-10)""",
+    },
+
+    # ── 15. PDF-Export & Daten-Ausgabe ──
+    "export_output": {
+        "name": "PDF-Export, Sharing & Datenausgabe",
+        "focus_dirs": ["src/components", "src/core/services", "src/hooks", "src/utils"],
+        "max_chars": 150000,
+        "prompt": """Du bist ein Frontend-Entwickler spezialisiert auf Datenexport und Sharing. Analysiere PDF-Generation, Sharing und Datenausgabe.
+
+<think>
+Pruefe systematisch:
+1. PDF-Export — jsPDF Integration korrekt? Layout? Schriftarten? Umlaute?
+2. Spielplan-PDF — Alle Informationen enthalten? Lesbar? Druckfreundlich?
+3. Ergebnis-Export — Tabellen, Endergebnis exportierbar?
+4. Share-Funktion — Web Share API? Deep Links? QR-Code?
+5. Turnier-Teilen — Wie wird ein Turnier mit anderen geteilt? Link? Code?
+6. Monitor-URL — Oeffentliche Anzeigetafel-URL? Ohne Auth zugaenglich?
+7. Clipboard — Copy-to-Clipboard fuer Links? Spielplaene?
+8. Print — @media print Styles? Druckvorschau?
+9. Datenformat — Gibt es Import/Export (z.B. CSV, JSON) fuer Turnierdaten?
+10. Fehlerbehandlung — Was wenn PDF-Generation fehlschlaegt? Fallback?
+</think>
+
+Gib ein strukturiertes Review mit:
+- **Export-Bugs** (fehlende Daten, Layout-Probleme)
+- **Fehlende Export-Formate**
+- **Sharing-UX-Probleme**
+- **Positive Patterns**
+- **Export Score** (1-10)""",
+    },
+}
+
+
+# ── Datei-Sammlung ──────────────────────────────────────────────
+
+def collect_files(focus_dirs: list[str], max_chars: int = 120000) -> str:
+    """Sammelt relevante Dateien aus den Fokus-Verzeichnissen."""
+    files_content = []
+    total_chars = 0
+
+    for focus_dir in focus_dirs:
+        dir_path = PROJECT_ROOT / focus_dir
+        if not dir_path.exists():
+            # Einzeldatei?
+            fp = PROJECT_ROOT / focus_dir
+            if fp.is_file() and fp.suffix in INCLUDE_EXTENSIONS:
+                try:
+                    content = fp.read_text(errors="replace")
+                    if total_chars + len(content) > max_chars:
+                        continue
+                    files_content.append(f"### {focus_dir}\n```{fp.suffix.lstrip('.')}\n{content}\n```")
+                    total_chars += len(content)
+                except Exception:
+                    pass
+            continue
+
+        for fp in sorted(dir_path.rglob("*")):
+            if not fp.is_file():
+                continue
+            if fp.suffix not in INCLUDE_EXTENSIONS:
+                continue
+            if any(excl in str(fp) for excl in EXCLUDE_PATTERNS):
+                continue
+
+            rel = fp.relative_to(PROJECT_ROOT)
+            try:
+                content = fp.read_text(errors="replace")
+            except Exception:
+                continue
+
+            # Grosse Dateien kuerzen
+            if len(content) > 10000:
+                content = content[:10000] + f"\n\n... (gekuerzt, {len(content)} Zeichen gesamt)"
+
+            if total_chars + len(content) > max_chars:
+                files_content.append(f"\n... (Budget erreicht nach {total_chars:,} Zeichen, weitere Dateien uebersprungen)")
+                break
+
+            files_content.append(f"### {rel}\n```{fp.suffix.lstrip('.')}\n{content}\n```")
+            total_chars += len(content)
+
+    return "\n\n".join(files_content)
+
+
+# ── API Call ────────────────────────────────────────────────────
+
+def call_qwen_thinking(agent_key: str, agent_def: dict, code_context: str) -> dict:
+    """Einzelnen Qwen Thinking-Agent aufrufen."""
+    t0 = time.time()
+
+    system_prompt = agent_def["prompt"] + COMMON_SYSTEM_SUFFIX
+    user_message = f"""# Code Review: hallenfussball-pwa
+
+## Projekt-Kontext
+React 19 + TypeScript PWA fuer Hallenfussball-Turnierverwaltung.
+Tech Stack: Vite 7, Supabase (Auth + DB + Realtime), Zod, React Router, i18next, jsPDF.
+626 Source-Dateien, ~24.000 LOC. Deployment: Vercel.
+Features: Turnier-Erstellung (Wizard), Spielplan-Generierung, Live-Cockpit (Timer, Tore),
+Ergebnis-Tabellen, Playoff-Bracket, Monitor/Anzeigetafel, PDF-Export, Multi-User via Supabase Realtime.
+
+## Fokus: {agent_def['name']}
+
+## Code ({len(code_context):,} Zeichen)
+
+{code_context}
+"""
+
+    headers = {
+        "Authorization": f"Bearer {API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        "max_tokens": MAX_TOKENS,
+        # Offizielle Qwen3 Thinking-Mode-Empfehlung (HF Modelcard, Qwen Quickstart):
+        # temp 0.6, top_p 0.95, top_k 20, presence_penalty 0.0, min_p 0.
+        # WARNUNG: greedy decoding (temp=0) führt zu endless repetitions.
+        "temperature": 0.6,
+        "top_p": 0.95,
+        "top_k": 20,
+        "presence_penalty": 0.0,
+        "extra_body": {"enable_thinking": True, "min_p": 0},
+    }
+
+    try:
+        resp = requests.post(
+            f"{API_BASE}/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
+        thinking = data["choices"][0]["message"].get("reasoning_content", "")
+        elapsed = time.time() - t0
+
+        return {
+            "agent": agent_key,
+            "name": agent_def["name"],
+            "status": "success",
+            "content": content,
+            "thinking": thinking,
+            "duration_seconds": round(elapsed, 1),
+            "tokens": data.get("usage", {}),
+            "code_chars": len(code_context),
+        }
+    except Exception as e:
+        return {
+            "agent": agent_key,
+            "name": agent_def["name"],
+            "status": "error",
+            "content": str(e),
+            "thinking": "",
+            "duration_seconds": round(time.time() - t0, 1),
+            "tokens": {},
+            "code_chars": len(code_context),
+        }
+
+
+# ── Main ────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Code Review mit Qwen Thinking-Agents")
+    parser.add_argument("--agent", type=str, help="Nur diesen Agent ausfuehren")
+    parser.add_argument("--list", action="store_true", help="Verfuegbare Agents anzeigen")
+    parser.add_argument("--sequential", action="store_true", help="Sequenziell statt parallel")
+    parser.add_argument("--batch", type=int, default=0, help="Agents in Batches aufteilen (z.B. --batch 6)")
+    args = parser.parse_args()
+
+    if args.list:
+        print("Verfuegbare Review-Agents:\n")
+        for key, agent in AGENTS.items():
+            print(f"  {key:25s} {agent['name']}")
+            print(f"  {'':25s} Fokus: {', '.join(agent['focus_dirs'])}")
+            print()
+        return
+
+    if not API_KEY:
+        print("FEHLER: ADESSO_AI_HUB_API_KEY nicht gesetzt")
+        print("  export ADESSO_AI_HUB_API_KEY=...")
+        sys.exit(1)
+
+    agents_to_run = AGENTS
+    if args.agent:
+        if args.agent not in AGENTS:
+            print(f"FEHLER: Agent '{args.agent}' nicht gefunden. Verfuegbar: {', '.join(AGENTS.keys())}")
+            sys.exit(1)
+        agents_to_run = {args.agent: AGENTS[args.agent]}
+
+    print(f"=== Code Review: hallenfussball-pwa ===")
+    print(f"Modell: {MODEL} (Thinking Mode)")
+    print(f"Agents: {len(agents_to_run)}")
+    print()
+
+    # Code sammeln pro Agent
+    agent_contexts = {}
+    for key, agent in agents_to_run.items():
+        max_c = agent.get("max_chars", 120000)
+        print(f"  Sammle Code fuer {agent['name']}...")
+        agent_contexts[key] = collect_files(agent["focus_dirs"], max_chars=max_c)
+        chars = len(agent_contexts[key])
+        print(f"    -> {chars:,} Zeichen aus {', '.join(agent['focus_dirs'])}")
+
+    print()
+
+    results = []
+    t_total = time.time()
+
+    if args.sequential:
+        print(f"Starte {len(agents_to_run)} Agents sequenziell...\n")
+        for key, agent in agents_to_run.items():
+            print(f"  [{key}] Laeuft...")
+            result = call_qwen_thinking(key, agent, agent_contexts[key])
+            results.append(result)
+            icon = "OK" if result["status"] == "success" else "FAIL"
+            print(f"  [{key}] {icon} ({result['duration_seconds']}s)")
+    elif args.batch > 0:
+        # In Batches aufteilen
+        keys = list(agents_to_run.keys())
+        batch_size = args.batch
+        batches = [keys[i:i + batch_size] for i in range(0, len(keys), batch_size)]
+        print(f"Starte {len(agents_to_run)} Agents in {len(batches)} Batches a {batch_size}...\n")
+
+        for batch_num, batch_keys in enumerate(batches, 1):
+            print(f"--- Batch {batch_num}/{len(batches)} ({len(batch_keys)} Agents) ---")
+            with ThreadPoolExecutor(max_workers=len(batch_keys)) as pool:
+                futures = {
+                    pool.submit(call_qwen_thinking, key, agents_to_run[key], agent_contexts[key]): key
+                    for key in batch_keys
+                }
+                for future in as_completed(futures):
+                    key = futures[future]
+                    result = future.result()
+                    results.append(result)
+                    icon = "OK" if result["status"] == "success" else "FAIL"
+                    print(f"  {icon} [{key}] {result['status']} ({result['duration_seconds']}s)")
+            print()
+    else:
+        print(f"Starte {len(agents_to_run)} Agents parallel...\n")
+        with ThreadPoolExecutor(max_workers=len(agents_to_run)) as pool:
+            futures = {
+                pool.submit(call_qwen_thinking, key, agent, agent_contexts[key]): key
+                for key, agent in agents_to_run.items()
+            }
+            for future in as_completed(futures):
+                key = futures[future]
+                result = future.result()
+                results.append(result)
+                icon = "OK" if result["status"] == "success" else "FAIL"
+                print(f"  {icon} [{key}] {result['status']} ({result['duration_seconds']}s)")
+
+    total_time = round(time.time() - t_total, 1)
+
+    # Ergebnisse speichern
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+
+    # Einzelne Agent-Reports
+    print(f"\nSpeichere Reports:")
+    for result in sorted(results, key=lambda x: x["agent"]):
+        out_path = REVIEWS_DIR / f"{timestamp}_{result['agent']}.md"
+        with open(out_path, "w") as f:
+            f.write(f"# Code Review: {result['name']}\n\n")
+            f.write(f"**Modell:** {MODEL} (Thinking Mode)  \n")
+            f.write(f"**Dauer:** {result['duration_seconds']}s  \n")
+            f.write(f"**Status:** {result['status']}  \n")
+            f.write(f"**Code-Kontext:** {result.get('code_chars', 0):,} Zeichen  \n\n")
+            if result.get("thinking"):
+                f.write(f"<details><summary>Thinking Process ({len(result['thinking']):,} Zeichen)</summary>\n\n")
+                f.write(f"{result['thinking']}\n\n</details>\n\n---\n\n")
+            f.write(result["content"])
+        print(f"  -> {out_path.name}")
+
+    # Gesamt-Report
+    summary_path = REVIEWS_DIR / f"{timestamp}_SUMMARY.md"
+    with open(summary_path, "w") as f:
+        f.write(f"# Code Review Summary: hallenfussball-pwa\n\n")
+        f.write(f"**Datum:** {datetime.now().strftime('%Y-%m-%d %H:%M')}  \n")
+        f.write(f"**Modell:** {MODEL} (Thinking Mode)  \n")
+        f.write(f"**Gesamtdauer:** {total_time}s  \n")
+        f.write(f"**Agents:** {len(results)}  \n\n")
+
+        f.write("## Uebersicht\n\n")
+        f.write("| # | Agent | Status | Dauer | Code | Tokens |\n")
+        f.write("|---|-------|--------|-------|------|--------|\n")
+        for i, r in enumerate(sorted(results, key=lambda x: x["agent"]), 1):
+            tokens = r.get("tokens", {})
+            total_tok = tokens.get("total_tokens", "?")
+            code_k = round(r.get("code_chars", 0) / 1000, 1)
+            f.write(f"| {i} | {r['name']} | {r['status']} | {r['duration_seconds']}s | {code_k}k | {total_tok} |\n")
+
+        f.write(f"\n---\n\n")
+
+        for r in sorted(results, key=lambda x: x["agent"]):
+            f.write(f"## {r['name']}\n\n")
+            if r["status"] == "error":
+                f.write(f"> **FEHLER:** {r['content']}\n\n")
+            else:
+                f.write(f"{r['content']}\n\n")
+            f.write(f"---\n\n")
+
+    print(f"\n  -> {summary_path.name}")
+    print(f"\n=== Fertig: {len(results)} Agents in {total_time}s ===")
+
+    # Fehler-Summary
+    errors = [r for r in results if r["status"] != "success"]
+    if errors:
+        print(f"\n  WARNUNG: {len(errors)} Agent(s) fehlgeschlagen:")
+        for e in errors:
+            print(f"    - {e['agent']}: {e['content'][:100]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/findings/AGENTS.md
+++ b/scripts/findings/AGENTS.md
@@ -1,0 +1,55 @@
+# Findings-Subsystem — Hinweise für Sub-Agents
+
+Dieses Verzeichnis enthält das Findings-Backlog-System.
+
+## Wichtige Regeln (aus Spec D-Entscheidungen)
+
+- Pure Python + Pydantic, KEIN LangGraph/LlamaIndex/CrewAI (D15)
+- Map-Reduce-Manage-Pattern: parallel children, single-threaded manager (D13)
+- /finding-fix ist ein deterministischer DAG, KEIN ReAct-Loop (D14)
+- Sovereign-First Routing mit Auto-Fallback (D4)
+- Sichtfeld-Klausel in Prompts: "fehlt komplett" → Severity Low + Tag (D19)
+- Sub-Agent muss IMMER Code aus echtem File lesen, nicht Bot-Beschreibung trauen (D21)
+- Symbol-Suche als Pfad-Fallback (D22)
+- AKs Pflicht ab severity=medium (D3)
+
+## Datenfluss
+
+```
+reviews/*.md (Bot-Output)  →  extract_findings.py  →  docs/findings/F-*.md + INDEX.md
+                                                              │
+                                                              ▼
+                                                       /finding-fix F-042
+                                                              │
+                                                              ▼
+                                       finding_fix.py (DAG-Orchestrator)
+                                                              │
+                              ┌───────────────────────────────┤
+                              ▼                               │
+                      verify_path → read_affected_files       │
+                              │                               │
+                              ▼                               │
+                      judge_necessity → apply_fix             │
+                              │                               │
+                              ▼                               │
+                      run_tests → update_index ──── commit ───┘
+```
+
+## Modell-Routing (4.1 im Spec)
+
+| Severity | Default | Fallback bei Tool-Fail |
+|----------|---------|------------------------|
+| low      | qwen-3.5-122b-sovereign FREE | claude-haiku-4-5 |
+| medium   | qwen-3.5-122b-sovereign FREE | claude-haiku-4-5 |
+| high     | claude-sonnet-4-6 | (kein Fallback nötig) |
+| critical | claude-opus-4-6 + Mensch-Review | – |
+
+## Sampling-Parameter (4.0 im Spec)
+
+| Modell | temp | top_p | top_k | enable_thinking |
+|--------|------|-------|-------|-----------------|
+| qwen-3.5-122b-sovereign | 0.6 | 0.95 | 20 | True |
+| qwen3-coder-480b | 1.0 | 0.95 | 20 | True |
+| claude-haiku/sonnet/opus | 0.5–0.7 | 0.95 | – | – |
+
+WARNUNG: Greedy-Decoding (temp=0) bei Qwen3 vermeiden — endless repetitions.

--- a/scripts/findings/README.md
+++ b/scripts/findings/README.md
@@ -1,0 +1,111 @@
+# Findings Backlog System
+
+> Spec: `docs/superpowers/specs/2026-03-17-findings-backlog-system-design.md`
+> Plan: `docs/superpowers/plans/2026-03-17-findings-backlog-system-implementation.md`
+
+## Was ist das?
+
+Ein automatisiertes System, das Bot-Reviews aus `reviews/` in einen aktionierbaren
+Backlog (`docs/findings/INDEX.md`) verwandelt und einzelne Findings via `/finding-fix F-XXX`
+durch ein deterministisches DAG fixt — mit Sovereign-First-Routing für maximale
+Token-Effizienz.
+
+## Quick Start
+
+```bash
+# 1. Backlog initial füllen (einmalig, ~10-30 min für 30+ Reviews)
+npm run findings:extract
+
+# 2. Status anschauen
+npm run findings:status
+
+# 3. Einen Fix anwenden (in Claude Code)
+/finding-fix F-042
+
+# 4. Nach 4 Wochen: Routing-Statistik
+npm run findings:routing-stats
+```
+
+## Architecture
+
+- **Pure Python + Pydantic** (kein Framework-Lock-in)
+- **Map-Reduce-Manage**: parallel children (Bots) + single-threaded manager (Extractor)
+- **Deterministischer DAG** für `/finding-fix` (kein autonomer ReAct-Loop)
+
+### DAG-Pipeline für /finding-fix
+
+```
+load_finding → verify_path → read_affected_files → judge_necessity
+                                                    │
+                                                    ▼
+                                              apply_fix
+                                                    │
+                                                    ▼
+                                              run_tests
+                                                    │
+                                              ┌─────┴─────┐
+                                            pass         fail
+                                              │           │
+                                              ▼           ▼
+                                        update_index   fallback
+                                                          │
+                                                          ▼
+                                                  retry with claude-haiku-4-5
+```
+
+## Modell-Routing
+
+| Severity | Modell | Tier |
+|----------|--------|------|
+| low/medium | qwen-3.5-122b-sovereign | FREE |
+| high | claude-sonnet-4-6 | $ |
+| critical | claude-opus-4-6 + Mensch-Review | $$ |
+
+Auto-Fallback bei Tool-Fail: Sovereign → claude-haiku-4-5.
+
+## Sampling-Parameter (Spec 4.0)
+
+| Modell | temp | top_p | top_k | thinking |
+|--------|------|-------|-------|----------|
+| qwen-3.5-122b-sovereign | 0.6 | 0.95 | 20 | True |
+| qwen3-coder-480b | 1.0 | 0.95 | 20 | True |
+| claude-* | 0.5–0.7 | 0.95 | – | – |
+
+⚠️ Niemals greedy decoding (temp=0) bei Qwen3 — endless repetitions.
+
+## Spec-Referenzen
+
+- D3: AKs Pflicht ab severity=medium
+- D13: Map-Reduce-Manage
+- D14: Deterministic DAG
+- D15: Pure Python + Pydantic (kein LangGraph)
+- D16: Sampling-Parameter pro Modell
+- D18: SELF_CHECK in System-Prompts
+- D19/D20: Sichtfeld-Klausel + erweiterte focus_dirs
+- D21: Sub-Agent liest echten Code, nicht Bot-Beschreibung
+- D22: Symbol-Search-Fallback bei Pfad-Ungenauigkeit
+
+## Module-Übersicht
+
+- `lib/models.py` — Pydantic Models (Severity, Status, Finding, FindingFixState)
+- `lib/aihub_client.py` — AI Hub LiteLLM-Proxy mit modell-spezifischen Sampling-Params
+- `lib/routing.py` — Severity → Modell-Mapping mit Auto-Fallback
+- `lib/jsonl_logger.py` — JSONL-Logger für Audit-Log
+- `lib/git_helpers.py` — git rev-parse / diff Wrapper
+- `lib/symbol_search.py` — grep-Fallback bei Pfad-Ungenauigkeit (D22)
+- `lib/frontmatter.py` — YAML-Frontmatter Parser/Writer
+- `dag_nodes/` — DAG-Knoten für /finding-fix
+- `extract_findings.py` — Phase 1 Extractor
+- `validate_review_freshness.py` — Phase 0a Stale-Detection
+- `finding_fix.py` — DAG-Orchestrator
+- `findings_status.py` + `findings_routing_stats.py` — Dashboards
+
+## Bot-Qualitäts-Baseline (empirisch, n=12)
+
+- Code-Befund verifiziert: **75 %**
+- Severity-Einstufung korrekt: **42 %**
+- Pfad-Genauigkeit: **83 %**
+- Echte Halluzination: **0 %**
+- Critical False Positives: **~8 %** (durch Sichtfeld-Beschränkung — D19 mitigates)
+
+→ Phase-2-Quality-Check ist Pflicht (Mensch korrigiert Severity vor `status: open`).

--- a/scripts/findings/README.md
+++ b/scripts/findings/README.md
@@ -13,14 +13,23 @@ Token-Effizienz.
 ## Quick Start
 
 ```bash
-# 1. Backlog initial füllen (einmalig, ~10-30 min für 30+ Reviews)
+# 1. Backlog initial füllen — variant A (alle Reviews auf einmal):
 npm run findings:extract
+# WARNUNG: Sequenzielle LLM-Calls (~30-90s pro Review × 30+ Reviews = 15-45 min).
+# Bei Hangs: Strg+C, dann auf Single-File-Mode wechseln (siehe unten).
+
+# 1b. Backlog initial füllen — variant B (resilient, Datei für Datei):
+PYTHONPATH=scripts python3 -m findings.extract_findings reviews/ \
+  --findings-dir docs/findings \
+  --single reviews/2026-05-07_2053_architecture.md
+# Wiederhole für jede Review-Datei einzeln. Hängende Calls killbar mit Strg+C.
 
 # 2. Status anschauen
 npm run findings:status
 
 # 3. Einen Fix anwenden (in Claude Code)
 /finding-fix F-042
+# Hard-Timeout: 300s (R7). Bei hängenden LLM-Calls bricht das DAG ab.
 
 # 4. Nach 4 Wochen: Routing-Statistik
 npm run findings:routing-stats
@@ -99,6 +108,23 @@ Auto-Fallback bei Tool-Fail: Sovereign → claude-haiku-4-5.
 - `validate_review_freshness.py` — Phase 0a Stale-Detection
 - `finding_fix.py` — DAG-Orchestrator
 - `findings_status.py` + `findings_routing_stats.py` — Dashboards
+
+## Operationelle Caveats
+
+### Sequenzielle Extraction
+`extract_findings.py` ruft pro Review-File EINEN LLM-Call sequenziell auf. Bei 30+ Reviews
+und qwen-3.5-122b-sovereign mit Thinking-Mode (~30-90s pro Call) läuft die volle Extraction
+**15-45 Minuten**. Es gibt keine Parallelität — bewusst, weil:
+
+1. Map-Reduce-Manage (D13): paralleles Schreiben in INDEX.md würde Race Conditions schaffen
+2. AI Hub Free-Tier hat Throttling-Limits, die Parallel-Calls blockieren würden (404er, 504er Gateway-Timeouts)
+
+**Recovery bei Hang**: Strg+C, dann mit `--single <file>` Datei für Datei nachholen.
+
+### /finding-fix Hard-Timeout
+`HARD_TIMEOUT_S = 300` (5 Min) im DAG-Orchestrator. Hängende LLM-Calls werden nach 5 Min
+abgebrochen — Finding bleibt im Status `open`, kein partieller Commit. Logs landen in
+`.claude/logs/finding-fixes.jsonl`.
 
 ## Bot-Qualitäts-Baseline (empirisch, n=12)
 

--- a/scripts/findings/dag_nodes/apply_fix.py
+++ b/scripts/findings/dag_nodes/apply_fix.py
@@ -1,0 +1,80 @@
+"""DAG node: apply the fix proposed by the LLM to the real file."""
+from __future__ import annotations
+import json
+import os
+from pathlib import Path
+from ..lib.models import FindingFixState
+from ..lib.aihub_client import AIHubClient
+
+
+_APPLY_SYSTEM_PROMPT = """Du bist ein präziser Code-Editor. Gegeben ein Finding und der ECHTE Code,
+schreibe den minimalsten Fix.
+
+Antworte NUR mit JSON: {"new_content": "<gesamter neuer Datei-Inhalt>", "diff": "<unified diff snippet>"}
+
+Regeln:
+- Ändere NUR die Stellen die das Finding adressiert
+- Behalte Code-Style, Indentation, Imports
+- Schreibe KEINE Kommentare wie "// Fix für F-XXX"
+- Bei Test-Datei: Test wird in Task 14 (run_tests) separat geprüft
+"""
+
+
+def _call_apply_llm(routing, finding_text: str, code_text: str) -> str:
+    if routing.provider == "aihub":
+        client = AIHubClient()
+        result = client.chat(
+            model=routing.model,
+            messages=[
+                {"role": "system", "content": _APPLY_SYSTEM_PROMPT},
+                {"role": "user", "content": f"## Finding\n{finding_text}\n\n## Code\n```\n{code_text}\n```"},
+            ],
+            max_tokens=8000,
+        )
+        return result["content"]
+    else:
+        from anthropic import Anthropic
+        client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        msg = client.messages.create(
+            model=f"claude-{routing.model}",
+            max_tokens=8000,
+            system=_APPLY_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": f"## Finding\n{finding_text}\n\n## Code\n```\n{code_text}\n```"}],
+        )
+        return msg.content[0].text
+
+
+def apply_fix(state: FindingFixState, *, repo_root: str | Path) -> FindingFixState:
+    if not state.is_still_valid:
+        state.fix_applied = False
+        return state
+
+    repo_root = Path(repo_root)
+    finding_text = f"{state.finding.title}\nAcceptance: {state.finding.acceptance_criteria}"
+    # Single-file-fix only for v1 (multi-file in future Phase 4)
+    if state.path_resolved is None or state.path_resolved not in state.file_contents:
+        state.fix_applied = False
+        return state
+    code_text = state.file_contents[state.path_resolved]
+
+    raw = _call_apply_llm(state.routing, finding_text, code_text)
+    raw = raw.strip().strip("`")
+    if raw.startswith("json"):
+        raw = raw[4:].strip()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        state.fix_applied = False
+        state.tool_call_errors += 1
+        return state
+
+    new_content = data.get("new_content", "")
+    if not new_content:
+        state.fix_applied = False
+        return state
+
+    target = repo_root / state.path_resolved
+    target.write_text(new_content, encoding="utf-8")
+    state.fix_applied = True
+    state.fix_diff = data.get("diff", "")
+    return state

--- a/scripts/findings/dag_nodes/apply_fix.py
+++ b/scripts/findings/dag_nodes/apply_fix.py
@@ -2,9 +2,49 @@
 from __future__ import annotations
 import json
 import os
+import re
 from pathlib import Path
 from ..lib.models import FindingFixState
 from ..lib.aihub_client import AIHubClient
+
+
+def _parse_llm_json(raw: str) -> dict | None:
+    """Extract a JSON object from an LLM response.
+
+    Handles three common Qwen3-Thinking-Mode wrappers:
+    1. <think>...</think> blocks (strip everything inside think tags)
+    2. ```json ... ``` code fences
+    3. Free-form text around a single {...} object (extract first balanced object)
+
+    Returns None if no parseable JSON object is found.
+    """
+    s = raw.strip()
+    # Strip <think>...</think> blocks
+    s = re.sub(r"<think>.*?</think>", "", s, flags=re.DOTALL).strip()
+    # Strip ```json ... ``` or ``` ... ``` fences
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"\s*```$", "", s).strip()
+    # Try direct parse
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        pass
+    # Fallback: extract first balanced {...} object
+    start = s.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "{":
+            depth += 1
+        elif s[i] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(s[start : i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
 
 
 _APPLY_SYSTEM_PROMPT = """Du bist ein präziser Code-Editor. Gegeben ein Finding und der ECHTE Code,
@@ -57,13 +97,22 @@ def apply_fix(state: FindingFixState, *, repo_root: str | Path) -> FindingFixSta
         return state
     code_text = state.file_contents[state.path_resolved]
 
-    raw = _call_apply_llm(state.routing, finding_text, code_text)
-    raw = raw.strip().strip("`")
-    if raw.startswith("json"):
-        raw = raw[4:].strip()
+    from ..lib.aihub_client import AIHubError
     try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
+        raw = _call_apply_llm(state.routing, finding_text, code_text)
+    except AIHubError as e:
+        # Provider 504 / network glitch / rate limit. Increment counter so the
+        # orchestrator's auto-fallback path triggers.
+        state.fix_applied = False
+        state.tool_call_errors += 1
+        return state
+    except Exception:
+        # Unknown error — also count as tool error to enable fallback.
+        state.fix_applied = False
+        state.tool_call_errors += 1
+        return state
+    data = _parse_llm_json(raw)
+    if data is None:
         state.fix_applied = False
         state.tool_call_errors += 1
         return state

--- a/scripts/findings/dag_nodes/apply_fix.py
+++ b/scripts/findings/dag_nodes/apply_fix.py
@@ -63,13 +63,16 @@ Regeln:
 def _call_apply_llm(routing, finding_text: str, code_text: str) -> str:
     if routing.provider == "aihub":
         client = AIHubClient()
+        # max_tokens=2000 (was 8000): empirically validated 2026-05-08 — Qwen-Thinking
+        # at 8000 tokens × ~30 tokens/sec = 4-5 min → LiteLLM-Proxy gateway timeout 504.
+        # 2000 fits structured JSON-fix output AND the thinking block in <90s.
         result = client.chat(
             model=routing.model,
             messages=[
                 {"role": "system", "content": _APPLY_SYSTEM_PROMPT},
                 {"role": "user", "content": f"## Finding\n{finding_text}\n\n## Code\n```\n{code_text}\n```"},
             ],
-            max_tokens=8000,
+            max_tokens=2000,
         )
         return result["content"]
     else:

--- a/scripts/findings/dag_nodes/judge_necessity.py
+++ b/scripts/findings/dag_nodes/judge_necessity.py
@@ -24,13 +24,15 @@ def _call_judge_llm(routing, finding_text: str, code_text: str) -> str:
     """Call the routed LLM (claude or aihub) for the judge step."""
     if routing.provider == "aihub":
         client = AIHubClient()
+        # max_tokens=500 (was 2000): judge produces a tiny JSON {is_still_valid, reasoning}.
+        # Smaller budget keeps Qwen-Thinking total output under the gateway timeout.
         result = client.chat(
             model=routing.model,
             messages=[
                 {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
                 {"role": "user", "content": f"## Finding\n{finding_text}\n\n## Aktueller Code\n```\n{code_text}\n```"},
             ],
-            max_tokens=2000,
+            max_tokens=500,
         )
         return result["content"]
     else:
@@ -59,11 +61,19 @@ def judge_necessity(state: FindingFixState) -> FindingFixState:
         state.judge_reasoning = f"Judge LLM unreachable ({type(e).__name__}); defaulting to valid."
         state.tool_call_errors += 1
         return state
-    raw = raw.strip().strip("`")
-    if raw.startswith("json"):
-        raw = raw[4:].strip()
+    if not raw:
+        # Empty response (Qwen sometimes returns thinking-only with empty content
+        # despite our normalisation). Conservative: assume still valid.
+        state.is_still_valid = True
+        state.judge_reasoning = "Judge LLM returned empty content; defaulting to valid."
+        return state
+    # Strip <think>…</think>, ```json fences, then parse.
+    import re as _re
+    s = _re.sub(r"<think>.*?</think>", "", raw, flags=_re.DOTALL).strip()
+    s = _re.sub(r"^```(?:json)?\s*", "", s)
+    s = _re.sub(r"\s*```$", "", s).strip()
     try:
-        data = json.loads(raw)
+        data = json.loads(s)
     except json.JSONDecodeError:
         # Conservative: if judge can't speak JSON, assume still valid and let apply_fix decide
         state.is_still_valid = True

--- a/scripts/findings/dag_nodes/judge_necessity.py
+++ b/scripts/findings/dag_nodes/judge_necessity.py
@@ -47,9 +47,18 @@ def _call_judge_llm(routing, finding_text: str, code_text: str) -> str:
 
 
 def judge_necessity(state: FindingFixState) -> FindingFixState:
+    from ..lib.aihub_client import AIHubError
     finding_text = f"{state.finding.title}\n{state.finding.area}\nFile: {state.finding.file}"
     code_text = "\n".join(f"# {p}\n{c}" for p, c in state.file_contents.items())
-    raw = _call_judge_llm(state.routing, finding_text, code_text)
+    try:
+        raw = _call_judge_llm(state.routing, finding_text, code_text)
+    except (AIHubError, Exception) as e:
+        # Provider 504 / network glitch / rate limit. Conservative: assume still
+        # valid (apply_fix will decide); count as tool error to enable fallback.
+        state.is_still_valid = True
+        state.judge_reasoning = f"Judge LLM unreachable ({type(e).__name__}); defaulting to valid."
+        state.tool_call_errors += 1
+        return state
     raw = raw.strip().strip("`")
     if raw.startswith("json"):
         raw = raw[4:].strip()

--- a/scripts/findings/dag_nodes/judge_necessity.py
+++ b/scripts/findings/dag_nodes/judge_necessity.py
@@ -1,0 +1,65 @@
+"""DAG node: judge whether a finding is still valid against current code.
+
+This is the LLM step where we DON'T trust the bot-description (D21).
+The judge sees the REAL file contents (state.file_contents) and decides:
+- 'still_valid: true' → proceed to apply_fix
+- 'still_valid: false' → mark Finding archived (obsolete) and stop
+"""
+from __future__ import annotations
+import json
+import os
+from ..lib.models import FindingFixState
+from ..lib.aihub_client import AIHubClient
+
+
+_JUDGE_SYSTEM_PROMPT = """Du bist ein Code-Judge. Ein Finding wurde von einem Reviewer-Bot
+gemeldet. Deine Aufgabe: Anhand des ECHTEN Code-Inhalts entscheiden, ob das Finding
+noch valide ist (Code-Stand könnte sich seit Review geändert haben).
+
+Antworte NUR mit JSON: {"is_still_valid": true|false, "reasoning": "<kurz>"}
+"""
+
+
+def _call_judge_llm(routing, finding_text: str, code_text: str) -> str:
+    """Call the routed LLM (claude or aihub) for the judge step."""
+    if routing.provider == "aihub":
+        client = AIHubClient()
+        result = client.chat(
+            model=routing.model,
+            messages=[
+                {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
+                {"role": "user", "content": f"## Finding\n{finding_text}\n\n## Aktueller Code\n```\n{code_text}\n```"},
+            ],
+            max_tokens=2000,
+        )
+        return result["content"]
+    else:
+        # Claude
+        from anthropic import Anthropic
+        client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        msg = client.messages.create(
+            model=f"claude-{routing.model}",
+            max_tokens=2000,
+            system=_JUDGE_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": f"## Finding\n{finding_text}\n\n## Code\n```\n{code_text}\n```"}],
+        )
+        return msg.content[0].text
+
+
+def judge_necessity(state: FindingFixState) -> FindingFixState:
+    finding_text = f"{state.finding.title}\n{state.finding.area}\nFile: {state.finding.file}"
+    code_text = "\n".join(f"# {p}\n{c}" for p, c in state.file_contents.items())
+    raw = _call_judge_llm(state.routing, finding_text, code_text)
+    raw = raw.strip().strip("`")
+    if raw.startswith("json"):
+        raw = raw[4:].strip()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Conservative: if judge can't speak JSON, assume still valid and let apply_fix decide
+        state.is_still_valid = True
+        state.judge_reasoning = "Judge LLM returned non-JSON; defaulting to valid."
+        return state
+    state.is_still_valid = bool(data.get("is_still_valid"))
+    state.judge_reasoning = data.get("reasoning", "")
+    return state

--- a/scripts/findings/dag_nodes/read_affected_files.py
+++ b/scripts/findings/dag_nodes/read_affected_files.py
@@ -1,0 +1,22 @@
+"""DAG node: read the resolved file into state (D21).
+
+This ensures the LLM works with REAL file contents, not the bot-snippet
+which may contain hallucinated paths or stale code.
+"""
+from __future__ import annotations
+from pathlib import Path
+from ..lib.models import FindingFixState
+
+
+def read_affected_files(state: FindingFixState, *, repo_root: str | Path, max_chars: int = 50000) -> FindingFixState:
+    """Read resolved file and any related-finding files into state.file_contents."""
+    repo_root = Path(repo_root)
+    if not state.path_resolved:
+        return state
+    full = repo_root / state.path_resolved
+    if full.is_file():
+        content = full.read_text(errors="replace")
+        if len(content) > max_chars:
+            content = content[:max_chars] + f"\n\n... (truncated at {max_chars} chars)"
+        state.file_contents[state.path_resolved] = content
+    return state

--- a/scripts/findings/dag_nodes/run_tests.py
+++ b/scripts/findings/dag_nodes/run_tests.py
@@ -1,0 +1,38 @@
+"""DAG node: run vitest (TS) or pytest (Py) and capture result."""
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from ..lib.models import FindingFixState
+
+
+def run_tests(state: FindingFixState, *, repo_root: str | Path, timeout: int = 300) -> FindingFixState:
+    """Run npm test (vitest) and/or pytest. Pass = both green (or only one configured)."""
+    if not state.fix_applied:
+        return state
+
+    repo_root = Path(repo_root)
+    cmds = []
+    if (repo_root / "package.json").is_file():
+        cmds.append(["npm", "test", "--", "--run"])
+    if (repo_root / "pyproject.toml").is_file() or (repo_root / "pytest.ini").is_file():
+        cmds.append(["python3", "-m", "pytest", "--quiet"])
+
+    # Fallback: if no config files detected (e.g. in tests), try both runners.
+    if not cmds:
+        cmds = [["npm", "test", "--", "--run"]]
+
+    all_pass = True
+    output_chunks: list[str] = []
+    for cmd in cmds:
+        try:
+            proc = subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, timeout=timeout)
+            output_chunks.append(f"$ {' '.join(cmd)}\n{proc.stdout}{proc.stderr}")
+            if proc.returncode != 0:
+                all_pass = False
+        except subprocess.TimeoutExpired:
+            all_pass = False
+            output_chunks.append(f"$ {' '.join(cmd)}\nTIMEOUT after {timeout}s")
+
+    state.tests_pass = all_pass
+    state.test_output = "\n\n".join(output_chunks)
+    return state

--- a/scripts/findings/dag_nodes/update_index.py
+++ b/scripts/findings/dag_nodes/update_index.py
@@ -1,0 +1,35 @@
+"""DAG node: update INDEX.md and per-finding frontmatter after fix."""
+from __future__ import annotations
+import re
+from datetime import date
+from pathlib import Path
+from ..lib.frontmatter import parse_frontmatter, write_frontmatter
+from ..lib.models import Status
+
+
+def update_finding_status(finding_path: str | Path, *, status: Status, commit_sha: str | None = None) -> None:
+    """Rewrite a per-finding markdown file with new status + (optional) commit-sha."""
+    p = Path(finding_path)
+    fm, body = parse_frontmatter(p.read_text())
+    fm["status"] = status.value
+    if status == Status.FIXED:
+        fm["fixed_at"] = date.today().isoformat()
+        if commit_sha:
+            fm["fixed_in_commit"] = commit_sha
+    p.write_text(write_frontmatter(fm, body))
+
+
+def regenerate_index(findings_dir: str | Path) -> None:
+    """Rebuild INDEX.md from all F-*.md files in findings_dir."""
+    findings_dir = Path(findings_dir)
+    severity_icon = {"critical": "⚫", "high": "🔴", "medium": "🟠", "low": "🟡"}
+    rows = ["| ID | Sev | Area | Title | File | Effort | Status |",
+            "|----|-----|------|-------|------|--------|--------|"]
+    for f_path in sorted(findings_dir.glob("F-*.md")):
+        fm, _ = parse_frontmatter(f_path.read_text())
+        rows.append(
+            f"| {fm.get('id','?')} | {severity_icon.get(fm.get('severity','low'),'?')} | "
+            f"{fm.get('area','?')} | {fm.get('title','?')} | {fm.get('file','?')} | "
+            f"{fm.get('effort','-')} | {fm.get('status','open')} |"
+        )
+    (findings_dir / "INDEX.md").write_text("# Findings Backlog\n\n" + "\n".join(rows) + "\n")

--- a/scripts/findings/dag_nodes/verify_path.py
+++ b/scripts/findings/dag_nodes/verify_path.py
@@ -1,0 +1,43 @@
+"""DAG node: verify the finding's file path, with symbol_search fallback (D22)."""
+from __future__ import annotations
+import re
+from pathlib import Path
+from ..lib.models import FindingFixState
+from ..lib.symbol_search import find_symbol
+
+
+def _extract_symbol(file_field: str) -> str | None:
+    """Extract symbol after ':' (e.g. 'src/x.ts:funcName' → 'funcName')."""
+    if ":" in file_field:
+        return file_field.rsplit(":", 1)[1].strip()
+    return None
+
+
+def verify_path(state: FindingFixState, *, repo_root: str | Path) -> FindingFixState:
+    """Try exact-path-match. If fail, try symbol_search. Updates state in-place-style."""
+    repo_root = Path(repo_root)
+    raw_path = state.finding.file
+    # Strip line-suffix like ":42" or ":42-58" (keep 'symbol' if non-numeric)
+    path_only = re.sub(r":\d+(-\d+)?$", "", raw_path)
+    # Strip symbol-suffix like ":funcName"
+    if ":" in path_only and not re.search(r"\.\w+:\d", path_only):
+        # path_only might be "src/x.ts:funcName" → keep "src/x.ts"
+        path_only = path_only.rsplit(":", 1)[0]
+
+    full = repo_root / path_only
+    if full.is_file():
+        state.path_resolved = path_only
+        state.path_resolution_method = "exact"
+        return state
+
+    # Fallback: symbol search
+    symbol = _extract_symbol(raw_path)
+    if symbol:
+        hits = find_symbol(symbol, search_root=repo_root)
+        if hits:
+            state.path_resolved = str(Path(hits[0].path).relative_to(repo_root))
+            state.path_resolution_method = "symbol_search"
+            return state
+
+    state.path_resolution_method = "failed"
+    return state

--- a/scripts/findings/dag_nodes/verify_path.py
+++ b/scripts/findings/dag_nodes/verify_path.py
@@ -30,12 +30,24 @@ def verify_path(state: FindingFixState, *, repo_root: str | Path) -> FindingFixS
         state.path_resolution_method = "exact"
         return state
 
-    # Fallback: symbol search
+    # Fallback 1: explicit symbol search (e.g. "src/x.ts:funcName")
     symbol = _extract_symbol(raw_path)
     if symbol:
         hits = find_symbol(symbol, search_root=repo_root)
         if hits:
             state.path_resolved = str(Path(hits[0].path).relative_to(repo_root))
+            state.path_resolution_method = "symbol_search"
+            return state
+
+    # Fallback 2: basename search (e.g. "src/components/X.tsx" might live in "src/components/ui/X.tsx")
+    basename = Path(path_only).stem  # "ConnectionStatusBar" from "ConnectionStatusBar.tsx"
+    if basename and len(basename) >= 3:  # avoid matching trivial names
+        hits = find_symbol(basename, search_root=repo_root / "src")
+        # Filter to files whose name matches the original basename
+        target_filename = Path(path_only).name  # "ConnectionStatusBar.tsx"
+        name_matches = [h for h in hits if Path(h.path).name == target_filename]
+        if name_matches:
+            state.path_resolved = str(Path(name_matches[0].path).relative_to(repo_root))
             state.path_resolution_method = "symbol_search"
             return state
 

--- a/scripts/findings/extract_findings.py
+++ b/scripts/findings/extract_findings.py
@@ -132,16 +132,38 @@ def write_finding_files(findings: List[Finding], *, findings_dir: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     argv = argv or sys.argv[1:]
     if not argv:
-        print("Usage: extract_findings.py <reviews-dir> [--findings-dir docs/findings]", file=sys.stderr)
+        print(
+            "Usage: extract_findings.py <reviews-dir> [--findings-dir docs/findings] [--single <review.md>]",
+            file=sys.stderr,
+        )
         return 2
 
     reviews_dir = Path(argv[0])
-    findings_dir = Path(argv[2]) if len(argv) > 2 and argv[1] == "--findings-dir" else Path("docs/findings")
+
+    # Parse optional flags
+    findings_dir = Path("docs/findings")
+    single_file: Path | None = None
+    i = 1
+    while i < len(argv):
+        if argv[i] == "--findings-dir" and i + 1 < len(argv):
+            findings_dir = Path(argv[i + 1])
+            i += 2
+        elif argv[i] == "--single" and i + 1 < len(argv):
+            single_file = Path(argv[i + 1])
+            i += 2
+        else:
+            i += 1
+
+    if single_file:
+        review_paths = [single_file]
+    else:
+        review_paths = [
+            p for p in sorted(reviews_dir.glob("*.md"))
+            if not p.name.endswith("SUMMARY.md") and not p.name.startswith("_")
+        ]
 
     all_findings: List[Finding] = []
-    for review_path in sorted(reviews_dir.glob("*.md")):
-        if review_path.name.endswith("SUMMARY.md") or review_path.name.startswith("_"):
-            continue
+    for review_path in review_paths:
         review_text = review_path.read_text(errors="replace")
         try:
             findings = extract_from_review(review_text, source=str(review_path), existing_ids=[f.id for f in all_findings])
@@ -150,7 +172,8 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as e:
             print(f"  {review_path.name}: ERROR — {e}", file=sys.stderr)
 
-    write_finding_files(all_findings, findings_dir=findings_dir)
+    if all_findings:
+        write_finding_files(all_findings, findings_dir=findings_dir)
     print(f"\nTotal findings: {len(all_findings)} written to {findings_dir}/")
     return 0
 

--- a/scripts/findings/extract_findings.py
+++ b/scripts/findings/extract_findings.py
@@ -1,0 +1,159 @@
+"""Phase 1: Extract structured findings from bot review markdown.
+
+Pattern: Map-Reduce-Manage (D13) — one bot-review = one batch of findings.
+LLM extracts a JSON array, we validate and write per-finding files + update INDEX.
+
+Sichtfeld-Klausel (D19): If the bot wrote 'fehlt komplett' or 'nicht im Code sichtbar',
+the extractor must rewrite that as severity=low + tag 'requires_cross_check'.
+"""
+from __future__ import annotations
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from typing import List
+
+from .lib.aihub_client import AIHubClient
+from .lib.frontmatter import write_frontmatter
+from .lib.models import Finding, Severity, Status
+
+
+_EXTRACTOR_SYSTEM_PROMPT = """Du bist ein Findings-Extractor. Aus einem Code-Review-Markdown
+extrahierst du strukturierte Findings als JSON-Array.
+
+PFLICHT: Antworte NUR mit einem JSON-Array, keine anderen Worte. Keine Erklärungen.
+
+Pro Finding folgende Felder:
+- severity: "critical" | "high" | "medium" | "low"
+- area: "architecture" | "security" | "data" | "perf" | "ux" | "a11y" | "testing" | "doc" | "other"
+- title: prägnanter Titel (max 80 Zeichen)
+- file: Datei-Pfad relativ zum Repo-Root (z.B. "src/foo.ts")
+- lines: optional, z.B. "42-58"
+- effort: optional, z.B. "30m", "2h"
+- problem: 1-2 Sätze
+- reproduction: konkreter grep/test-Befehl
+- fix_proposal: kurze Beschreibung
+- acceptance_criteria: Liste von 2-4 prüfbaren Kriterien (Pflicht ab severity=medium)
+
+KRITISCHE REGELN (D19, Sichtfeld):
+- Wenn das Review schreibt "fehlt komplett" / "nicht im Code sichtbar" / "existiert nicht":
+  setze severity="low" und füge ans Ende des problem-Feldes "[REQUIRES_CROSS_CHECK]" hinzu.
+  Begründung: Bots haben begrenzte focus_dirs und können fälschlich "fehlt" sagen.
+
+- Wenn das Review nur eine Score-Zahl liefert (z.B. "7.5/10"): KEIN Finding extrahieren.
+- Wenn der Pfad nur ein Verzeichnis ist (z.B. "src/core/generators/"): KEIN Finding,
+  weil zu vage.
+
+KONSERVATIV einstufen:
+- Severity=critical NUR bei Security-Lücken oder Datenverlust-Risiken
+- "useRef ohne offensichtlichen Cleanup" → high, NICHT critical
+
+OUTPUT: Pure JSON, mit `[` beginnen und `]` enden.
+"""
+
+
+def _next_finding_id(existing_ids: List[str]) -> str:
+    """Return next ID like F-042."""
+    nums = [int(re.match(r"F-(\d+)", x).group(1)) for x in existing_ids if re.match(r"F-(\d+)", x)]
+    nxt = (max(nums) + 1) if nums else 1
+    return f"F-{nxt:03d}"
+
+
+def _call_llm_extract(review_text: str) -> str:
+    """Call AI Hub for extraction. Separate function for testability (mockable)."""
+    client = AIHubClient()
+    msg = [
+        {"role": "system", "content": _EXTRACTOR_SYSTEM_PROMPT},
+        {"role": "user", "content": f"# Review-Markdown\n\n{review_text}"},
+    ]
+    result = client.chat(model="qwen-3.5-122b-sovereign", messages=msg, max_tokens=8000)
+    return result["content"]
+
+
+def extract_from_review(review_text: str, *, source: str, existing_ids: List[str] | None = None) -> List[Finding]:
+    """Extract Finding objects from a single bot-review markdown."""
+    existing_ids = existing_ids or []
+    raw = _call_llm_extract(review_text)
+    raw = raw.strip()
+    # Strip code fences if LLM wrapped output
+    raw = re.sub(r"^```(?:json)?\s*", "", raw)
+    raw = re.sub(r"\s*```$", "", raw)
+    items = json.loads(raw)
+
+    findings: List[Finding] = []
+    for item in items:
+        fid = _next_finding_id(existing_ids + [f.id for f in findings])
+        findings.append(Finding(
+            id=fid,
+            severity=Severity(item["severity"]),
+            area=item["area"],
+            title=item["title"],
+            file=item["file"],
+            lines=item.get("lines"),
+            effort=item.get("effort"),
+            status=Status.OPEN,
+            source=source,
+            detected=date.today(),
+            related=[],
+            parent=None,
+            model_routing=None,
+            acceptance_criteria=item.get("acceptance_criteria", []),
+        ))
+    return findings
+
+
+def write_finding_files(findings: List[Finding], *, findings_dir: Path) -> None:
+    """Write per-finding markdown files and update INDEX.md."""
+    findings_dir = Path(findings_dir)
+    findings_dir.mkdir(parents=True, exist_ok=True)
+
+    for f in findings:
+        fm = f.model_dump(mode="json")
+        body = f"# {f.title}\n\n## Problem\n<extracted by extractor>\n\n## Akzeptanzkriterien\n"
+        for ak in f.acceptance_criteria:
+            body += f"- [ ] {ak}\n"
+        (findings_dir / f"{f.id}.md").write_text(write_frontmatter(fm, body), encoding="utf-8")
+
+    # Update INDEX.md
+    index_path = findings_dir / "INDEX.md"
+    rows = ["| ID | Sev | Area | Title | File | Effort | Status |",
+            "|----|-----|------|-------|------|--------|--------|"]
+    severity_icon = {"critical": "⚫", "high": "🔴", "medium": "🟠", "low": "🟡"}
+    for f in findings:
+        rows.append(
+            f"| {f.id} | {severity_icon[f.severity.value]} | {f.area} | {f.title} | "
+            f"{f.file} | {f.effort or '-'} | {f.status.value} |"
+        )
+    header = "# Findings Backlog\n\n" + "\n".join(rows) + "\n"
+    index_path.write_text(header)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("Usage: extract_findings.py <reviews-dir> [--findings-dir docs/findings]", file=sys.stderr)
+        return 2
+
+    reviews_dir = Path(argv[0])
+    findings_dir = Path(argv[2]) if len(argv) > 2 and argv[1] == "--findings-dir" else Path("docs/findings")
+
+    all_findings: List[Finding] = []
+    for review_path in sorted(reviews_dir.glob("*.md")):
+        if review_path.name.endswith("SUMMARY.md") or review_path.name.startswith("_"):
+            continue
+        review_text = review_path.read_text(errors="replace")
+        try:
+            findings = extract_from_review(review_text, source=str(review_path), existing_ids=[f.id for f in all_findings])
+            all_findings.extend(findings)
+            print(f"  {review_path.name}: extracted {len(findings)} findings")
+        except Exception as e:
+            print(f"  {review_path.name}: ERROR — {e}", file=sys.stderr)
+
+    write_finding_files(all_findings, findings_dir=findings_dir)
+    print(f"\nTotal findings: {len(all_findings)} written to {findings_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/findings/extract_findings.py
+++ b/scripts/findings/extract_findings.py
@@ -103,30 +103,49 @@ def extract_from_review(review_text: str, *, source: str, existing_ids: List[str
     return findings
 
 
+def existing_finding_ids(findings_dir: Path) -> List[str]:
+    """Return all F-XXX IDs already on disk in findings_dir."""
+    findings_dir = Path(findings_dir)
+    return [fp.stem for fp in findings_dir.glob("F-*.md")]
+
+
 def write_finding_files(findings: List[Finding], *, findings_dir: Path) -> None:
-    """Write per-finding markdown files and update INDEX.md."""
+    """Write per-finding markdown files and rebuild INDEX.md from ALL files on disk.
+
+    Idempotent: writes only the new findings (does NOT overwrite existing F-XXX),
+    then rebuilds INDEX.md by reading every F-*.md present in findings_dir. This
+    is safe under repeated --single invocations.
+    """
     findings_dir = Path(findings_dir)
     findings_dir.mkdir(parents=True, exist_ok=True)
 
     for f in findings:
+        target = findings_dir / f"{f.id}.md"
+        if target.exists():
+            # Defensive: a same-ID file already exists. Skip to avoid clobbering
+            # an unrelated finding (race-safe under --single from multiple shells).
+            print(f"  skipping {f.id}: {target} already exists", file=sys.stderr)
+            continue
         fm = f.model_dump(mode="json")
         body = f"# {f.title}\n\n## Problem\n<extracted by extractor>\n\n## Akzeptanzkriterien\n"
         for ak in f.acceptance_criteria:
             body += f"- [ ] {ak}\n"
-        (findings_dir / f"{f.id}.md").write_text(write_frontmatter(fm, body), encoding="utf-8")
+        target.write_text(write_frontmatter(fm, body), encoding="utf-8")
 
-    # Update INDEX.md
-    index_path = findings_dir / "INDEX.md"
+    # Rebuild INDEX.md from ALL F-*.md files on disk (not just the new ones)
+    from .lib.frontmatter import parse_frontmatter as _parse_fm
+    severity_icon = {"critical": "⚫", "high": "🔴", "medium": "🟠", "low": "🟡"}
     rows = ["| ID | Sev | Area | Title | File | Effort | Status |",
             "|----|-----|------|-------|------|--------|--------|"]
-    severity_icon = {"critical": "⚫", "high": "🔴", "medium": "🟠", "low": "🟡"}
-    for f in findings:
+    for fp in sorted(findings_dir.glob("F-*.md")):
+        fm, _ = _parse_fm(fp.read_text(errors="replace"))
+        sev = fm.get("severity", "low")
         rows.append(
-            f"| {f.id} | {severity_icon[f.severity.value]} | {f.area} | {f.title} | "
-            f"{f.file} | {f.effort or '-'} | {f.status.value} |"
+            f"| {fm.get('id', fp.stem)} | {severity_icon.get(sev, '?')} | "
+            f"{fm.get('area', '?')} | {fm.get('title', '?')} | "
+            f"{fm.get('file', '?')} | {fm.get('effort') or '-'} | {fm.get('status', 'open')} |"
         )
-    header = "# Findings Backlog\n\n" + "\n".join(rows) + "\n"
-    index_path.write_text(header)
+    (findings_dir / "INDEX.md").write_text("# Findings Backlog\n\n" + "\n".join(rows) + "\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -162,11 +181,18 @@ def main(argv: list[str] | None = None) -> int:
             if not p.name.endswith("SUMMARY.md") and not p.name.startswith("_")
         ]
 
+    # Seed with IDs already on disk so --single calls don't collide with existing files.
+    seed_ids = existing_finding_ids(findings_dir)
+
     all_findings: List[Finding] = []
     for review_path in review_paths:
         review_text = review_path.read_text(errors="replace")
         try:
-            findings = extract_from_review(review_text, source=str(review_path), existing_ids=[f.id for f in all_findings])
+            findings = extract_from_review(
+                review_text,
+                source=str(review_path),
+                existing_ids=seed_ids + [f.id for f in all_findings],
+            )
             all_findings.extend(findings)
             print(f"  {review_path.name}: extracted {len(findings)} findings")
         except Exception as e:

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -18,9 +18,14 @@ Flow (Spec section 5.4):
                                                               ▼
                                                       retry with claude-haiku-4-5
 
-Hard-Caps (R7): max_steps=10 internally, max_duration=300s.
+Hard-Caps (R7): max_steps=10 internally, max_duration=300s (HARD_TIMEOUT_S).
+The timeout is enforced via concurrent.futures.ThreadPoolExecutor — NOT signal.alarm,
+because signal.alarm is Unix-only and interferes with pytest (which installs its own
+SIGALRM handler). Python cannot forcibly kill a running thread, so a timed-out thread
+will linger in the background until its LLM call returns; we abort the wait and move on.
 """
 from __future__ import annotations
+import concurrent.futures
 import sys
 import time
 from pathlib import Path
@@ -68,11 +73,24 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
     t0 = time.time()
     state = FindingFixState(finding=finding, routing=routing)
 
+    timed_out = False
     try:
-        state = _run_dag(state, repo_root=repo_root)
-        # Auto-fallback on tool errors or red tests when sovereign was used
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(_run_dag, state, repo_root=repo_root)
+            try:
+                state = future.result(timeout=HARD_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                # Cannot kill the inner thread (Python limitation), but we abort the wait.
+                # The lingering thread will eventually finish or be GCed when Python exits.
+                timed_out = True
+                state.tool_call_errors += 1
+                state.is_still_valid = None
+        # Auto-fallback on tool errors or red tests when sovereign was used.
+        # Skip fallback entirely when the DAG timed out — a hard timeout means the LLM
+        # is unresponsive; retrying immediately would just hang again.
         should_fallback = (
-            (state.tool_call_errors > 0 or state.tests_pass is False)
+            not timed_out
+            and (state.tool_call_errors > 0 or state.tests_pass is False)
             and routing.provider == "aihub"
         )
         if should_fallback:

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -1,0 +1,133 @@
+"""DAG orchestrator for /finding-fix.
+
+Flow (Spec section 5.4):
+  load_finding → verify_path → read_affected_files → judge_necessity
+                                                      │
+                                                      ▼
+                                                 apply_fix
+                                                      │
+                                                      ▼
+                                                 run_tests
+                                                      │
+                                                ┌─────┴─────┐
+                                              pass         fail
+                                                │           │
+                                                ▼           ▼
+                                          update_index   fallback?
+                                                              │
+                                                              ▼
+                                                      retry with claude-haiku-4-5
+
+Hard-Caps (R7): max_steps=10 internally, max_duration=300s.
+"""
+from __future__ import annotations
+import sys
+import time
+from pathlib import Path
+
+from .lib.frontmatter import parse_frontmatter
+from .lib.jsonl_logger import JsonlLogger
+from .lib.models import Finding, FindingFixState, Severity, Status
+from .lib.routing import route_finding_fix, fallback_for, ModelChoice
+from .dag_nodes.verify_path import verify_path
+from .dag_nodes.read_affected_files import read_affected_files
+from .dag_nodes.judge_necessity import judge_necessity
+from .dag_nodes.apply_fix import apply_fix
+from .dag_nodes.run_tests import run_tests
+from .dag_nodes.update_index import update_finding_status, regenerate_index
+
+LOG_PATH = Path(".claude/logs/finding-fixes.jsonl")
+HARD_TIMEOUT_S = 300
+
+
+def load_finding(finding_path: Path) -> Finding:
+    fm, _body = parse_frontmatter(finding_path.read_text())
+    return Finding(**fm)
+
+
+def _run_dag(state: FindingFixState, *, repo_root: Path) -> FindingFixState:
+    state = verify_path(state, repo_root=repo_root)
+    if state.path_resolution_method == "failed":
+        return state
+    state = read_affected_files(state, repo_root=repo_root)
+    state = judge_necessity(state)
+    if not state.is_still_valid:
+        return state
+    state = apply_fix(state, repo_root=repo_root)
+    if state.fix_applied:
+        state = run_tests(state, repo_root=repo_root)
+    return state
+
+
+def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> FindingFixState:
+    finding_path = Path(findings_dir) / f"{finding_id}.md"
+    finding = load_finding(finding_path)
+    routing = route_finding_fix(finding)
+
+    logger = JsonlLogger(repo_root / LOG_PATH)
+    t0 = time.time()
+    state = FindingFixState(finding=finding, routing=routing)
+
+    try:
+        state = _run_dag(state, repo_root=repo_root)
+        # Auto-fallback on tool errors or red tests when sovereign was used
+        should_fallback = (
+            (state.tool_call_errors > 0 or state.tests_pass is False)
+            and routing.provider == "aihub"
+        )
+        if should_fallback:
+            fb = fallback_for(routing)
+            if fb:
+                state.fallback_used = True
+                state.routing = fb
+                # Reset partial state and re-run from apply_fix
+                state.fix_applied = False
+                state.tests_pass = None
+                state = apply_fix(state, repo_root=repo_root)
+                if state.fix_applied:
+                    state = run_tests(state, repo_root=repo_root)
+
+        # If finally green: mark fixed + commit (not done by DAG; user reviews and commits)
+        if state.tests_pass:
+            update_finding_status(finding_path, status=Status.FIXED)
+            regenerate_index(findings_dir)
+    finally:
+        state.duration_ms = int((time.time() - t0) * 1000)
+        logger.log({
+            "finding_id": finding.id,
+            "severity": finding.severity.value,
+            "model": state.routing.model,
+            "provider": state.routing.provider,
+            "fix_applied": state.fix_applied,
+            "tests_pass": state.tests_pass,
+            "fallback_used": state.fallback_used,
+            "tool_call_errors": state.tool_call_errors,
+            "duration_ms": state.duration_ms,
+            "path_resolution": state.path_resolution_method,
+        })
+
+    return state
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if len(argv) < 1:
+        print("Usage: finding_fix.py F-001 [--findings-dir docs/findings]", file=sys.stderr)
+        return 2
+    fid = argv[0]
+    findings_dir = Path(argv[2]) if len(argv) > 2 and argv[1] == "--findings-dir" else Path("docs/findings")
+    repo_root = Path.cwd()
+
+    result = run_finding_fix(finding_id=fid, findings_dir=findings_dir, repo_root=repo_root)
+    print(f"\n--- Result for {fid} ---")
+    print(f"Path-resolution: {result.path_resolution_method}")
+    print(f"Judge says valid: {result.is_still_valid}")
+    print(f"Fix applied: {result.fix_applied}")
+    print(f"Tests pass: {result.tests_pass}")
+    print(f"Fallback used: {result.fallback_used}")
+    print(f"Duration: {result.duration_ms}ms")
+    return 0 if result.tests_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/findings/findings_routing_stats.py
+++ b/scripts/findings/findings_routing_stats.py
@@ -1,0 +1,40 @@
+"""Auswertung von .claude/logs/finding-fixes.jsonl: Erfolgsrate je Modell."""
+from __future__ import annotations
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from statistics import median
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    log_path = Path(argv[0]) if argv else Path(".claude/logs/finding-fixes.jsonl")
+    if not log_path.is_file():
+        print(f"Log file not found: {log_path}")
+        return 1
+
+    by_model = defaultdict(list)
+    for line in log_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        by_model[entry.get("model", "unknown")].append(entry)
+
+    print(f"Source: {log_path}")
+    print(f"Total entries: {sum(len(v) for v in by_model.values())}\n")
+
+    print(f"{'Model':30s} | {'Runs':>5s} | {'Pass-rate':>10s} | {'Median ms':>10s} | {'Fallback':>9s}")
+    print("-" * 80)
+    for model, entries in sorted(by_model.items()):
+        total = len(entries)
+        passed = sum(1 for e in entries if e.get("tests_pass"))
+        med_ms = median([e.get("duration_ms", 0) for e in entries]) if entries else 0
+        fallback_used = sum(1 for e in entries if e.get("fallback_used"))
+        pass_rate = (passed / total * 100) if total else 0
+        print(f"{model:30s} | {total:>5d} | {pass_rate:>9.1f}% | {med_ms:>10.0f} | {fallback_used:>9d}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/findings/findings_status.py
+++ b/scripts/findings/findings_status.py
@@ -1,0 +1,45 @@
+"""Quick dashboard: count findings per severity / area / status."""
+from __future__ import annotations
+import sys
+from collections import Counter
+from pathlib import Path
+from .lib.frontmatter import parse_frontmatter
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    findings_dir = Path(argv[0]) if argv else Path("docs/findings")
+    files = list(findings_dir.glob("F-*.md"))
+    if not files:
+        print(f"No findings in {findings_dir}/")
+        return 1
+
+    severity = Counter()
+    area = Counter()
+    status = Counter()
+    stale = 0
+
+    for f in files:
+        fm, _ = parse_frontmatter(f.read_text())
+        severity[fm.get("severity", "?")] += 1
+        area[fm.get("area", "?")] += 1
+        status[fm.get("status", "?")] += 1
+        if fm.get("stale"):
+            stale += 1
+
+    print(f"Total findings: {len(files)}")
+    print(f"\nSeverity:")
+    for s in ("critical", "high", "medium", "low"):
+        print(f"  {s:10s}: {severity[s]}")
+    print(f"\nStatus:")
+    for s in ("open", "in-progress", "fixed", "archived", "wontfix"):
+        print(f"  {s:12s}: {status[s]}")
+    print(f"\nArea:")
+    for a, count in area.most_common():
+        print(f"  {a:20s}: {count}")
+    print(f"\nStale: {stale}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/findings/lib/aihub_client.py
+++ b/scripts/findings/lib/aihub_client.py
@@ -1,0 +1,69 @@
+"""AI Hub client (LiteLLM-Proxy) with model-specific sampling parameters.
+
+Sampling defaults (Spec 4.0, validated 2026-05-07):
+- qwen-3.5-122b-sovereign / qwen-3.6-35b-sovereign: temp=0.6, top_p=0.95, top_k=20, enable_thinking=True
+- qwen3-coder-480b: temp=1.0, top_p=0.95, top_k=20, enable_thinking=True
+- gpt-oss-120b-sovereign: temp=0.7, top_p=0.8, top_k=20 (to verify on first use)
+"""
+from __future__ import annotations
+import os
+from typing import List
+import requests
+
+
+DEFAULT_BASE_URL = "https://adesso-ai-hub.3asabc.de/v1"
+DEFAULT_TIMEOUT = 600  # 10 min for thinking-mode
+
+QWEN_THINKING_PARAMS = {"temperature": 0.6, "top_p": 0.95, "top_k": 20, "presence_penalty": 0.0}
+QWEN_CODER_PARAMS = {"temperature": 1.0, "top_p": 0.95, "top_k": 20, "presence_penalty": 0.0}
+GPT_OSS_PARAMS = {"temperature": 0.7, "top_p": 0.8, "top_k": 20, "presence_penalty": 0.0}
+
+
+class AIHubError(Exception):
+    """Raised when AI Hub returns non-2xx response."""
+
+
+class AIHubClient:
+    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+        self.api_key = api_key or os.environ.get("ADESSO_API_KEY") or os.environ.get("ADESSO_AI_HUB_API_KEY")
+        if not self.api_key:
+            raise ValueError("ADESSO_API_KEY environment variable not set")
+        self.base_url = base_url or os.environ.get("ADESSO_AI_HUB_BASE_URL", DEFAULT_BASE_URL)
+
+    def _params_for_model(self, model: str) -> dict:
+        if model.startswith("qwen3-coder"):
+            return {**QWEN_CODER_PARAMS, "extra_body": {"enable_thinking": True, "min_p": 0}}
+        if model.startswith("qwen-3"):
+            return {**QWEN_THINKING_PARAMS, "extra_body": {"enable_thinking": True, "min_p": 0}}
+        if model.startswith("gpt-oss"):
+            return {**GPT_OSS_PARAMS}
+        # Conservative default
+        return {"temperature": 0.6, "top_p": 0.95}
+
+    def chat(self, model: str, messages: List[dict], max_tokens: int = 32000, timeout: int = DEFAULT_TIMEOUT) -> dict:
+        """Send a chat completion request. Returns {content, tokens_in, tokens_out, raw}."""
+        params = self._params_for_model(model)
+        payload = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            **params,
+        }
+        resp = requests.post(
+            f"{self.base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
+            json=payload,
+            timeout=timeout,
+        )
+        if not resp.ok:
+            raise AIHubError(f"HTTP {resp.status_code}: {resp.text[:300]}")
+        data = resp.json()
+        msg = data["choices"][0]["message"]
+        usage = data.get("usage", {})
+        return {
+            "content": msg.get("content", ""),
+            "thinking": msg.get("reasoning_content", ""),
+            "tokens_in": usage.get("prompt_tokens", 0),
+            "tokens_out": usage.get("completion_tokens", 0),
+            "raw": data,
+        }

--- a/scripts/findings/lib/aihub_client.py
+++ b/scripts/findings/lib/aihub_client.py
@@ -60,9 +60,14 @@ class AIHubClient:
         data = resp.json()
         msg = data["choices"][0]["message"]
         usage = data.get("usage", {})
+        # Qwen-Thinking-Mode quirk: `content` may be None when the entire
+        # response is a reasoning block. Normalise so callers always see a string,
+        # and fall back to reasoning_content if content is empty/None.
+        content = msg.get("content") or msg.get("reasoning_content") or ""
+        thinking = msg.get("reasoning_content") or ""
         return {
-            "content": msg.get("content", ""),
-            "thinking": msg.get("reasoning_content", ""),
+            "content": content,
+            "thinking": thinking,
             "tokens_in": usage.get("prompt_tokens", 0),
             "tokens_out": usage.get("completion_tokens", 0),
             "raw": data,

--- a/scripts/findings/lib/frontmatter.py
+++ b/scripts/findings/lib/frontmatter.py
@@ -1,0 +1,28 @@
+"""YAML-Frontmatter Parser/Writer for finding markdown files."""
+from __future__ import annotations
+import re
+from typing import Tuple
+import yaml
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n(.*)\Z", re.DOTALL)
+
+
+def parse_frontmatter(text: str) -> Tuple[dict, str]:
+    """Parse YAML frontmatter from a markdown string.
+
+    Returns (frontmatter_dict, body_string).
+    Returns ({}, text) if no frontmatter present.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm_yaml, body = m.group(1), m.group(2)
+    fm = yaml.safe_load(fm_yaml) or {}
+    return fm, body
+
+
+def write_frontmatter(frontmatter: dict, body: str) -> str:
+    """Combine frontmatter dict + body into a markdown string with --- delimiters."""
+    fm_yaml = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True, default_flow_style=False)
+    return f"---\n{fm_yaml}---\n\n{body.lstrip()}"

--- a/scripts/findings/lib/git_helpers.py
+++ b/scripts/findings/lib/git_helpers.py
@@ -1,0 +1,22 @@
+"""Git helpers for commit-hash lookup and diff queries."""
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from typing import List
+
+
+def commit_hash_at(ref: str, *, repo: str | Path = ".") -> str:
+    """Return the full commit SHA for a given ref (e.g. 'HEAD', 'main', '@{u}')."""
+    return subprocess.check_output(
+        ["git", "rev-parse", ref], cwd=str(repo), text=True
+    ).strip()
+
+
+def files_changed_between(from_ref: str, to_ref: str, *, repo: str | Path = ".") -> List[str]:
+    """List files changed between two refs (relative paths)."""
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", from_ref, to_ref],
+        cwd=str(repo),
+        text=True,
+    )
+    return [line for line in out.splitlines() if line.strip()]

--- a/scripts/findings/lib/jsonl_logger.py
+++ b/scripts/findings/lib/jsonl_logger.py
@@ -1,0 +1,18 @@
+"""JSONL append-only logger for finding-fix events (Spec 6.3)."""
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class JsonlLogger:
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+
+    def log(self, entry: dict) -> None:
+        """Append a single entry as one JSON line. Adds 'timestamp' if missing."""
+        if "timestamp" not in entry:
+            entry["timestamp"] = datetime.now(timezone.utc).isoformat()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/scripts/findings/lib/models.py
+++ b/scripts/findings/lib/models.py
@@ -1,0 +1,98 @@
+"""Pydantic models for the findings backlog system.
+
+Sources of truth:
+- Spec section 3.2 (YAML Frontmatter Schema)
+- Spec section 4.0 (Sampling parameters per model)
+- Spec section 4.2 (Routing decision logic)
+"""
+from __future__ import annotations
+from datetime import date
+from enum import Enum
+from typing import List, Literal, Optional
+from pydantic import BaseModel, Field, model_validator
+
+
+class Severity(str, Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class Status(str, Enum):
+    OPEN = "open"
+    IN_PROGRESS = "in-progress"
+    FIXED = "fixed"
+    ARCHIVED = "archived"
+    WONTFIX = "wontfix"
+
+
+class Verdict(str, Enum):
+    BESTAETIGT = "bestätigt"
+    WIDERSPRICHT = "widerspricht"
+    NICHT_PRUEFBAR = "nicht_prüfbar"
+
+
+class ModelChoice(BaseModel):
+    provider: Literal["aihub", "claude"]
+    model: str
+    require_human_review: bool = False
+
+
+class Finding(BaseModel):
+    """Pro-Finding-File frontmatter as a typed model."""
+    id: str = Field(pattern=r"^F-\d{3,}$")
+    severity: Severity
+    area: str
+    title: str
+    file: str
+    lines: Optional[str] = None
+    effort: Optional[str] = None
+    status: Status = Status.OPEN
+    source: str
+    detected: date
+    fixed_at: Optional[date] = None
+    fixed_in_commit: Optional[str] = None
+    related: List[str] = Field(default_factory=list)
+    parent: Optional[str] = None
+    model_routing: Optional[str] = None
+    acceptance_criteria: List[str] = Field(default_factory=list)
+    stale: bool = False  # Phase 0a: file changed since review
+
+    @model_validator(mode="after")
+    def validate_acceptance_criteria(self) -> "Finding":
+        """D3: AKs Pflicht ab medium."""
+        if self.severity in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM):
+            if not self.acceptance_criteria:
+                raise ValueError(
+                    f"Finding {self.id} with severity={self.severity.value} "
+                    "requires acceptance_criteria (D3)"
+                )
+        return self
+
+
+class FindingFixState(BaseModel):
+    """State passed between DAG nodes in finding_fix.py.
+
+    Each node reads needed fields, writes its outputs, returns updated state.
+    """
+    finding: Finding
+    routing: ModelChoice
+    # verify_path output:
+    path_resolved: Optional[str] = None  # actual path (after symbol_search fallback)
+    path_resolution_method: Optional[Literal["exact", "symbol_search", "failed"]] = None
+    # read_affected_files output:
+    file_contents: dict = Field(default_factory=dict)  # path → content
+    # judge_necessity output:
+    is_still_valid: Optional[bool] = None
+    judge_reasoning: Optional[str] = None
+    # apply_fix output:
+    fix_applied: bool = False
+    fix_diff: Optional[str] = None
+    # run_tests output:
+    tests_pass: Optional[bool] = None
+    test_output: Optional[str] = None
+    # tracking
+    tool_call_errors: int = 0
+    fallback_used: bool = False
+    duration_ms: int = 0

--- a/scripts/findings/lib/routing.py
+++ b/scripts/findings/lib/routing.py
@@ -30,9 +30,17 @@ def route_finding_fix(finding: Finding) -> ModelChoice:
 def fallback_for(routing: ModelChoice) -> ModelChoice | None:
     """Auto-fallback target on tool-fail (Spec 4.3).
 
-    aihub/qwen → claude-haiku-4-5
+    Strategy: stay within AI Hub for the first fallback (Sovereign-first), escalate
+    to Anthropic only if the AI Hub code-specialist also fails. Keeps `anthropic`
+    SDK as an optional dependency — only loaded when severity HIGH/CRITICAL or an
+    explicit per-finding model_routing override targets claude-*.
+
+    aihub/qwen-3.5-122b-sovereign → aihub/qwen3-coder-480b (paid, code-tuned)
+    aihub/qwen3-coder-480b → claude/haiku-4-5 (last resort, requires anthropic)
     claude/* → no fallback
     """
     if routing.provider == "aihub":
-        return ModelChoice(provider="claude", model="haiku-4-5", require_human_review=False)
+        if routing.model.startswith("qwen3-coder"):
+            return ModelChoice(provider="claude", model="haiku-4-5", require_human_review=False)
+        return ModelChoice(provider="aihub", model="qwen3-coder-480b", require_human_review=False)
     return None

--- a/scripts/findings/lib/routing.py
+++ b/scripts/findings/lib/routing.py
@@ -1,0 +1,38 @@
+"""Severity → Modell routing with auto-fallback (Spec 4.2, 4.3)."""
+from __future__ import annotations
+from .models import Severity, Finding, ModelChoice
+
+
+def parse_model_override(spec: str) -> ModelChoice:
+    """Parse 'claude-opus-4-6' or 'qwen-3.5-122b-sovereign' into ModelChoice."""
+    if spec.startswith("claude-"):
+        return ModelChoice(
+            provider="claude",
+            model=spec[len("claude-"):],
+            require_human_review="opus" in spec,
+        )
+    return ModelChoice(provider="aihub", model=spec, require_human_review=False)
+
+
+def route_finding_fix(finding: Finding) -> ModelChoice:
+    """Default routing per Spec 4.1, with explicit `model_routing` override."""
+    if finding.model_routing:
+        return parse_model_override(finding.model_routing)
+
+    if finding.severity == Severity.CRITICAL:
+        return ModelChoice(provider="claude", model="opus-4-6", require_human_review=True)
+    elif finding.severity == Severity.HIGH:
+        return ModelChoice(provider="claude", model="sonnet-4-6", require_human_review=False)
+    else:  # MEDIUM or LOW
+        return ModelChoice(provider="aihub", model="qwen-3.5-122b-sovereign", require_human_review=False)
+
+
+def fallback_for(routing: ModelChoice) -> ModelChoice | None:
+    """Auto-fallback target on tool-fail (Spec 4.3).
+
+    aihub/qwen → claude-haiku-4-5
+    claude/* → no fallback
+    """
+    if routing.provider == "aihub":
+        return ModelChoice(provider="claude", model="haiku-4-5", require_human_review=False)
+    return None

--- a/scripts/findings/lib/symbol_search.py
+++ b/scripts/findings/lib/symbol_search.py
@@ -1,0 +1,48 @@
+"""Symbol search fallback for path-imprecise findings (D22).
+
+When a finding references file `X/Y/Z.ts:funcName` but that path doesn't exist,
+grep across the project for `funcName` and return matches.
+"""
+from __future__ import annotations
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class SymbolHit:
+    path: str
+    line: int
+    text: str
+
+
+_DEFAULT_INCLUDE = (".ts", ".tsx", ".js", ".jsx", ".py", ".sql", ".css", ".json")
+_DEFAULT_EXCLUDE = ("node_modules", "dist", ".git", "test-results", "coverage")
+
+
+def find_symbol(symbol: str, *, search_root: str | Path, include_ext: tuple = _DEFAULT_INCLUDE) -> List[SymbolHit]:
+    """Recursively find files in search_root that contain the symbol.
+
+    Uses simple word-boundary regex (`\\bsymbol\\b`).
+    """
+    root = Path(search_root)
+    pattern = re.compile(r"\b" + re.escape(symbol) + r"\b")
+    hits: List[SymbolHit] = []
+
+    for fp in root.rglob("*"):
+        if not fp.is_file():
+            continue
+        if fp.suffix not in include_ext:
+            continue
+        if any(excl in str(fp) for excl in _DEFAULT_EXCLUDE):
+            continue
+        try:
+            for ln, line in enumerate(fp.read_text(errors="replace").splitlines(), start=1):
+                if pattern.search(line):
+                    hits.append(SymbolHit(path=str(fp), line=ln, text=line))
+                    break  # one hit per file is enough for triage
+        except OSError:
+            continue
+    return hits

--- a/scripts/findings/validate_review_freshness.py
+++ b/scripts/findings/validate_review_freshness.py
@@ -1,0 +1,61 @@
+"""Phase 0a: detect findings that reference files changed since the review.
+
+Strategy:
+1. Parse all review markdown files in reviews/.
+2. Extract referenced file paths (regex: `src/...\\.tsx?` or **Datei:** patterns).
+3. Get list of files changed in git since review timestamp (or commit hash if specified).
+4. Output list of {review, stale_files}.
+"""
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Set
+
+from .lib.git_helpers import commit_hash_at, files_changed_between
+
+
+_FILE_PATTERN = re.compile(r"`(src/[\w/_-]+\.(?:tsx?|jsx?|css|sql|py))(?::\d+(?:-\d+)?)?`")
+_DATEI_PATTERN = re.compile(r"\*\*Datei:\*\*\s*`?([\w/_-]+\.\w+)`?")
+
+
+def extract_file_refs(review_text: str) -> Set[str]:
+    """Extract all `src/...` style file references from a review."""
+    refs: Set[str] = set()
+    for m in _FILE_PATTERN.finditer(review_text):
+        refs.add(m.group(1))
+    for m in _DATEI_PATTERN.finditer(review_text):
+        refs.add(m.group(1))
+    return refs
+
+
+def find_stale_files_in_reviews(review_paths: Iterable[Path], changed_files: list[str]) -> Set[str]:
+    """Return the set of file paths that are referenced in any review AND changed."""
+    referenced: Set[str] = set()
+    for p in review_paths:
+        referenced |= extract_file_refs(Path(p).read_text(errors="replace"))
+    return referenced & set(changed_files)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if len(argv) < 2:
+        print("Usage: validate_review_freshness.py <review-commit-sha> <reviews-dir>", file=sys.stderr)
+        return 2
+    review_sha, reviews_dir = argv[0], argv[1]
+    head = commit_hash_at("HEAD")
+    changed = files_changed_between(review_sha, head)
+    review_files = list(Path(reviews_dir).glob("*.md"))
+    stale = find_stale_files_in_reviews(review_files, changed)
+
+    print(f"Review-SHA: {review_sha}  HEAD: {head}")
+    print(f"Reviews scanned: {len(review_files)}")
+    print(f"Files changed since review: {len(changed)}")
+    print(f"Stale files (referenced AND changed): {len(stale)}")
+    for f in sorted(stale):
+        print(f"  STALE: {f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/findings/conftest.py
+++ b/tests/findings/conftest.py
@@ -1,0 +1,28 @@
+"""Pytest fixtures for findings tests."""
+from __future__ import annotations
+import pytest
+from pathlib import Path
+
+@pytest.fixture
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+@pytest.fixture
+def sample_finding_dict() -> dict:
+    return {
+        "id": "F-001",
+        "severity": "high",
+        "area": "architecture",
+        "title": "Test Finding",
+        "file": "src/example.ts",
+        "lines": "10-20",
+        "effort": "1h",
+        "status": "open",
+        "source": "reviews/test.md",
+        "detected": "2026-05-07",
+        "fixed_at": None,
+        "fixed_in_commit": None,
+        "related": [],
+        "parent": None,
+        "model_routing": None,
+    }

--- a/tests/findings/conftest.py
+++ b/tests/findings/conftest.py
@@ -25,4 +25,5 @@ def sample_finding_dict() -> dict:
         "related": [],
         "parent": None,
         "model_routing": None,
+        "acceptance_criteria": ["Fix the architecture issue"],
     }

--- a/tests/findings/dag_nodes/test_apply_fix.py
+++ b/tests/findings/dag_nodes/test_apply_fix.py
@@ -1,0 +1,43 @@
+"""Tests for apply_fix DAG node."""
+from __future__ import annotations
+from unittest.mock import patch
+import pytest
+from findings.dag_nodes.apply_fix import apply_fix
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def _ready_state():
+    finding = Finding(
+        id="F-001", severity=Severity.HIGH, area="data", title="title",
+        file="src/x.ts", status=Status.OPEN, source="r", detected="2026-05-07",
+        related=[], acceptance_criteria=["AK1"],
+    )
+    return FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="claude", model="sonnet-4-6"),
+        path_resolved="src/x.ts",
+        path_resolution_method="exact",
+        file_contents={"src/x.ts": "let x = 1;\n"},
+        is_still_valid=True,
+    )
+
+
+def test_apply_fix_writes_diff_to_state(tmp_path):
+    src = tmp_path / "src" / "x.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("let x = 1;\n")
+
+    state = _ready_state()
+    with patch("findings.dag_nodes.apply_fix._call_apply_llm") as mock_call:
+        mock_call.return_value = '{"new_content": "const x = 1;\\n", "diff": "-let x\\n+const x"}'
+        state = apply_fix(state, repo_root=tmp_path)
+    assert state.fix_applied is True
+    assert "const x" in src.read_text()
+    assert state.fix_diff is not None
+
+
+def test_apply_fix_skips_when_finding_invalidated():
+    state = _ready_state()
+    state.is_still_valid = False
+    state = apply_fix(state, repo_root="/tmp/dummy")
+    assert state.fix_applied is False

--- a/tests/findings/dag_nodes/test_judge_necessity.py
+++ b/tests/findings/dag_nodes/test_judge_necessity.py
@@ -1,0 +1,38 @@
+"""Tests for judge_necessity DAG node."""
+from __future__ import annotations
+from unittest.mock import patch
+import pytest
+from findings.dag_nodes.judge_necessity import judge_necessity
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def _state_with_real_code():
+    finding = Finding(
+        id="F-001", severity=Severity.HIGH, area="data", title="useRef issue",
+        file="src/x.ts", status=Status.OPEN, source="r", detected="2026-05-07",
+        related=[], acceptance_criteria=["AK1"],
+    )
+    return FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="claude", model="sonnet-4-6"),
+        path_resolved="src/x.ts",
+        path_resolution_method="exact",
+        file_contents={"src/x.ts": "const x = useRef(); useEffect(() => {});"},
+    )
+
+
+def test_judge_returns_valid_when_llm_says_so():
+    state = _state_with_real_code()
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_call:
+        mock_call.return_value = '{"is_still_valid": true, "reasoning": "issue confirmed"}'
+        state = judge_necessity(state)
+    assert state.is_still_valid is True
+    assert "confirmed" in state.judge_reasoning
+
+
+def test_judge_returns_invalid_for_obsolete_finding():
+    state = _state_with_real_code()
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_call:
+        mock_call.return_value = '{"is_still_valid": false, "reasoning": "fixed already"}'
+        state = judge_necessity(state)
+    assert state.is_still_valid is False

--- a/tests/findings/dag_nodes/test_read_affected_files.py
+++ b/tests/findings/dag_nodes/test_read_affected_files.py
@@ -1,0 +1,24 @@
+"""Tests for read_affected_files DAG node (D21)."""
+from __future__ import annotations
+from findings.dag_nodes.read_affected_files import read_affected_files
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def test_reads_resolved_file_into_state(tmp_path):
+    target = tmp_path / "src" / "x.ts"
+    target.parent.mkdir(parents=True)
+    target.write_text("export const HELLO = 1;")
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="t", file="src/x.ts",
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[],
+        acceptance_criteria=[],
+    )
+    state = FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="x"),
+        path_resolved="src/x.ts",
+        path_resolution_method="exact",
+    )
+    state = read_affected_files(state, repo_root=tmp_path)
+    assert "src/x.ts" in state.file_contents
+    assert "HELLO" in state.file_contents["src/x.ts"]

--- a/tests/findings/dag_nodes/test_run_tests.py
+++ b/tests/findings/dag_nodes/test_run_tests.py
@@ -1,0 +1,41 @@
+"""Tests for run_tests DAG node."""
+from __future__ import annotations
+from unittest.mock import patch, MagicMock
+from findings.dag_nodes.run_tests import run_tests
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def _state_post_fix():
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="t", file="src/x.ts",
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[], acceptance_criteria=[],
+    )
+    s = FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="x"),
+        fix_applied=True,
+    )
+    return s
+
+
+def test_run_tests_passes_on_zero_exit():
+    state = _state_post_fix()
+    with patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="all good", stderr="")
+        state = run_tests(state, repo_root="/tmp")
+    assert state.tests_pass is True
+
+
+def test_run_tests_fails_on_nonzero_exit():
+    state = _state_post_fix()
+    with patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="FAIL", stderr="error")
+        state = run_tests(state, repo_root="/tmp")
+    assert state.tests_pass is False
+
+
+def test_run_tests_skips_if_no_fix_applied():
+    state = _state_post_fix()
+    state.fix_applied = False
+    state = run_tests(state, repo_root="/tmp")
+    assert state.tests_pass is None

--- a/tests/findings/dag_nodes/test_update_index.py
+++ b/tests/findings/dag_nodes/test_update_index.py
@@ -1,0 +1,18 @@
+"""Tests for update_index DAG node."""
+from __future__ import annotations
+import yaml
+from findings.dag_nodes.update_index import update_finding_status
+from findings.lib.models import Status
+
+
+def test_update_finding_status_sets_fixed_with_commit(tmp_path):
+    f = tmp_path / "F-001.md"
+    f.write_text("---\nid: F-001\nstatus: open\n---\n\nbody\n")
+    update_finding_status(f, status=Status.FIXED, commit_sha="abc1234")
+
+    text = f.read_text()
+    fm_yaml = text.split("---")[1]
+    fm = yaml.safe_load(fm_yaml)
+    assert fm["status"] == "fixed"
+    assert fm["fixed_in_commit"] == "abc1234"
+    assert fm["fixed_at"] is not None

--- a/tests/findings/dag_nodes/test_verify_path.py
+++ b/tests/findings/dag_nodes/test_verify_path.py
@@ -1,0 +1,48 @@
+"""Tests for verify_path DAG node."""
+from __future__ import annotations
+import pytest
+from findings.dag_nodes.verify_path import verify_path
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def _state(file_path: str) -> FindingFixState:
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="t", file=file_path,
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[],
+        acceptance_criteria=[],
+    )
+    return FindingFixState(finding=finding, routing=ModelChoice(provider="aihub", model="qwen-3.5-122b-sovereign"))
+
+
+def test_exact_path_match(tmp_path):
+    target = tmp_path / "src" / "exists.ts"
+    target.parent.mkdir(parents=True)
+    target.write_text("// exists")
+    state = _state(str(target.relative_to(tmp_path)))
+    state = verify_path(state, repo_root=tmp_path)
+    assert state.path_resolved == str(target.relative_to(tmp_path))
+    assert state.path_resolution_method == "exact"
+
+
+def test_symbol_search_fallback(tmp_path):
+    """When path doesn't exist, but symbol can be found via grep."""
+    real_file = tmp_path / "src" / "actual.ts"
+    real_file.parent.mkdir(parents=True)
+    real_file.write_text("export function generateRoundRobinPairings() {}")
+
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="missing path",
+        file="src/wrong/path.ts:generateRoundRobinPairings",
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[],
+        acceptance_criteria=[],
+    )
+    state = FindingFixState(finding=finding, routing=ModelChoice(provider="aihub", model="x"))
+    state = verify_path(state, repo_root=tmp_path)
+    assert state.path_resolution_method == "symbol_search"
+    assert "actual.ts" in state.path_resolved
+
+
+def test_failed_when_neither_path_nor_symbol_found(tmp_path):
+    state = _state("src/does_not_exist.ts:totally_missing_func")
+    state = verify_path(state, repo_root=tmp_path)
+    assert state.path_resolution_method == "failed"

--- a/tests/findings/test_aihub_client.py
+++ b/tests/findings/test_aihub_client.py
@@ -1,0 +1,88 @@
+"""Tests for AI Hub client (LiteLLM-Proxy)."""
+from __future__ import annotations
+from unittest.mock import patch, MagicMock
+import pytest
+from findings.lib.aihub_client import AIHubClient, AIHubError
+
+
+def test_client_uses_official_qwen3_thinking_params():
+    """D16/Spec 4.0: Qwen3 thinking mode requires temp=0.6, top_p=0.95, top_k=20."""
+    client = AIHubClient(api_key="sk-test")
+
+    with patch("findings.lib.aihub_client.requests.post") as mock_post:
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+        client.chat(
+            model="qwen-3.5-122b-sovereign",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=100,
+        )
+
+        call_kwargs = mock_post.call_args.kwargs
+        payload = call_kwargs["json"]
+        assert payload["temperature"] == 0.6
+        assert payload["top_p"] == 0.95
+        assert payload["top_k"] == 20
+        assert payload["extra_body"]["enable_thinking"] is True
+
+
+def test_client_uses_qwen3_coder_higher_temp():
+    """Spec 4.0: qwen3-coder uses temp=1.0."""
+    client = AIHubClient(api_key="sk-test")
+
+    with patch("findings.lib.aihub_client.requests.post") as mock_post:
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+        client.chat(
+            model="qwen3-coder-480b",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=100,
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["temperature"] == 1.0
+
+
+def test_client_raises_on_401():
+    client = AIHubClient(api_key="sk-bad")
+
+    with patch("findings.lib.aihub_client.requests.post") as mock_post:
+        mock_post.return_value.ok = False
+        mock_post.return_value.status_code = 401
+        mock_post.return_value.text = "Unauthorized"
+
+        with pytest.raises(AIHubError, match="401"):
+            client.chat(
+                model="qwen-3.5-122b-sovereign",
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=100,
+            )
+
+
+def test_client_returns_content_and_usage():
+    client = AIHubClient(api_key="sk-test")
+
+    with patch("findings.lib.aihub_client.requests.post") as mock_post:
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+
+        result = client.chat(
+            model="qwen-3.5-122b-sovereign",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=10,
+        )
+
+        assert result["content"] == "Hello"
+        assert result["tokens_in"] == 5
+        assert result["tokens_out"] == 1

--- a/tests/findings/test_extract_findings.py
+++ b/tests/findings/test_extract_findings.py
@@ -54,3 +54,31 @@ def test_write_finding_files_creates_index_and_per_finding(tmp_path, sample_find
     assert (tmp_path / "INDEX.md").exists()
     index_text = (tmp_path / "INDEX.md").read_text()
     assert "F-001" in index_text
+
+
+def test_main_with_single_flag_processes_only_one_file(tmp_path, monkeypatch):
+    """Test that --single processes only the specified review file."""
+    reviews = tmp_path / "reviews"
+    reviews.mkdir()
+    (reviews / "a.md").write_text("# Review A")
+    (reviews / "b.md").write_text("# Review B")
+    findings_dir = tmp_path / "docs/findings"
+
+    calls: list[str] = []
+
+    def fake_extract(text: str, *, source: str, existing_ids=None):
+        calls.append(source)
+        return []
+
+    monkeypatch.setattr("findings.extract_findings.extract_from_review", fake_extract)
+
+    from findings.extract_findings import main
+    rc = main([
+        str(reviews),
+        "--findings-dir", str(findings_dir),
+        "--single", str(reviews / "a.md"),
+    ])
+    assert rc == 0
+    # Only the 'a.md' source should have been passed to extract_from_review
+    assert len(calls) == 1
+    assert calls[0].endswith("a.md")

--- a/tests/findings/test_extract_findings.py
+++ b/tests/findings/test_extract_findings.py
@@ -1,0 +1,56 @@
+"""Tests for findings extractor (Phase 1)."""
+from __future__ import annotations
+from unittest.mock import patch
+import pytest
+from pathlib import Path
+from findings.extract_findings import extract_from_review, write_finding_files
+
+
+SAMPLE_REVIEW = """# Review: architecture
+
+## Critical
+- **useRef für Subscriptions** in `src/core/contexts/RepositoryContext.tsx:33`
+  Cleanup-Problem bei Re-Renders.
+"""
+
+# A mocked LLM extraction returns structured findings.
+MOCK_LLM_OUTPUT = '''[
+  {
+    "severity": "high",
+    "area": "architecture",
+    "title": "useRef für Subscriptions ohne Cleanup",
+    "file": "src/core/contexts/RepositoryContext.tsx",
+    "lines": "33",
+    "effort": "1h",
+    "problem": "useRef könnte Cleanup-Probleme bei Re-Renders haben",
+    "reproduction": "grep -n 'supabaseLiveMatchRepoRef' src/core/contexts/RepositoryContext.tsx",
+    "fix_proposal": "useEffect cleanup logic verifizieren oder durch state ersetzen",
+    "acceptance_criteria": [
+      "RepositoryContext rendert ohne useRef für Subscriptions",
+      "Tests verifizieren Cleanup bei Unmount"
+    ]
+  }
+]'''
+
+
+def test_extract_from_review_yields_findings():
+    with patch("findings.extract_findings._call_llm_extract") as mock_call:
+        mock_call.return_value = MOCK_LLM_OUTPUT
+        findings = extract_from_review(SAMPLE_REVIEW, source="reviews/test.md")
+    assert len(findings) == 1
+    assert findings[0].severity.value == "high"
+    assert findings[0].file.endswith("RepositoryContext.tsx")
+    assert findings[0].id.startswith("F-")
+    assert len(findings[0].acceptance_criteria) >= 1
+
+
+def test_write_finding_files_creates_index_and_per_finding(tmp_path, sample_finding_dict):
+    from findings.lib.models import Finding
+    sample_finding_dict["acceptance_criteria"] = ["AK1", "AK2"]
+    f = Finding(**sample_finding_dict)
+    write_finding_files([f], findings_dir=tmp_path)
+
+    assert (tmp_path / "F-001.md").exists()
+    assert (tmp_path / "INDEX.md").exists()
+    index_text = (tmp_path / "INDEX.md").read_text()
+    assert "F-001" in index_text

--- a/tests/findings/test_finding_fix.py
+++ b/tests/findings/test_finding_fix.py
@@ -66,3 +66,36 @@ def test_fallback_kicks_in_after_aihub_failure(tmp_path):
         result = run_finding_fix(finding_id="F-002", findings_dir=findings, repo_root=tmp_path)
 
     assert result.fallback_used is True
+
+
+def test_dag_timeout_aborts_long_running_step(tmp_path, monkeypatch):
+    """R7: HARD_TIMEOUT_S must abort a hanging LLM call."""
+    import time
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-003.md").write_text(
+        "---\nid: F-003\nseverity: low\narea: ux\ntitle: t\nfile: src/z.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: []\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "z.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("a")
+
+    # Force tiny timeout so the test does not take 300s
+    monkeypatch.setattr("findings.finding_fix.HARD_TIMEOUT_S", 0.5)
+
+    from unittest.mock import patch
+
+    def slow_judge(*args, **kwargs):
+        time.sleep(2.0)  # exceeds the patched HARD_TIMEOUT_S of 0.5s
+        return '{"is_still_valid": true, "reasoning": "slow"}'
+
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm", side_effect=slow_judge):
+        from findings.finding_fix import run_finding_fix
+        result = run_finding_fix(finding_id="F-003", findings_dir=findings, repo_root=tmp_path)
+
+    # The slow judge should have been timed out; tool_call_errors incremented
+    assert result.tool_call_errors >= 1
+    # Fix should NOT have been applied (timeout aborted before apply_fix)
+    assert result.fix_applied is False

--- a/tests/findings/test_finding_fix.py
+++ b/tests/findings/test_finding_fix.py
@@ -1,0 +1,68 @@
+"""Integration tests for the finding_fix orchestrator (DAG)."""
+from __future__ import annotations
+from unittest.mock import patch
+import pytest
+from pathlib import Path
+from findings.finding_fix import run_finding_fix
+from findings.lib.models import Severity
+
+
+def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
+    # Setup: minimal repo with a finding
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-001.md").write_text(
+        "---\nid: F-001\nseverity: low\narea: ux\ntitle: test\nfile: src/x.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: []\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "x.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("let x = 1;\n")
+
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.apply_fix._call_apply_llm") as mock_apply, \
+         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+        mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
+        mock_apply.return_value = '{"new_content": "const x = 1;\\n", "diff": "diff"}'
+        from unittest.mock import MagicMock
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        result = run_finding_fix(
+            finding_id="F-001",
+            findings_dir=findings,
+            repo_root=tmp_path,
+        )
+
+    assert result.fix_applied is True
+    assert result.tests_pass is True
+    # The status should be flipped to 'fixed'
+    text = (findings / "F-001.md").read_text()
+    assert "status: fixed" in text
+
+
+def test_fallback_kicks_in_after_aihub_failure(tmp_path):
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-002.md").write_text(
+        "---\nid: F-002\nseverity: medium\narea: ux\ntitle: t\nfile: src/y.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: [AK1]\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "y.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("a")
+
+    # Simulate aihub failure → fallback to claude haiku
+    with patch("findings.dag_nodes.apply_fix._call_apply_llm") as mock_apply, \
+         patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+        # First call (aihub) fails JSON parse, second call (haiku) succeeds
+        mock_apply.side_effect = ["INVALID JSON", '{"new_content":"b","diff":""}']
+        mock_judge.return_value = '{"is_still_valid": true, "reasoning":"y"}'
+        from unittest.mock import MagicMock
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        result = run_finding_fix(finding_id="F-002", findings_dir=findings, repo_root=tmp_path)
+
+    assert result.fallback_used is True

--- a/tests/findings/test_frontmatter.py
+++ b/tests/findings/test_frontmatter.py
@@ -1,0 +1,53 @@
+"""Tests for YAML frontmatter parser/writer."""
+from __future__ import annotations
+import pytest
+from findings.lib.frontmatter import parse_frontmatter, write_frontmatter
+
+
+SAMPLE = """---
+id: F-042
+severity: low
+area: ux
+title: Touch-Target zu klein
+file: src/components/ui/ActionMenu.tsx
+status: open
+source: reviews/2026-05-07_2056_components_ui.md
+detected: 2026-05-07
+related: []
+acceptance_criteria: []
+---
+
+# Body
+
+Markdown content here.
+"""
+
+
+def test_parse_frontmatter_extracts_yaml_dict():
+    fm, body = parse_frontmatter(SAMPLE)
+    assert fm["id"] == "F-042"
+    assert fm["severity"] == "low"
+    assert fm["related"] == []
+    assert "# Body" in body
+
+
+def test_parse_frontmatter_handles_no_frontmatter():
+    fm, body = parse_frontmatter("# Just a body\n\nNo frontmatter.")
+    assert fm == {}
+    assert body.strip().startswith("# Just a body")
+
+
+def test_write_frontmatter_roundtrip():
+    fm, body = parse_frontmatter(SAMPLE)
+    rebuilt = write_frontmatter(fm, body)
+    fm2, body2 = parse_frontmatter(rebuilt)
+    assert fm2 == fm
+    assert body2.strip() == body.strip()
+
+
+def test_write_frontmatter_uses_block_yaml():
+    fm = {"id": "F-001", "tags": ["a", "b"]}
+    out = write_frontmatter(fm, "Body")
+    assert out.startswith("---\n")
+    assert "id: F-001" in out
+    assert "Body" in out

--- a/tests/findings/test_git_helpers.py
+++ b/tests/findings/test_git_helpers.py
@@ -1,0 +1,18 @@
+"""Tests for git helpers (commit-hash, file-changed-since)."""
+from __future__ import annotations
+import pytest
+import subprocess
+from findings.lib.git_helpers import commit_hash_at, files_changed_between
+
+
+@pytest.mark.integration
+def test_commit_hash_at_returns_sha(repo_root):
+    sha = commit_hash_at("HEAD", repo=repo_root)
+    assert len(sha) == 40 or len(sha) == 7  # full or short
+
+
+@pytest.mark.integration
+def test_files_changed_between_returns_list(repo_root):
+    head = commit_hash_at("HEAD", repo=repo_root)
+    files = files_changed_between(f"{head}~1", head, repo=repo_root)
+    assert isinstance(files, list)

--- a/tests/findings/test_jsonl_logger.py
+++ b/tests/findings/test_jsonl_logger.py
@@ -1,0 +1,37 @@
+"""Tests for JSONL logger (.claude/logs/finding-fixes.jsonl)."""
+from __future__ import annotations
+import json
+import pytest
+from pathlib import Path
+from findings.lib.jsonl_logger import JsonlLogger
+
+
+def test_logger_appends_jsonl_line(tmp_path):
+    log_path = tmp_path / "test.jsonl"
+    logger = JsonlLogger(log_path)
+    logger.log({"finding_id": "F-001", "model": "qwen", "tokens_in": 100})
+
+    content = log_path.read_text()
+    assert content.endswith("\n")
+    parsed = json.loads(content.strip())
+    assert parsed["finding_id"] == "F-001"
+    assert "timestamp" in parsed
+
+
+def test_logger_creates_parent_dirs(tmp_path):
+    log_path = tmp_path / "deeply" / "nested" / "log.jsonl"
+    logger = JsonlLogger(log_path)
+    logger.log({"x": 1})
+    assert log_path.exists()
+
+
+def test_logger_appends_multiple_entries(tmp_path):
+    log_path = tmp_path / "log.jsonl"
+    logger = JsonlLogger(log_path)
+    logger.log({"a": 1})
+    logger.log({"b": 2})
+
+    lines = log_path.read_text().strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0])["a"] == 1
+    assert json.loads(lines[1])["b"] == 2

--- a/tests/findings/test_models.py
+++ b/tests/findings/test_models.py
@@ -1,0 +1,57 @@
+"""Tests for findings Pydantic models."""
+from __future__ import annotations
+import pytest
+from datetime import date
+from findings.lib.models import (
+    Severity, Status, Verdict, Finding, ModelChoice, FindingFixState
+)
+
+
+def test_severity_values():
+    assert Severity.CRITICAL.value == "critical"
+    assert Severity.HIGH.value == "high"
+    assert Severity.MEDIUM.value == "medium"
+    assert Severity.LOW.value == "low"
+
+
+def test_status_values():
+    assert Status.OPEN.value == "open"
+    assert Status.IN_PROGRESS.value == "in-progress"
+    assert Status.FIXED.value == "fixed"
+    assert Status.ARCHIVED.value == "archived"
+    assert Status.WONTFIX.value == "wontfix"
+
+
+def test_finding_from_dict(sample_finding_dict):
+    f = Finding(**sample_finding_dict)
+    assert f.id == "F-001"
+    assert f.severity == Severity.HIGH
+    assert f.status == Status.OPEN
+    assert f.related == []
+    assert f.parent is None
+
+
+def test_finding_severity_default_routing(sample_finding_dict):
+    f = Finding(**sample_finding_dict)
+    assert f.severity == Severity.HIGH
+
+
+def test_finding_acceptance_criteria_required_for_medium(sample_finding_dict):
+    """D3: AKs Pflicht ab medium."""
+    sample_finding_dict["severity"] = "medium"
+    sample_finding_dict["acceptance_criteria"] = []
+    with pytest.raises(ValueError, match="acceptance_criteria"):
+        Finding(**sample_finding_dict)
+
+
+def test_finding_acceptance_criteria_optional_for_low(sample_finding_dict):
+    """D3: AKs optional bei low."""
+    sample_finding_dict["severity"] = "low"
+    sample_finding_dict["acceptance_criteria"] = []
+    f = Finding(**sample_finding_dict)
+    assert f.acceptance_criteria == []
+
+
+def test_model_choice_for_critical():
+    mc = ModelChoice(provider="claude", model="opus-4-6", require_human_review=True)
+    assert mc.require_human_review is True

--- a/tests/findings/test_routing.py
+++ b/tests/findings/test_routing.py
@@ -1,0 +1,62 @@
+"""Tests for severity → model routing logic (Spec 4.2)."""
+from __future__ import annotations
+import pytest
+from findings.lib.models import Severity, Finding, ModelChoice
+from findings.lib.routing import route_finding_fix, parse_model_override
+
+
+def _make_finding(severity: Severity, model_routing: str | None = None) -> Finding:
+    return Finding(
+        id="F-001",
+        severity=severity,
+        area="test",
+        title="Test",
+        file="src/test.ts",
+        status="open",
+        source="reviews/test.md",
+        detected="2026-05-07",
+        related=[],
+        acceptance_criteria=["AK1"] if severity != Severity.LOW else [],
+        model_routing=model_routing,
+    )
+
+
+def test_critical_routes_to_opus_with_human_review():
+    f = _make_finding(Severity.CRITICAL)
+    mc = route_finding_fix(f)
+    assert mc.provider == "claude"
+    assert mc.model == "opus-4-6"
+    assert mc.require_human_review is True
+
+
+def test_high_routes_to_sonnet():
+    f = _make_finding(Severity.HIGH)
+    mc = route_finding_fix(f)
+    assert mc.provider == "claude"
+    assert mc.model == "sonnet-4-6"
+    assert mc.require_human_review is False
+
+
+def test_medium_routes_to_sovereign_qwen():
+    f = _make_finding(Severity.MEDIUM)
+    mc = route_finding_fix(f)
+    assert mc.provider == "aihub"
+    assert mc.model == "qwen-3.5-122b-sovereign"
+
+
+def test_low_routes_to_sovereign_qwen():
+    f = _make_finding(Severity.LOW)
+    mc = route_finding_fix(f)
+    assert mc.provider == "aihub"
+    assert mc.model == "qwen-3.5-122b-sovereign"
+
+
+def test_explicit_override_wins():
+    f = _make_finding(Severity.LOW, model_routing="claude-sonnet-4-6")
+    mc = route_finding_fix(f)
+    assert mc.model == "sonnet-4-6"
+
+
+def test_parse_model_override():
+    assert parse_model_override("claude-opus-4-6").provider == "claude"
+    assert parse_model_override("qwen-3.5-122b-sovereign").provider == "aihub"

--- a/tests/findings/test_symbol_search.py
+++ b/tests/findings/test_symbol_search.py
@@ -1,0 +1,28 @@
+"""Tests for symbol search fallback (D22)."""
+from __future__ import annotations
+import pytest
+from pathlib import Path
+from findings.lib.symbol_search import find_symbol
+
+
+def test_find_existing_function(tmp_path):
+    src = tmp_path / "lib.py"
+    src.write_text("def my_function(): pass\n")
+    hits = find_symbol("my_function", search_root=tmp_path)
+    assert len(hits) == 1
+    assert "my_function" in hits[0].text
+    assert hits[0].path == str(src)
+
+
+def test_find_returns_empty_when_missing(tmp_path):
+    (tmp_path / "lib.py").write_text("def other(): pass\n")
+    hits = find_symbol("missing_function", search_root=tmp_path)
+    assert hits == []
+
+
+def test_find_searches_recursively(tmp_path):
+    sub = tmp_path / "sub" / "deep"
+    sub.mkdir(parents=True)
+    (sub / "x.py").write_text("class FooBar: pass\n")
+    hits = find_symbol("FooBar", search_root=tmp_path)
+    assert len(hits) == 1

--- a/tests/findings/test_validate_review_freshness.py
+++ b/tests/findings/test_validate_review_freshness.py
@@ -1,0 +1,27 @@
+"""Tests for review freshness validation (Phase 0a)."""
+from __future__ import annotations
+import pytest
+from pathlib import Path
+from findings.validate_review_freshness import find_stale_files_in_reviews
+
+
+def test_finds_files_referenced_in_review_that_changed_since(tmp_path):
+    review = tmp_path / "review.md"
+    review.write_text(
+        "Some text\n"
+        "- **Datei:** `src/foo.ts`\n"
+        "- Issue in `src/bar.ts:42`\n"
+    )
+    changed_files = ["src/foo.ts"]
+
+    stale = find_stale_files_in_reviews([review], changed_files)
+    assert "src/foo.ts" in stale
+    assert "src/bar.ts" not in stale
+
+
+def test_no_stale_when_only_unrelated_files_changed(tmp_path):
+    review = tmp_path / "review.md"
+    review.write_text("Issue in `src/foo.ts`\n")
+    changed = ["src/unrelated.ts"]
+    stale = find_stale_files_in_reviews([review], changed)
+    assert stale == set()


### PR DESCRIPTION
## Summary

Implements a complete Findings-Backlog-System that turns bot-generated code reviews from `reviews/*.md` into an actionable backlog (`docs/findings/INDEX.md`), and a deterministic `/finding-fix F-XXX` DAG that fixes individual findings with Sovereign-First model routing.

26 commits, 49 unit tests, ~2.100 LoC of new Python code under `scripts/findings/` and `tests/findings/`. `pyproject.toml` declares Python 3.9+ deps (pydantic, requests, anthropic, pyyaml).

## Architecture decisions

- **Pure Python + Pydantic** — no LangGraph/LlamaIndex/CrewAI dependency
- **Map-Reduce-Manage** pattern: parallel bot reviews (children) + single-threaded extractor (manager) → INDEX.md (single source of truth)
- **Deterministic DAG** for `/finding-fix`: load → verify_path → read_affected_files → judge_necessity → apply_fix → run_tests → update_index. No autonomous ReAct loops.
- **Sovereign-First Routing** with two-tier auto-fallback:
  - low/medium → qwen-3.5-122b-sovereign (FREE)
  - high → claude-sonnet-4-6
  - critical → claude-opus-4-6 + mandatory human review
  - Auto-fallback: aihub → qwen3-coder-480b → claude-haiku-4-5
- **Hard timeout** (300s) on the DAG via ThreadPoolExecutor to prevent hung LLM calls from blocking
- **Sichtfeld-Klausel** (D19) in bot prompts: bots cannot label things outside their scope as Critical Findings
- **Symbol-search + basename fallback** (D22) when finding paths are imprecise

## Live-validated bug fixes

The first `/finding-fix` runs surfaced 6 real bugs that have been fixed in this PR:

1. **`verify_path` basename fallback** — paths without `:symbol` suffix now fall back to filename-stem search across `src/`
2. **AIHubError graceful handling** — provider 504s no longer crash the DAG; counted as tool errors, trigger fallback
3. **Two-tier fallback** — keep first fallback within AI Hub, escalate to Anthropic only as last resort (avoids hard `anthropic` SDK dependency)
4. **Idempotent extractor** — repeated `--single` calls don't overwrite existing F-XXX files; INDEX.md regenerated from disk, not from in-memory state
5. **max_tokens token-fix** — apply 8000 → 2000, judge 2000 → 500. Fits Qwen-Thinking output under the LiteLLM gateway timeout (was causing 504s)
6. **Content-None normalisation** — Qwen-Thinking sometimes emits everything in `reasoning_content` with `content: null`. Client now normalises to a string

## Test plan

- [x] Unit tests: 49/49 green (`PYTHONPATH=scripts python3 -m pytest tests/findings -q`)
- [x] Vitest regression: 830 tests green (no regressions)
- [x] Live AI Hub auth + ping: HTTP 200, ~0.4-2s latency
- [x] Live `/finding-fix F-013` (low, a11y): wrote `aria-label` to ConnectionStatusBar.tsx — proved real fix application
- [ ] Initial backlog extraction (`npm run findings:extract`) on existing 36 reviews — partial (15 findings extracted, AI Hub provider 504s on some sovereign calls)
- [ ] Real-world `/finding-fix` campaigns once provider is stable

## Out-of-scope (separate PR)

- 52 Dependabot vulnerabilities on main
- E2E test failures pre-dating this PR (PR #116)

## Spec

The full spec is at `docs/superpowers/specs/2026-03-17-findings-backlog-system-design.md` (locally; `docs/` is gitignored as the GitHub repo is public). Module overview lives in `scripts/findings/README.md` (committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)