### PR TITLE
feat(findings): plan/apply/review DAG for /finding-fix (replaces monolithic apply_fix)

### DIFF
--- a/scripts/findings/dag_nodes/apply_patch.py
+++ b/scripts/findings/dag_nodes/apply_patch.py
@@ -1,7 +1,7 @@
 """DAG node: apply state.planned_changes to the target file using the local patcher.
 
 Pure local — NO LLM call.  Uses code_patcher.apply_changes (deterministic).
-Implements the "apply" step of the Belegflow-pattern pipeline:
+Implements the "apply" step of the plan/apply/review pipeline:
 
     plan_changes (LLM)  →  apply_patch (LOCAL)  →  review_patch (LLM)
 

--- a/scripts/findings/dag_nodes/apply_patch.py
+++ b/scripts/findings/dag_nodes/apply_patch.py
@@ -1,0 +1,64 @@
+"""DAG node: apply state.planned_changes to the target file using the local patcher.
+
+Pure local — NO LLM call.  Uses code_patcher.apply_changes (deterministic).
+Implements the "apply" step of the Belegflow-pattern pipeline:
+
+    plan_changes (LLM)  →  apply_patch (LOCAL)  →  review_patch (LLM)
+
+This separation guarantees that the LLM never writes files directly:
+it only produces structured change operations, which a deterministic
+code patcher applies and a reviewer LLM then validates.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..lib.code_patcher import apply_changes
+from ..lib.models import FindingFixState
+
+
+def apply_patch(state: FindingFixState, *, repo_root: str | Path) -> FindingFixState:
+    """Apply state.planned_changes to the file at repo_root / state.path_resolved.
+
+    Pre-conditions (from upstream nodes):
+    - state.planned_changes contains at least one operation dict (from plan_changes)
+    - state.path_resolved is set and points to an existing file within repo_root
+
+    Outputs written to state:
+    - state.fix_applied: True if patch succeeded, False otherwise
+    - state.patched_content: new file content (str) when fix_applied is True
+    - state.patch_warnings: list of non-fatal warnings from the patcher
+    - state.patch_errors: list of error messages when fix_applied is False
+    """
+    if not state.planned_changes:
+        state.fix_applied = False
+        return state
+
+    repo_root = Path(repo_root)
+
+    if not state.path_resolved:
+        state.fix_applied = False
+        state.patch_errors = ["path_resolved is not set"]
+        return state
+
+    target = repo_root / state.path_resolved
+    if not target.is_file():
+        state.fix_applied = False
+        state.patch_errors = [f"Target file not found: {state.path_resolved}"]
+        return state
+
+    file_content = target.read_text(encoding="utf-8")
+    result = apply_changes(file_content, state.planned_changes, file_path=state.path_resolved)
+
+    state.patch_warnings = result.warnings
+
+    if result.success:
+        target.write_text(result.new_content, encoding="utf-8")
+        state.patched_content = result.new_content
+        state.fix_applied = True
+        state.patch_errors = []
+    else:
+        state.fix_applied = False
+        state.patch_errors = result.errors
+
+    return state

--- a/scripts/findings/dag_nodes/plan_changes.py
+++ b/scripts/findings/dag_nodes/plan_changes.py
@@ -1,0 +1,190 @@
+"""DAG node: ask the LLM to PLAN structured code changes.
+
+Belegflow-pattern: LLM never produces full file content — only structured
+operations (replace_text, insert_before_line, etc.) that the deterministic
+apply_patch node applies.  This avoids Qwen-Thinking's known incompatibility
+with structured output (Alibaba/vLLM official: thinking mode does not support
+response_format=json_object) and prevents full-file hallucination drift.
+
+Routing: qwen3-coder-480b (non-thinking by nature, code-specialised).
+Temperature override: 0.3 (well below the 1.0 default for this model).
+max_tokens: 4000 (sufficient for structured plan, avoids gateway timeout).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..lib.aihub_client import AIHubClient, AIHubError
+from ..lib.json_extract import extract_json
+from ..lib.models import FindingFixState
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_PLAN_SYSTEM_PROMPT = """Du bist ein präziser Code-Chirurg. Deine Aufgabe ist es, minimale,
+chirurgische Code-Änderungen als STRUKTURIERTE OPERATIONEN zu planen.
+
+Antworte AUSSCHLIESSLICH mit einem JSON-Objekt. Kein Markdown, kein Freitext.
+
+## Unterstützte Operationstypen (Feld "typ")
+
+| typ                  | Pflichtfelder                          | Beschreibung                                  |
+|----------------------|----------------------------------------|-----------------------------------------------|
+| replace_text         | find (str), replace (str)             | Eindeutigen Substring ersetzen                |
+| replace_lines        | line_from (int), line_to (int), new_text (str) | Zeilen ersetzen (1-indexed, inklusiv) |
+| insert_before_line   | line (int), text (str)                | Text VOR Zeile einfügen (1-indexed)           |
+| insert_after_line    | line (int), text (str)                | Text NACH Zeile einfügen (1-indexed)          |
+| delete_lines         | line_from (int), line_to (int)        | Zeilen löschen (1-indexed, inklusiv)          |
+| append_to_file       | text (str)                            | Text ans Dateiende anhängen                   |
+| prepend_to_file      | text (str)                            | Text an den Dateianfang voranstellen          |
+
+## Antwort-Schema
+
+{
+  "analyse": "1-3 Sätze: Was ist das Problem und wie wird es behoben",
+  "aenderungen": [
+    {
+      "typ": "<operation>",
+      ... operationsspezifische Felder ...
+    }
+  ]
+}
+
+## Konkretes Beispiel (replace_text für a11y-Fix)
+
+Aufgabe: Button hat kein aria-label.
+Vorher: <button onClick={handleClose}>X</button>
+Nachher: <button aria-label="Dialog schließen" onClick={handleClose}>X</button>
+
+{
+  "analyse": "Der Schließen-Button hat kein aria-label. Screen-Reader-Nutzer können den Zweck nicht erkennen. Füge aria-label hinzu.",
+  "aenderungen": [
+    {
+      "typ": "replace_text",
+      "find": "<button onClick={handleClose}>X</button>",
+      "replace": "<button aria-label=\\"Dialog schließen\\" onClick={handleClose}>X</button>"
+    }
+  ]
+}
+
+## Harte Regeln
+
+- NIEMALS den ganzen Datei-Inhalt produzieren — nur Operationen
+- replace_text: 'find' muss EXAKT und EINDEUTIG im Datei-Inhalt vorkommen (genau 1 Treffer)
+- Ändere NUR die Stellen die das Finding adressieren
+- Behalte Code-Style, Indentation, Imports unverändert
+- Schreibe KEINE Kommentare wie "// Fix für F-XXX"
+- Wenn mehrere unabhängige Stellen geändert werden müssen: mehrere Operationen in der Liste
+- Bei Zeilennummern: exakt die Zeilennummern aus dem bereitgestellten Code mit Zeilennummern verwenden
+"""
+
+
+def _build_user_message(state: FindingFixState, file_content: str) -> str:
+    """Build the user message with numbered file content and finding context."""
+    finding = state.finding
+
+    # Build acceptance criteria block
+    aks = "\n".join(f"- {ak}" for ak in finding.acceptance_criteria) if finding.acceptance_criteria else "- (keine)"
+
+    # Number the lines for easy reference by the LLM
+    numbered_lines = "\n".join(
+        f"{i + 1:4d}| {line}" for i, line in enumerate(file_content.splitlines())
+    )
+
+    return (
+        f"## Finding\n"
+        f"{finding.title}\n"
+        f"Severity: {finding.severity.value}\n"
+        f"File: {finding.file}\n"
+        f"Akzeptanzkriterien:\n{aks}\n"
+        f"\n"
+        f"## Aktueller Code (echter Datei-Inhalt mit Zeilennummern)\n"
+        f"{numbered_lines}\n"
+        f"\n"
+        f"## Deine Aufgabe\n"
+        f"Plane Änderungen die ALLE Akzeptanzkriterien erfüllen. "
+        f"Antworte mit JSON gemäß dem System-Prompt-Schema."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal LLM call (split out for easy mocking in tests)
+# ---------------------------------------------------------------------------
+
+def _call_plan_llm(routing, user_message: str) -> str:
+    """Call the AI Hub with the plan prompt. Returns raw LLM response string."""
+    client = AIHubClient()
+    result = client.chat(
+        model=routing.model,
+        messages=[
+            {"role": "system", "content": _PLAN_SYSTEM_PROMPT},
+            {"role": "user", "content": user_message},
+        ],
+        max_tokens=4000,
+        temperature_override=0.3,
+    )
+    return result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Public DAG node
+# ---------------------------------------------------------------------------
+
+def plan_changes(state: FindingFixState, *, repo_root: str | Path) -> FindingFixState:
+    """Ask the LLM to produce a structured patch plan for state.finding.
+
+    Pre-conditions (from upstream nodes):
+    - state.is_still_valid is True
+    - state.path_resolved is set
+    - The file exists at repo_root / state.path_resolved
+
+    Outputs written to state:
+    - state.planned_changes: list of operation dicts
+    - state.plan_analyse: human-readable summary string
+    - state.tool_call_errors += 1 on any failure
+    """
+    if not state.is_still_valid:
+        state.planned_changes = []
+        return state
+
+    if not state.path_resolved:
+        state.planned_changes = []
+        state.tool_call_errors += 1
+        return state
+
+    repo_root = Path(repo_root)
+    target = repo_root / state.path_resolved
+    if not target.is_file():
+        state.planned_changes = []
+        state.tool_call_errors += 1
+        return state
+
+    file_content = target.read_text(encoding="utf-8")
+    user_message = _build_user_message(state, file_content)
+
+    try:
+        raw = _call_plan_llm(state.routing, user_message)
+    except AIHubError:
+        state.planned_changes = []
+        state.tool_call_errors += 1
+        return state
+    except Exception:
+        state.planned_changes = []
+        state.tool_call_errors += 1
+        return state
+
+    data = extract_json(raw)
+    if data is None:
+        state.planned_changes = []
+        state.tool_call_errors += 1
+        return state
+
+    aenderungen = data.get("aenderungen", [])
+    if not isinstance(aenderungen, list):
+        aenderungen = []
+
+    state.planned_changes = aenderungen
+    state.plan_analyse = data.get("analyse") or None
+    return state

--- a/scripts/findings/dag_nodes/plan_changes.py
+++ b/scripts/findings/dag_nodes/plan_changes.py
@@ -115,6 +115,17 @@ def _build_user_message(state: FindingFixState, file_content: str) -> str:
 
 def _call_plan_llm(routing, user_message: str) -> str:
     """Call the AI Hub with the plan prompt. Returns raw LLM response string."""
+    # Temperature: 0.3 — DELIBERATELY lower than Qwen3-Coder default (1.0).
+    #
+    # Rationale: We need DETERMINISTIC structured operation output (JSON aenderungen-list),
+    # not creative code generation. Higher temperatures cause Qwen3-Coder to occasionally
+    # wrap valid JSON in extra prose or vary the operation 'typ' names, breaking the
+    # patcher. 0.3 is the value Belegflow's production pipeline uses (workflows/agents/
+    # scripts/aihub_pipeline_v3.py) for the same reason.
+    #
+    # If patcher-error rates climb above ~10% in .claude/logs/finding-fixes.jsonl,
+    # consider raising to 0.5 or implementing response_format=json_schema (LiteLLM
+    # supports it for Qwen Coder series).
     client = AIHubClient()
     result = client.chat(
         model=routing.model,

--- a/scripts/findings/dag_nodes/plan_changes.py
+++ b/scripts/findings/dag_nodes/plan_changes.py
@@ -1,6 +1,6 @@
 """DAG node: ask the LLM to PLAN structured code changes.
 
-Belegflow-pattern: LLM never produces full file content — only structured
+Pattern: the LLM never produces full file content — only structured
 operations (replace_text, insert_before_line, etc.) that the deterministic
 apply_patch node applies.  This avoids Qwen-Thinking's known incompatibility
 with structured output (Alibaba/vLLM official: thinking mode does not support
@@ -120,8 +120,8 @@ def _call_plan_llm(routing, user_message: str) -> str:
     # Rationale: We need DETERMINISTIC structured operation output (JSON aenderungen-list),
     # not creative code generation. Higher temperatures cause Qwen3-Coder to occasionally
     # wrap valid JSON in extra prose or vary the operation 'typ' names, breaking the
-    # patcher. 0.3 is the value Belegflow's production pipeline uses (workflows/agents/
-    # scripts/aihub_pipeline_v3.py) for the same reason.
+    # patcher. Lower temperature reduces the rate at which Qwen3-Coder wraps
+    # JSON in extra prose or varies the 'typ' field naming.
     #
     # If patcher-error rates climb above ~10% in .claude/logs/finding-fixes.jsonl,
     # consider raising to 0.5 or implementing response_format=json_schema (LiteLLM

--- a/scripts/findings/dag_nodes/review_patch.py
+++ b/scripts/findings/dag_nodes/review_patch.py
@@ -1,4 +1,4 @@
-"""DAG node: LLM-based patch reviewer (Belegflow-pattern).
+"""DAG node: LLM-based patch reviewer (final stage of plan/apply/review DAG).
 
 Validates that the deterministic patcher produced a correct result by asking
 a second LLM to compare the original finding + planned operations against
@@ -22,8 +22,7 @@ _REVIEW_MODEL = "gpt-4.1-mini"
 # Temperature: 0.5 — middle ground.
 #
 # Reviewer needs both structured JSON output (low temp) AND nuanced judgement
-# about edge cases (higher temp). 0.5 balances both. Belegflow uses the same
-# value for their reviewer agent.
+# about edge cases (higher temp). 0.5 balances both.
 _REVIEW_TEMPERATURE = 0.5
 _REVIEW_MAX_TOKENS = 1500
 

--- a/scripts/findings/dag_nodes/review_patch.py
+++ b/scripts/findings/dag_nodes/review_patch.py
@@ -47,6 +47,31 @@ Verdickt-Definitionen:
 - REJECTED:     Der Patch löst das Finding NICHT oder bringt offensichtliche Bugs/Regressionen.
 - NEEDS_HUMAN:  Unklar, Edge-Case, breaking change risk, oder Sicherheits-Implikation.
 
+STRUKTURELLE PFLICHT-CHECKS (alle MÜSSEN ✓ für APPROVED):
+
+1. **Scope-Korrektheit**: Werden neue Funktionen/Konstanten/Types am korrekten Scope-Level eingefügt?
+   - Neue helper-Funktionen → module-level (nicht innerhalb anderer Funktionen)
+   - Neue React-Hooks-Aufrufe → top of component (nicht in conditionals/loops)
+   - Neue Imports → top of file
+   - Verstoß? → REJECTED
+
+2. **Syntax-Plausibilität**: Sind Klammern, Brackets, Generics, JSX-Tags korrekt geschlossen?
+   - Inkonsistente Indentation, fehlende Schließ-Brackets → REJECTED
+
+3. **Side-Effect-Risk**: Verändert der Patch globalen Zustand, Imports, oder API-Contracts?
+   - JA → NEEDS_HUMAN (nicht APPROVED, auch wenn korrekt)
+
+4. **Acceptance-Criteria**: Erfüllt jeder einzelne AK aus dem Finding?
+   - Auch nur EIN AK nicht erfüllt → REJECTED
+
+5. **Test-Impact**: Würden die Änderungen plausibel bestehende Tests brechen?
+   - Function-rename ohne Aufrufer-Update? → REJECTED
+   - Type-Signature-Änderung ohne consumer-update? → REJECTED
+   - Im Zweifel → NEEDS_HUMAN
+
+WENN DU UNSICHER BIST → NEEDS_HUMAN, niemals APPROVED.
+APPROVED ist die Ausnahme, nicht die Regel.
+
 Sei streng: Im Zweifel NEEDS_HUMAN statt APPROVED.
 Antworte NUR mit JSON — kein Markdown, kein Freitext darum herum.
 """

--- a/scripts/findings/dag_nodes/review_patch.py
+++ b/scripts/findings/dag_nodes/review_patch.py
@@ -1,0 +1,154 @@
+"""DAG node: LLM-based patch reviewer (Belegflow-pattern).
+
+Validates that the deterministic patcher produced a correct result by asking
+a second LLM to compare the original finding + planned operations against
+the actual patched file content.
+
+Routing: gpt-4.1-mini via AI Hub (EU-hosted, OpenAI-style API, no
+Qwen thinking-mode conflicts).
+
+Verdicts:
+  APPROVED     — patch fulfils all acceptance criteria, no obvious bugs
+  REJECTED     — patch does not fix the finding or introduces clear bugs
+  NEEDS_HUMAN  — unclear / edge-case / breaking-change risk, human required
+"""
+from __future__ import annotations
+
+from ..lib.aihub_client import AIHubClient, AIHubError
+from ..lib.json_extract import extract_json
+from ..lib.models import FindingFixState
+
+_REVIEW_MODEL = "gpt-4.1-mini"
+_REVIEW_TEMPERATURE = 0.5
+_REVIEW_MAX_TOKENS = 1500
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+_REVIEW_SYSTEM_PROMPT = """Du bist ein erfahrener Code-Reviewer. Deine Aufgabe ist es zu beurteilen,
+ob ein automatisch erzeugter Code-Patch ein gemeldetes Finding korrekt behebt.
+
+Du erhältst:
+1. Das Finding mit Akzeptanzkriterien
+2. Den geplanten Patch (strukturierte Operationen)
+3. Den tatsächlichen Datei-Inhalt NACH Anwendung des Patches
+
+Antworte AUSSCHLIESSLICH mit einem JSON-Objekt:
+{
+  "verdict": "APPROVED" | "REJECTED" | "NEEDS_HUMAN",
+  "reasoning": "1-2 Sätze warum",
+  "concerns": ["optionale Liste konkreter Bedenken"]
+}
+
+Verdickt-Definitionen:
+- APPROVED:     Der Patch erfüllt ALLE Akzeptanzkriterien. Keine offensichtlichen Bugs.
+- REJECTED:     Der Patch löst das Finding NICHT oder bringt offensichtliche Bugs/Regressionen.
+- NEEDS_HUMAN:  Unklar, Edge-Case, breaking change risk, oder Sicherheits-Implikation.
+
+Sei streng: Im Zweifel NEEDS_HUMAN statt APPROVED.
+Antworte NUR mit JSON — kein Markdown, kein Freitext darum herum.
+"""
+
+
+def _build_review_user_message(state: FindingFixState) -> str:
+    """Assemble the review prompt with finding, planned changes, and patched content."""
+    finding = state.finding
+    aks = "\n".join(f"- {ak}" for ak in finding.acceptance_criteria) if finding.acceptance_criteria else "- (keine)"
+
+    import json as _json
+    changes_repr = _json.dumps(state.planned_changes, ensure_ascii=False, indent=2)
+
+    patched = state.patched_content or "(kein Inhalt verfügbar)"
+
+    return (
+        f"## Finding\n"
+        f"ID: {finding.id}\n"
+        f"Titel: {finding.title}\n"
+        f"Severity: {finding.severity.value}\n"
+        f"Akzeptanzkriterien:\n{aks}\n"
+        f"\n"
+        f"## Geplante Änderungen (strukturierte Operationen)\n"
+        f"```json\n{changes_repr}\n```\n"
+        f"\n"
+        f"## Datei-Inhalt NACH Patch\n"
+        f"```\n{patched}\n```\n"
+        f"\n"
+        f"Beurteile: Erfüllt der Patch ALLE Akzeptanzkriterien ohne Bugs/Regressionen?\n"
+        f"Antworte mit JSON."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal LLM call (split out for easy mocking in tests)
+# ---------------------------------------------------------------------------
+
+def _call_review_llm(user_message: str) -> str:
+    """Call the review LLM and return raw response string."""
+    client = AIHubClient()
+    result = client.chat(
+        model=_REVIEW_MODEL,
+        messages=[
+            {"role": "system", "content": _REVIEW_SYSTEM_PROMPT},
+            {"role": "user", "content": user_message},
+        ],
+        max_tokens=_REVIEW_MAX_TOKENS,
+        temperature_override=_REVIEW_TEMPERATURE,
+    )
+    return result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Public DAG node
+# ---------------------------------------------------------------------------
+
+def review_patch(state: FindingFixState) -> FindingFixState:
+    """Review the patch using a second LLM and set state.review_verdict.
+
+    Pre-conditions (from upstream apply_patch node):
+    - state.fix_applied is True
+    - state.patched_content is set
+    - state.planned_changes is non-empty
+
+    Outputs written to state:
+    - state.review_verdict: "APPROVED" | "REJECTED" | "NEEDS_HUMAN"
+    - state.review_reasoning: short explanation string
+    """
+    if not state.fix_applied:
+        # Nothing was patched; skip review but mark as needing human attention
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = "apply_patch did not produce a patch (fix_applied=False)"
+        return state
+
+    user_message = _build_review_user_message(state)
+
+    try:
+        raw = _call_review_llm(user_message)
+    except AIHubError as exc:
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = f"AIHubError during review: {exc}"
+        state.tool_call_errors += 1
+        return state
+    except Exception as exc:
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = f"Unexpected error during review: {exc}"
+        state.tool_call_errors += 1
+        return state
+
+    data = extract_json(raw)
+    if data is None:
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = "Could not parse LLM review response as JSON"
+        state.tool_call_errors += 1
+        return state
+
+    raw_verdict = data.get("verdict", "")
+    if raw_verdict not in ("APPROVED", "REJECTED", "NEEDS_HUMAN"):
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = f"Unknown verdict '{raw_verdict}' from review LLM"
+        return state
+
+    state.review_verdict = raw_verdict  # type: ignore[assignment]
+    state.review_reasoning = data.get("reasoning") or ""
+    return state

--- a/scripts/findings/dag_nodes/review_patch.py
+++ b/scripts/findings/dag_nodes/review_patch.py
@@ -19,6 +19,11 @@ from ..lib.json_extract import extract_json
 from ..lib.models import FindingFixState
 
 _REVIEW_MODEL = "gpt-4.1-mini"
+# Temperature: 0.5 — middle ground.
+#
+# Reviewer needs both structured JSON output (low temp) AND nuanced judgement
+# about edge cases (higher temp). 0.5 balances both. Belegflow uses the same
+# value for their reviewer agent.
 _REVIEW_TEMPERATURE = 0.5
 _REVIEW_MAX_TOKENS = 1500
 

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -119,11 +119,20 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
             if fb:
                 state.fallback_used = True
                 state.routing = fb
-                # Reset partial state and re-run plan→patch→review
+                # Reset ALL partial state from the previous attempt so the
+                # fallback log entry is clean and not misleadingly mixed with
+                # stale values (e.g. review_verdict: APPROVED while fix_applied: False).
                 state.planned_changes = []
+                state.plan_analyse = None
                 state.fix_applied = False
                 state.tests_pass = None
+                state.test_output = None
                 state.tool_call_errors = 0  # reset for clean retry
+                state.patched_content = None
+                state.patch_errors = []
+                state.patch_warnings = []
+                state.review_verdict = None
+                state.review_reasoning = None
                 state = plan_changes(state, repo_root=repo_root)
                 if state.planned_changes:
                     state = apply_patch(state, repo_root=repo_root)

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -1,6 +1,6 @@
 """DAG orchestrator for /finding-fix.
 
-Flow (Belegflow-pattern, Spec section 5.4):
+Flow (plan/apply/review DAG, Spec section 5.4):
   load_finding → verify_path → read_affected_files → judge_necessity
                                                       │
                                                       ▼
@@ -70,7 +70,7 @@ def _run_dag(state: FindingFixState, *, repo_root: Path) -> FindingFixState:
     state = judge_necessity(state)
     if not state.is_still_valid:
         return state
-    # NEW: plan → patch → review (Belegflow-pattern, replaces single apply_fix call)
+    # NEW: plan → patch → review (replaces single apply_fix call)
     state = plan_changes(state, repo_root=repo_root)
     if not state.planned_changes:
         return state  # plan failed
@@ -158,7 +158,7 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
             "tool_call_errors": state.tool_call_errors,
             "duration_ms": state.duration_ms,
             "path_resolution": state.path_resolution_method,
-            # NEW: Belegflow-pattern fields
+            # NEW: plan/apply/review fields
             "planned_changes_count": len(state.planned_changes),
             "patch_errors_count": len(state.patch_errors) if state.patch_errors else 0,
             "review_verdict": state.review_verdict,

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -1,22 +1,31 @@
 """DAG orchestrator for /finding-fix.
 
-Flow (Spec section 5.4):
+Flow (Belegflow-pattern, Spec section 5.4):
   load_finding → verify_path → read_affected_files → judge_necessity
                                                       │
                                                       ▼
-                                                 apply_fix
+                                                 plan_changes  (LLM: structured operations)
                                                       │
                                                       ▼
-                                                 run_tests
+                                                 apply_patch   (local, deterministic)
                                                       │
-                                                ┌─────┴─────┐
-                                              pass         fail
-                                                │           │
-                                                ▼           ▼
-                                          update_index   fallback?
-                                                              │
-                                                              ▼
-                                                      retry with claude-haiku-4-5
+                                                      ▼
+                                                 review_patch  (LLM: validate result)
+                                                      │
+                                              ┌───────┴───────┐
+                                           APPROVED      REJECTED/NEEDS_HUMAN
+                                              │                │
+                                              ▼                ▼
+                                         run_tests        (flag for human)
+                                              │
+                                         ┌───┴───┐
+                                       pass     fail
+                                         │       │
+                                         ▼       ▼
+                                   update_index  fallback?
+                                                    │
+                                                    ▼
+                                            retry from plan_changes
 
 Hard-Caps (R7): max_steps=10 internally, max_duration=300s (HARD_TIMEOUT_S).
 The timeout is enforced via concurrent.futures.ThreadPoolExecutor — NOT signal.alarm,
@@ -37,7 +46,10 @@ from .lib.routing import route_finding_fix, fallback_for, ModelChoice
 from .dag_nodes.verify_path import verify_path
 from .dag_nodes.read_affected_files import read_affected_files
 from .dag_nodes.judge_necessity import judge_necessity
-from .dag_nodes.apply_fix import apply_fix
+from .dag_nodes.apply_fix import apply_fix  # kept for back-compat; no longer called from _run_dag
+from .dag_nodes.plan_changes import plan_changes
+from .dag_nodes.apply_patch import apply_patch
+from .dag_nodes.review_patch import review_patch
 from .dag_nodes.run_tests import run_tests
 from .dag_nodes.update_index import update_finding_status, regenerate_index
 
@@ -58,9 +70,18 @@ def _run_dag(state: FindingFixState, *, repo_root: Path) -> FindingFixState:
     state = judge_necessity(state)
     if not state.is_still_valid:
         return state
-    state = apply_fix(state, repo_root=repo_root)
-    if state.fix_applied:
-        state = run_tests(state, repo_root=repo_root)
+    # NEW: plan → patch → review (Belegflow-pattern, replaces single apply_fix call)
+    state = plan_changes(state, repo_root=repo_root)
+    if not state.planned_changes:
+        return state  # plan failed
+    state = apply_patch(state, repo_root=repo_root)
+    if not state.fix_applied:
+        return state  # patch ops failed (e.g., replace_text not unique)
+    state = review_patch(state)
+    if state.review_verdict != "APPROVED":
+        # REJECTED or NEEDS_HUMAN: do NOT run tests, leave file as patched but flag for human
+        return state
+    state = run_tests(state, repo_root=repo_root)
     return state
 
 
@@ -98,12 +119,18 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
             if fb:
                 state.fallback_used = True
                 state.routing = fb
-                # Reset partial state and re-run from apply_fix
+                # Reset partial state and re-run plan→patch→review
+                state.planned_changes = []
                 state.fix_applied = False
                 state.tests_pass = None
-                state = apply_fix(state, repo_root=repo_root)
-                if state.fix_applied:
-                    state = run_tests(state, repo_root=repo_root)
+                state.tool_call_errors = 0  # reset for clean retry
+                state = plan_changes(state, repo_root=repo_root)
+                if state.planned_changes:
+                    state = apply_patch(state, repo_root=repo_root)
+                    if state.fix_applied:
+                        state = review_patch(state)
+                        if state.review_verdict == "APPROVED":
+                            state = run_tests(state, repo_root=repo_root)
 
         # If finally green: mark fixed + commit (not done by DAG; user reviews and commits)
         if state.tests_pass:
@@ -122,6 +149,10 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
             "tool_call_errors": state.tool_call_errors,
             "duration_ms": state.duration_ms,
             "path_resolution": state.path_resolution_method,
+            # NEW: Belegflow-pattern fields
+            "planned_changes_count": len(state.planned_changes),
+            "patch_errors_count": len(state.patch_errors) if state.patch_errors else 0,
+            "review_verdict": state.review_verdict,
         })
 
     return state
@@ -140,6 +171,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"\n--- Result for {fid} ---")
     print(f"Path-resolution: {result.path_resolution_method}")
     print(f"Judge says valid: {result.is_still_valid}")
+    print(f"Planned changes count: {len(result.planned_changes)}")
+    print(f"Patch errors: {result.patch_errors}")
+    print(f"Review verdict: {result.review_verdict}")
     print(f"Fix applied: {result.fix_applied}")
     print(f"Tests pass: {result.tests_pass}")
     print(f"Fallback used: {result.fallback_used}")

--- a/scripts/findings/lib/aihub_client.py
+++ b/scripts/findings/lib/aihub_client.py
@@ -17,6 +17,7 @@ DEFAULT_TIMEOUT = 600  # 10 min for thinking-mode
 QWEN_THINKING_PARAMS = {"temperature": 0.6, "top_p": 0.95, "top_k": 20, "presence_penalty": 0.0}
 QWEN_CODER_PARAMS = {"temperature": 1.0, "top_p": 0.95, "top_k": 20, "presence_penalty": 0.0}
 GPT_OSS_PARAMS = {"temperature": 0.7, "top_p": 0.8, "top_k": 20, "presence_penalty": 0.0}
+GPT_OPENAI_PARAMS = {"temperature": 0.5, "top_p": 0.95, "presence_penalty": 0.0}
 
 
 class AIHubError(Exception):
@@ -37,12 +38,34 @@ class AIHubClient:
             return {**QWEN_THINKING_PARAMS, "extra_body": {"enable_thinking": True, "min_p": 0}}
         if model.startswith("gpt-oss"):
             return {**GPT_OSS_PARAMS}
-        # Conservative default
+        if model.startswith("gpt-4") or model.startswith("gpt-3"):
+            # OpenAI-style models (e.g. gpt-4.1-mini): no Qwen extra_body params
+            return {**GPT_OPENAI_PARAMS}
+        # Conservative default (no provider-specific extra_body)
         return {"temperature": 0.6, "top_p": 0.95}
 
-    def chat(self, model: str, messages: List[dict], max_tokens: int = 32000, timeout: int = DEFAULT_TIMEOUT) -> dict:
-        """Send a chat completion request. Returns {content, tokens_in, tokens_out, raw}."""
+    def chat(
+        self,
+        model: str,
+        messages: List[dict],
+        max_tokens: int = 32000,
+        timeout: int = DEFAULT_TIMEOUT,
+        temperature_override: float | None = None,
+    ) -> dict:
+        """Send a chat completion request. Returns {content, tokens_in, tokens_out, raw}.
+
+        Args:
+            model:               Model identifier.
+            messages:            Chat messages list.
+            max_tokens:          Token budget for the response.
+            timeout:             HTTP request timeout in seconds.
+            temperature_override: When set, replaces the model-default temperature.
+                                  Use for nodes that require deterministic output
+                                  (e.g. plan_changes at 0.3 instead of coder-default 1.0).
+        """
         params = self._params_for_model(model)
+        if temperature_override is not None:
+            params = {**params, "temperature": temperature_override}
         payload = {
             "model": model,
             "messages": messages,

--- a/scripts/findings/lib/code_patcher.py
+++ b/scripts/findings/lib/code_patcher.py
@@ -1,0 +1,338 @@
+"""Deterministic code patcher — Belegflow-pattern Foundation Layer.
+
+LLM produces structured change operations; this module applies them atomically
+to source file content (pure string-in / string-out, no I/O).
+
+Supported operations (field "typ"):
+  replace_text       — find exact unique substring and replace it
+  replace_lines      — replace lines [line_from, line_to] (1-indexed, inclusive)
+  insert_before_line — insert text before line N (1-indexed)
+  insert_after_line  — insert text after line N (1-indexed)
+  delete_lines       — delete lines [line_from, line_to] (1-indexed, inclusive)
+  append_to_file     — append text at end of file
+  prepend_to_file    — prepend text at start of file
+
+Atomicity guarantee: if any single operation fails, the entire patch is
+rejected and new_content is None.  No partial changes are returned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PatchResult:
+    success: bool
+    new_content: str | None   # None when success is False
+    applied: int              # number of operations successfully applied
+    errors: list[str]         # human-readable failure messages
+    warnings: list[str]       # non-fatal notes
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _split_lines(content: str) -> list[str]:
+    """Split file content into lines, preserving line endings on each element.
+
+    The last line may lack a trailing newline — that is intentional.
+    Recombining with ''.join(lines) must reproduce the original content exactly.
+    """
+    # str.splitlines(keepends=True) handles \\n, \\r\\n, \\r correctly.
+    # An empty string returns [], but we need to distinguish "" from "\\n":
+    # for our purposes the round-trip property ''.join(splitlines(True)) == s
+    # holds for all inputs, which is what we need.
+    return content.splitlines(keepends=True)
+
+
+def _join_lines(lines: list[str]) -> str:
+    return "".join(lines)
+
+
+def _check_line_bounds(
+    op_name: str,
+    line_from: int,
+    line_to: int,
+    total_lines: int,
+    file_path: str,
+) -> str | None:
+    """Return an error string if the range is invalid, else None."""
+    if line_from < 1:
+        return (
+            f"{op_name}: line_from={line_from} is below 1 "
+            f"(file has {total_lines} lines) in {file_path}"
+        )
+    if line_to < line_from:
+        return (
+            f"{op_name}: line_to={line_to} < line_from={line_from} "
+            f"(inverted range) in {file_path}"
+        )
+    if line_to > total_lines:
+        return (
+            f"{op_name}: line_to={line_to} exceeds file length "
+            f"({total_lines} lines) in {file_path}"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Operation implementations — each returns (new_lines, warning | None)
+# or raises ValueError on failure.
+# ---------------------------------------------------------------------------
+
+def _op_replace_text(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    find_str: str = change.get("find", "")
+    replace_str: str = change.get("replace", "")
+
+    if not find_str:
+        raise ValueError(
+            f"replace_text: 'find' is empty or missing in {file_path}"
+        )
+
+    content = _join_lines(lines)
+    count = content.count(find_str)
+
+    if count == 0:
+        raise ValueError(
+            f"replace_text: '{find_str[:80]}' found 0 times in {file_path}"
+        )
+    if count > 1:
+        raise ValueError(
+            f"replace_text: '{find_str[:80]}' found {count} times in {file_path} "
+            f"(must be unique)"
+        )
+
+    new_content = content.replace(find_str, replace_str, 1)
+    return _split_lines(new_content), None
+
+
+def _op_replace_lines(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    line_from: int = change.get("line_from")
+    line_to: int = change.get("line_to")
+    new_text: str = change.get("new_text", "")
+
+    if line_from is None or line_to is None:
+        raise ValueError(
+            f"replace_lines: 'line_from' or 'line_to' missing in {file_path}"
+        )
+
+    err = _check_line_bounds("replace_lines", line_from, line_to, len(lines), file_path)
+    if err:
+        raise ValueError(err)
+
+    # Convert to 0-indexed
+    replacement_lines = _split_lines(new_text)
+    new_lines = lines[: line_from - 1] + replacement_lines + lines[line_to:]
+    return new_lines, None
+
+
+def _op_insert_before_line(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    line: int = change.get("line")
+    text: str = change.get("text", "")
+
+    if line is None:
+        raise ValueError(f"insert_before_line: 'line' missing in {file_path}")
+
+    total = len(lines)
+    # Valid range: 1 .. total  (inserting before line 1 = prepend)
+    # Inserting before line total+1 would be append — disallow to keep semantics clear.
+    if line < 1 or line > total:
+        raise ValueError(
+            f"insert_before_line: line={line} out of range "
+            f"[1, {total}] in {file_path}"
+        )
+
+    insert_lines = _split_lines(text)
+    new_lines = lines[: line - 1] + insert_lines + lines[line - 1 :]
+    return new_lines, None
+
+
+def _op_insert_after_line(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    line: int = change.get("line")
+    text: str = change.get("text", "")
+
+    if line is None:
+        raise ValueError(f"insert_after_line: 'line' missing in {file_path}")
+
+    total = len(lines)
+    # Valid range: 1 .. total
+    if line < 1 or line > total:
+        raise ValueError(
+            f"insert_after_line: line={line} out of range "
+            f"[1, {total}] in {file_path}"
+        )
+
+    insert_lines = _split_lines(text)
+    new_lines = lines[:line] + insert_lines + lines[line:]
+    return new_lines, None
+
+
+def _op_delete_lines(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    line_from: int = change.get("line_from")
+    line_to: int = change.get("line_to")
+
+    if line_from is None or line_to is None:
+        raise ValueError(
+            f"delete_lines: 'line_from' or 'line_to' missing in {file_path}"
+        )
+
+    err = _check_line_bounds("delete_lines", line_from, line_to, len(lines), file_path)
+    if err:
+        raise ValueError(err)
+
+    new_lines = lines[: line_from - 1] + lines[line_to:]
+    return new_lines, None
+
+
+def _op_append_to_file(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    text: str = change.get("text", "")
+    warning: str | None = None
+
+    if not lines:
+        # Empty file — just set content
+        return _split_lines(text), None
+
+    # Ensure the last existing line ends with a newline before appending
+    if lines and not lines[-1].endswith(("\n", "\r")):
+        lines = lines[:-1] + [lines[-1] + "\n"]
+        warning = (
+            f"append_to_file: added missing trailing newline before appending in {file_path}"
+        )
+
+    append_lines = _split_lines(text)
+    return lines + append_lines, warning
+
+
+def _op_prepend_to_file(
+    lines: list[str],
+    change: dict,
+    file_path: str,
+) -> tuple[list[str], str | None]:
+    text: str = change.get("text", "")
+    prepend_lines = _split_lines(text)
+    return prepend_lines + lines, None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+_HANDLERS = {
+    "replace_text": _op_replace_text,
+    "replace_lines": _op_replace_lines,
+    "insert_before_line": _op_insert_before_line,
+    "insert_after_line": _op_insert_after_line,
+    "delete_lines": _op_delete_lines,
+    "append_to_file": _op_append_to_file,
+    "prepend_to_file": _op_prepend_to_file,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def apply_changes(
+    file_content: str,
+    changes: list[dict],
+    *,
+    file_path: str = "<file>",
+) -> PatchResult:
+    """Apply a list of change operations to a file's content (in-memory).
+
+    Each change dict has shape: {"typ": "<op>", ...op-specific fields}.
+
+    Operations are applied in sequence; each step receives the result of
+    the previous.  If ANY operation fails the whole patch is rejected
+    (atomic all-or-nothing): success=False, new_content=None.
+
+    Args:
+        file_content: Current file content as a string.
+        changes:      List of change operation dicts.
+        file_path:    Used only in error/warning messages.
+
+    Returns:
+        PatchResult with success flag, resulting content, counters, and messages.
+    """
+    if not changes:
+        return PatchResult(
+            success=True,
+            new_content=file_content,
+            applied=0,
+            errors=[],
+            warnings=[],
+        )
+
+    # Work on a mutable list of lines throughout; handlers return new lists.
+    current_lines: list[str] = _split_lines(file_content)
+    all_warnings: list[str] = []
+
+    for idx, change in enumerate(changes):
+        typ: str = change.get("typ", "")
+        handler = _HANDLERS.get(typ)
+
+        if handler is None:
+            known = ", ".join(sorted(_HANDLERS))
+            return PatchResult(
+                success=False,
+                new_content=None,
+                applied=idx,
+                errors=[
+                    f"op #{idx + 1}: unknown operation type '{typ}' "
+                    f"(known: {known}) in {file_path}"
+                ],
+                warnings=all_warnings,
+            )
+
+        try:
+            new_lines, warning = handler(current_lines, change, file_path)
+        except ValueError as exc:
+            return PatchResult(
+                success=False,
+                new_content=None,
+                applied=idx,
+                errors=[f"op #{idx + 1} ({typ}): {exc}"],
+                warnings=all_warnings,
+            )
+
+        current_lines = new_lines
+        if warning:
+            all_warnings.append(warning)
+
+    return PatchResult(
+        success=True,
+        new_content=_join_lines(current_lines),
+        applied=len(changes),
+        errors=[],
+        warnings=all_warnings,
+    )

--- a/scripts/findings/lib/code_patcher.py
+++ b/scripts/findings/lib/code_patcher.py
@@ -1,4 +1,4 @@
-"""Deterministic code patcher — Belegflow-pattern Foundation Layer.
+"""Deterministic code patcher — foundation layer for the plan/apply/review DAG.
 
 LLM produces structured change operations; this module applies them atomically
 to source file content (pure string-in / string-out, no I/O).

--- a/scripts/findings/lib/json_extract.py
+++ b/scripts/findings/lib/json_extract.py
@@ -1,0 +1,69 @@
+"""Robust JSON extraction from LLM responses.
+
+Handles the common wrappers that language models produce around JSON:
+1. <think>...</think> blocks (Qwen-Thinking-Mode)
+2. Markdown code fences: ```json ... ``` or ``` ... ```
+3. Direct JSON object
+4. First { to last } substring fallback
+
+All callers (plan_changes, review_patch, apply_fix) should use this
+helper to keep extraction logic in one place.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+
+def extract_json(raw: str) -> dict | None:
+    """Extract the first JSON object from an LLM response string.
+
+    Applies three fallbacks in order:
+    1. Strip <think>...</think> blocks, then try markdown code-fence unwrap + direct parse.
+    2. Direct JSON parse of the cleaned string.
+    3. Balanced-brace substring: scan for first '{' to matching '}'.
+
+    Returns the parsed dict, or None if no valid JSON object could be found.
+    """
+    if not raw:
+        return None
+
+    s = raw.strip()
+
+    # --- Step 0: strip Qwen-Thinking <think>...</think> blocks ---
+    s = re.sub(r"<think>.*?</think>", "", s, flags=re.DOTALL).strip()
+
+    # --- Step 1: strip markdown code fences ---
+    # Handles ```json ... ```, ```JSON ... ```, ``` ... ```
+    s = re.sub(r"^```[a-zA-Z]*\s*", "", s)
+    s = re.sub(r"\s*```$", "", s).strip()
+
+    # --- Step 2: try direct parse ---
+    try:
+        result = json.loads(s)
+        if isinstance(result, dict):
+            return result
+    except json.JSONDecodeError:
+        pass
+
+    # --- Step 3: balanced-brace substring ---
+    start = s.find("{")
+    if start < 0:
+        return None
+
+    depth = 0
+    for i in range(start, len(s)):
+        c = s[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    result = json.loads(s[start : i + 1])
+                    if isinstance(result, dict):
+                        return result
+                except json.JSONDecodeError:
+                    return None
+
+    return None

--- a/scripts/findings/lib/models.py
+++ b/scripts/findings/lib/models.py
@@ -86,9 +86,19 @@ class FindingFixState(BaseModel):
     # judge_necessity output:
     is_still_valid: Optional[bool] = None
     judge_reasoning: Optional[str] = None
-    # apply_fix output:
+    # apply_fix output (legacy — kept for backward compat):
     fix_applied: bool = False
     fix_diff: Optional[str] = None
+    # plan_changes output:
+    planned_changes: list = Field(default_factory=list)   # raw aenderungen list
+    plan_analyse: Optional[str] = None                     # human-readable summary
+    # apply_patch output:
+    patch_warnings: list = Field(default_factory=list)
+    patch_errors: list = Field(default_factory=list)
+    patched_content: Optional[str] = None                  # new file content (for review LLM)
+    # review_patch output:
+    review_verdict: Optional[Literal["APPROVED", "REJECTED", "NEEDS_HUMAN"]] = None
+    review_reasoning: Optional[str] = None
     # run_tests output:
     tests_pass: Optional[bool] = None
     test_output: Optional[str] = None

--- a/tests/findings/dag_nodes/test_apply_patch.py
+++ b/tests/findings/dag_nodes/test_apply_patch.py
@@ -1,0 +1,142 @@
+"""Tests for apply_patch DAG node.
+
+Uses real code_patcher + real tmp files (no LLM, no mocking).
+
+Run with:
+    PYTHONPATH=scripts python3 -m pytest tests/findings/dag_nodes/test_apply_patch.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from findings.dag_nodes.apply_patch import apply_patch
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state(planned_changes: list, path_resolved: str = "src/x.ts") -> FindingFixState:
+    finding = Finding(
+        id="F-042",
+        severity=Severity.HIGH,
+        area="a11y",
+        title="Button lacks aria-label",
+        file="src/x.ts",
+        status=Status.OPEN,
+        source="reviews/r.md",
+        detected="2026-05-07",
+        related=[],
+        acceptance_criteria=["Button has aria-label"],
+    )
+    return FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="qwen3-coder-480b"),
+        path_resolved=path_resolved,
+        path_resolution_method="exact",
+        file_contents={},
+        is_still_valid=True,
+        planned_changes=planned_changes,
+    )
+
+
+ORIGINAL_CODE = '<button onClick={fn}>X</button>\n'
+EXPECTED_CODE = '<button aria-label="Close" onClick={fn}>X</button>\n'
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_apply_patch_happy_path(tmp_path):
+    """replace_text operation should produce correct patched_content and write file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text(ORIGINAL_CODE)
+
+    changes = [
+        {
+            "typ": "replace_text",
+            "find": '<button onClick={fn}>X</button>',
+            "replace": '<button aria-label="Close" onClick={fn}>X</button>',
+        }
+    ]
+    state = _make_state(changes)
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is True
+    assert state.patched_content == EXPECTED_CODE
+    assert (tmp_path / "src" / "x.ts").read_text() == EXPECTED_CODE
+    assert state.patch_errors == []
+
+
+def test_apply_patch_empty_planned_changes(tmp_path):
+    """Empty planned_changes: fix_applied=False, no file write."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text(ORIGINAL_CODE)
+
+    state = _make_state([])
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is False
+    # File should be unchanged
+    assert (tmp_path / "src" / "x.ts").read_text() == ORIGINAL_CODE
+
+
+def test_apply_patch_missing_file(tmp_path):
+    """When target file doesn't exist: fix_applied=False, patch_errors populated."""
+    changes = [{"typ": "replace_text", "find": "x", "replace": "y"}]
+    state = _make_state(changes, path_resolved="src/missing.ts")
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is False
+    assert any("not found" in e for e in state.patch_errors)
+
+
+def test_apply_patch_operation_error_leaves_file_unchanged(tmp_path):
+    """When replace_text find-string is not found: file must NOT be modified."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text(ORIGINAL_CODE)
+
+    changes = [{"typ": "replace_text", "find": "DOES_NOT_EXIST", "replace": "nope"}]
+    state = _make_state(changes)
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is False
+    # Errors should explain what went wrong
+    assert len(state.patch_errors) > 0
+    # File must be unchanged (atomicity guarantee from code_patcher)
+    assert (tmp_path / "src" / "x.ts").read_text() == ORIGINAL_CODE
+
+
+def test_apply_patch_sets_patched_content_and_fix_applied(tmp_path):
+    """Verify both fix_applied=True and patched_content are set on success."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text("const x = 1;\n")
+
+    changes = [{"typ": "replace_text", "find": "const x = 1;", "replace": "const x = 42;"}]
+    state = _make_state(changes)
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is True
+    assert state.patched_content is not None
+    assert "42" in state.patched_content
+
+
+def test_apply_patch_append_operation(tmp_path):
+    """append_to_file operation appends text to file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text("const x = 1;\n")
+
+    changes = [{"typ": "append_to_file", "text": "// end of file\n"}]
+    state = _make_state(changes)
+    state = apply_patch(state, repo_root=tmp_path)
+
+    assert state.fix_applied is True
+    content = (tmp_path / "src" / "x.ts").read_text()
+    assert content.endswith("// end of file\n")

--- a/tests/findings/dag_nodes/test_plan_changes.py
+++ b/tests/findings/dag_nodes/test_plan_changes.py
@@ -1,0 +1,128 @@
+"""Tests for plan_changes DAG node."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from findings.dag_nodes.plan_changes import plan_changes
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state(is_still_valid: bool = True, path_resolved: str = "src/x.ts") -> FindingFixState:
+    finding = Finding(
+        id="F-042",
+        severity=Severity.HIGH,
+        area="a11y",
+        title="Button lacks aria-label",
+        file="src/x.ts",
+        status=Status.OPEN,
+        source="reviews/r.md",
+        detected="2026-05-07",
+        related=[],
+        acceptance_criteria=["Button has aria-label", "No regression"],
+    )
+    return FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="qwen3-coder-480b"),
+        path_resolved=path_resolved,
+        path_resolution_method="exact",
+        file_contents={path_resolved: '<button onClick={fn}>X</button>\n'},
+        is_still_valid=is_still_valid,
+    )
+
+
+_VALID_LLM_RESPONSE = json.dumps({
+    "analyse": "Button fehlt aria-label. Hinzufügen.",
+    "aenderungen": [
+        {
+            "typ": "replace_text",
+            "find": '<button onClick={fn}>X</button>',
+            "replace": '<button aria-label="Schließen" onClick={fn}>X</button>',
+        }
+    ],
+})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_plan_changes_happy_path(tmp_path):
+    """Happy path: LLM returns valid JSON, state gets planned_changes and plan_analyse."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text('<button onClick={fn}>X</button>\n')
+
+    state = _make_state()
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_llm:
+        mock_llm.return_value = _VALID_LLM_RESPONSE
+        state = plan_changes(state, repo_root=tmp_path)
+
+    assert len(state.planned_changes) == 1
+    assert state.planned_changes[0]["typ"] == "replace_text"
+    assert state.plan_analyse == "Button fehlt aria-label. Hinzufügen."
+    assert state.tool_call_errors == 0
+
+
+def test_plan_changes_skips_when_finding_invalidated(tmp_path):
+    """When is_still_valid=False, node should early-return with empty planned_changes."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text("code\n")
+
+    state = _make_state(is_still_valid=False)
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_llm:
+        state = plan_changes(state, repo_root=tmp_path)
+        mock_llm.assert_not_called()
+
+    assert state.planned_changes == []
+    assert state.tool_call_errors == 0
+
+
+def test_plan_changes_increments_errors_on_aihub_error(tmp_path):
+    """AIHubError must increment tool_call_errors and leave planned_changes empty."""
+    from findings.lib.aihub_client import AIHubError
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text("code\n")
+
+    state = _make_state()
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_llm:
+        mock_llm.side_effect = AIHubError("gateway timeout")
+        state = plan_changes(state, repo_root=tmp_path)
+
+    assert state.planned_changes == []
+    assert state.tool_call_errors == 1
+
+
+def test_plan_changes_increments_errors_on_unparseable_json(tmp_path):
+    """If the LLM returns non-JSON, tool_call_errors should be incremented."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "x.ts").write_text("code\n")
+
+    state = _make_state()
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_llm:
+        mock_llm.return_value = "Sorry, I cannot help with that."
+        state = plan_changes(state, repo_root=tmp_path)
+
+    assert state.planned_changes == []
+    assert state.tool_call_errors == 1
+
+
+def test_plan_changes_increments_errors_when_file_missing(tmp_path):
+    """If path_resolved points to a non-existent file, increment tool_call_errors."""
+    state = _make_state(path_resolved="src/does_not_exist.ts")
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_llm:
+        state = plan_changes(state, repo_root=tmp_path)
+        mock_llm.assert_not_called()
+
+    assert state.planned_changes == []
+    assert state.tool_call_errors == 1

--- a/tests/findings/dag_nodes/test_review_patch.py
+++ b/tests/findings/dag_nodes/test_review_patch.py
@@ -1,0 +1,112 @@
+"""Tests for review_patch DAG node."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from findings.dag_nodes.review_patch import review_patch
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state(fix_applied: bool = True) -> FindingFixState:
+    finding = Finding(
+        id="F-042",
+        severity=Severity.HIGH,
+        area="a11y",
+        title="Button lacks aria-label",
+        file="src/x.ts",
+        status=Status.OPEN,
+        source="reviews/r.md",
+        detected="2026-05-07",
+        related=[],
+        acceptance_criteria=["Button has aria-label attribute"],
+    )
+    return FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="qwen3-coder-480b"),
+        path_resolved="src/x.ts",
+        path_resolution_method="exact",
+        file_contents={},
+        is_still_valid=True,
+        fix_applied=fix_applied,
+        planned_changes=[
+            {
+                "typ": "replace_text",
+                "find": '<button onClick={fn}>X</button>',
+                "replace": '<button aria-label="Close" onClick={fn}>X</button>',
+            }
+        ],
+        patched_content='<button aria-label="Close" onClick={fn}>X</button>\n',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_review_patch_approved(tmp_path):
+    """When LLM returns APPROVED verdict, state reflects it."""
+    state = _make_state()
+    response = json.dumps({"verdict": "APPROVED", "reasoning": "All ACs met.", "concerns": []})
+
+    with patch("findings.dag_nodes.review_patch._call_review_llm") as mock_llm:
+        mock_llm.return_value = response
+        state = review_patch(state)
+
+    assert state.review_verdict == "APPROVED"
+    assert "ACs met" in state.review_reasoning
+    assert state.tool_call_errors == 0
+
+
+def test_review_patch_rejected(tmp_path):
+    """When LLM returns REJECTED, state.review_verdict == REJECTED."""
+    state = _make_state()
+    response = json.dumps({"verdict": "REJECTED", "reasoning": "aria-label still missing."})
+
+    with patch("findings.dag_nodes.review_patch._call_review_llm") as mock_llm:
+        mock_llm.return_value = response
+        state = review_patch(state)
+
+    assert state.review_verdict == "REJECTED"
+
+
+def test_review_patch_needs_human_on_aihub_error():
+    """AIHubError should produce NEEDS_HUMAN verdict and increment error counter."""
+    from findings.lib.aihub_client import AIHubError
+
+    state = _make_state()
+    with patch("findings.dag_nodes.review_patch._call_review_llm") as mock_llm:
+        mock_llm.side_effect = AIHubError("503 gateway timeout")
+        state = review_patch(state)
+
+    assert state.review_verdict == "NEEDS_HUMAN"
+    assert state.tool_call_errors == 1
+    assert "AIHubError" in state.review_reasoning
+
+
+def test_review_patch_needs_human_on_unparseable_response():
+    """If the LLM returns non-JSON, verdict must be NEEDS_HUMAN."""
+    state = _make_state()
+    with patch("findings.dag_nodes.review_patch._call_review_llm") as mock_llm:
+        mock_llm.return_value = "I cannot parse this."
+        state = review_patch(state)
+
+    assert state.review_verdict == "NEEDS_HUMAN"
+    assert state.tool_call_errors == 1
+
+
+def test_review_patch_skips_when_fix_not_applied():
+    """If fix_applied=False, review should return NEEDS_HUMAN without calling LLM."""
+    state = _make_state(fix_applied=False)
+    with patch("findings.dag_nodes.review_patch._call_review_llm") as mock_llm:
+        state = review_patch(state)
+        mock_llm.assert_not_called()
+
+    assert state.review_verdict == "NEEDS_HUMAN"
+    assert "fix_applied=False" in state.review_reasoning

--- a/tests/findings/lib/test_code_patcher.py
+++ b/tests/findings/lib/test_code_patcher.py
@@ -1,0 +1,434 @@
+"""Tests for findings.lib.code_patcher — deterministic code patch engine.
+
+Run with:
+    PYTHONPATH=scripts python3 -m pytest tests/findings/lib/test_code_patcher.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from findings.lib.code_patcher import apply_changes, PatchResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE = "let x = 1;\nlet y = 2;\nlet z = 3;\n"
+
+# Five-line fixture used for line-based operations
+FIVE_LINES = "line1\nline2\nline3\nline4\nline5\n"
+
+
+# ---------------------------------------------------------------------------
+# replace_text — happy path
+# ---------------------------------------------------------------------------
+
+def test_replace_text_happy_path():
+    content = "let x = 1;\nlet y = 2;\n"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "let x = 1;", "replace": "const x = 1;"}
+    ])
+    assert result.success is True
+    assert result.new_content == "const x = 1;\nlet y = 2;\n"
+    assert result.applied == 1
+    assert result.errors == []
+
+
+def test_replace_text_multiline_find():
+    content = "function foo() {\n  return 1;\n}\n"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "  return 1;\n", "replace": "  return 42;\n"}
+    ])
+    assert result.success is True
+    assert "return 42;" in result.new_content
+
+
+# ---------------------------------------------------------------------------
+# replace_text — uniqueness constraint
+# ---------------------------------------------------------------------------
+
+def test_replace_text_zero_matches_fails():
+    result = apply_changes(SIMPLE, [
+        {"typ": "replace_text", "find": "DOES_NOT_EXIST", "replace": "nope"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+    assert result.applied == 0
+    assert any("0 times" in e for e in result.errors)
+
+
+def test_replace_text_two_matches_fails():
+    content = "foo\nfoo\n"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "foo", "replace": "bar"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+    assert any("2 times" in e or "must be unique" in e for e in result.errors)
+
+
+def test_replace_text_three_matches_fails():
+    content = "x x x"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "x", "replace": "y"}
+    ])
+    assert result.success is False
+    assert any("3 times" in e or "must be unique" in e for e in result.errors)
+
+
+def test_replace_text_empty_find_fails():
+    result = apply_changes(SIMPLE, [
+        {"typ": "replace_text", "find": "", "replace": "something"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+
+
+# ---------------------------------------------------------------------------
+# replace_lines — happy path
+# ---------------------------------------------------------------------------
+
+def test_replace_lines_single_line():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "replace_lines", "line_from": 2, "line_to": 2, "new_text": "replaced\n"}
+    ])
+    assert result.success is True
+    lines = result.new_content.splitlines()
+    assert lines[0] == "line1"
+    assert lines[1] == "replaced"
+    assert lines[2] == "line3"
+    assert result.applied == 1
+
+
+def test_replace_lines_range():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "replace_lines", "line_from": 2, "line_to": 4, "new_text": "mid\n"}
+    ])
+    assert result.success is True
+    lines = result.new_content.splitlines()
+    assert lines == ["line1", "mid", "line5"]
+
+
+# ---------------------------------------------------------------------------
+# replace_lines — out-of-bounds / inverted range
+# ---------------------------------------------------------------------------
+
+def test_replace_lines_line_to_exceeds_file():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "replace_lines", "line_from": 4, "line_to": 99, "new_text": "x"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+    assert any("exceeds" in e or "line_to" in e for e in result.errors)
+
+
+def test_replace_lines_inverted_range():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "replace_lines", "line_from": 4, "line_to": 2, "new_text": "x"}
+    ])
+    assert result.success is False
+    assert any("inverted" in e or "line_to" in e for e in result.errors)
+
+
+def test_replace_lines_line_from_zero_fails():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "replace_lines", "line_from": 0, "line_to": 1, "new_text": "x"}
+    ])
+    assert result.success is False
+    assert any("below 1" in e or "line_from" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# insert_before_line — happy path and bounds
+# ---------------------------------------------------------------------------
+
+def test_insert_before_line_happy_path():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_before_line", "line": 3, "text": "inserted\n"}
+    ])
+    assert result.success is True
+    lines = result.new_content.splitlines()
+    assert lines[2] == "inserted"
+    assert lines[3] == "line3"
+    assert result.applied == 1
+
+
+def test_insert_before_line_first_line():
+    content = "alpha\nbeta\n"
+    result = apply_changes(content, [
+        {"typ": "insert_before_line", "line": 1, "text": "zero\n"}
+    ])
+    assert result.success is True
+    assert result.new_content.startswith("zero\n")
+
+
+def test_insert_before_line_out_of_bounds_zero():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_before_line", "line": 0, "text": "x"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+
+
+def test_insert_before_line_out_of_bounds_too_large():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_before_line", "line": 10, "text": "x"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+
+
+# ---------------------------------------------------------------------------
+# insert_after_line — happy path and bounds
+# ---------------------------------------------------------------------------
+
+def test_insert_after_line_happy_path():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_after_line", "line": 2, "text": "between2and3\n"}
+    ])
+    assert result.success is True
+    lines = result.new_content.splitlines()
+    assert lines[1] == "line2"
+    assert lines[2] == "between2and3"
+    assert lines[3] == "line3"
+
+
+def test_insert_after_line_last_line():
+    content = "alpha\nbeta\n"
+    result = apply_changes(content, [
+        {"typ": "insert_after_line", "line": 2, "text": "gamma\n"}
+    ])
+    assert result.success is True
+    assert result.new_content.endswith("gamma\n")
+
+
+def test_insert_after_line_out_of_bounds():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_after_line", "line": 99, "text": "x"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+
+
+def test_insert_after_line_zero_fails():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "insert_after_line", "line": 0, "text": "x"}
+    ])
+    assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# delete_lines — happy path and bounds
+# ---------------------------------------------------------------------------
+
+def test_delete_lines_happy_path():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "delete_lines", "line_from": 2, "line_to": 3}
+    ])
+    assert result.success is True
+    lines = result.new_content.splitlines()
+    assert lines == ["line1", "line4", "line5"]
+    assert result.applied == 1
+
+
+def test_delete_lines_single_line():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "delete_lines", "line_from": 1, "line_to": 1}
+    ])
+    assert result.success is True
+    assert not result.new_content.startswith("line1")
+
+
+def test_delete_lines_exceeds_bounds():
+    result = apply_changes(FIVE_LINES, [
+        {"typ": "delete_lines", "line_from": 4, "line_to": 100}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+
+
+# ---------------------------------------------------------------------------
+# append_to_file
+# ---------------------------------------------------------------------------
+
+def test_append_to_file_happy_path():
+    content = "hello\n"
+    result = apply_changes(content, [
+        {"typ": "append_to_file", "text": "world\n"}
+    ])
+    assert result.success is True
+    assert result.new_content == "hello\nworld\n"
+    assert result.applied == 1
+
+
+def test_append_to_file_adds_newline_if_missing():
+    content = "no_trailing_newline"
+    result = apply_changes(content, [
+        {"typ": "append_to_file", "text": "appended\n"}
+    ])
+    assert result.success is True
+    assert "no_trailing_newline\n" in result.new_content
+    assert result.new_content.endswith("appended\n")
+    assert len(result.warnings) == 1
+
+
+def test_append_to_file_empty_file():
+    result = apply_changes("", [
+        {"typ": "append_to_file", "text": "first line\n"}
+    ])
+    assert result.success is True
+    assert result.new_content == "first line\n"
+
+
+# ---------------------------------------------------------------------------
+# prepend_to_file
+# ---------------------------------------------------------------------------
+
+def test_prepend_to_file_happy_path():
+    content = "second\n"
+    result = apply_changes(content, [
+        {"typ": "prepend_to_file", "text": "first\n"}
+    ])
+    assert result.success is True
+    assert result.new_content == "first\nsecond\n"
+    assert result.applied == 1
+
+
+def test_prepend_to_file_empty_file():
+    result = apply_changes("", [
+        {"typ": "prepend_to_file", "text": "header\n"}
+    ])
+    assert result.success is True
+    assert result.new_content == "header\n"
+
+
+# ---------------------------------------------------------------------------
+# Atomic property: mid-sequence failure rolls back everything
+# ---------------------------------------------------------------------------
+
+def test_atomic_failure_mid_sequence():
+    """op #2 of 3 fails → new_content must be None, not partial."""
+    content = "aaa\nbbb\nccc\n"
+    changes = [
+        # op 1: valid
+        {"typ": "replace_text", "find": "aaa", "replace": "AAA"},
+        # op 2: invalid (NOT_FOUND)
+        {"typ": "replace_text", "find": "DOES_NOT_EXIST", "replace": "x"},
+        # op 3: would be valid, but never reached
+        {"typ": "append_to_file", "text": "ddd\n"},
+    ]
+    result = apply_changes(content, changes)
+    assert result.success is False
+    assert result.new_content is None
+    # Only op 1 succeeded before failure
+    assert result.applied == 1
+    assert len(result.errors) == 1
+
+
+def test_atomic_failure_first_op():
+    """First op fails → applied=0."""
+    changes = [
+        {"typ": "replace_text", "find": "MISSING", "replace": "x"},
+        {"typ": "append_to_file", "text": "extra\n"},
+    ]
+    result = apply_changes(SIMPLE, changes)
+    assert result.success is False
+    assert result.applied == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty changes list
+# ---------------------------------------------------------------------------
+
+def test_empty_changes_returns_original():
+    result = apply_changes(SIMPLE, [])
+    assert result.success is True
+    assert result.new_content == SIMPLE
+    assert result.applied == 0
+    assert result.errors == []
+    assert result.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown operation type
+# ---------------------------------------------------------------------------
+
+def test_unknown_op_type_fails():
+    result = apply_changes(SIMPLE, [
+        {"typ": "magic_rewrite", "instructions": "do something"}
+    ])
+    assert result.success is False
+    assert result.new_content is None
+    assert any("magic_rewrite" in e for e in result.errors)
+    assert any("unknown" in e.lower() for e in result.errors)
+
+
+def test_unknown_op_type_lists_known_ops():
+    result = apply_changes(SIMPLE, [{"typ": "nonexistent"}])
+    assert result.success is False
+    # Error message should hint at known operations
+    error_text = " ".join(result.errors)
+    assert "replace_text" in error_text or "known" in error_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Multi-op happy path: 3 operations in sequence
+# ---------------------------------------------------------------------------
+
+def test_multi_op_sequence():
+    """Three operations applied in order, each sees the result of the previous."""
+    content = "alpha\nbeta\ngamma\n"
+    changes = [
+        {"typ": "replace_text", "find": "alpha", "replace": "ALPHA"},
+        {"typ": "insert_after_line", "line": 2, "text": "inserted\n"},
+        {"typ": "append_to_file", "text": "omega\n"},
+    ]
+    result = apply_changes(content, changes)
+    assert result.success is True
+    assert result.applied == 3
+    lines = result.new_content.splitlines()
+    assert lines[0] == "ALPHA"
+    assert lines[1] == "beta"
+    assert lines[2] == "inserted"
+    assert lines[3] == "gamma"
+    assert lines[4] == "omega"
+
+
+def test_multi_op_delete_then_replace():
+    """Delete a block then replace a remaining line."""
+    content = "keep\ndelete_me\nalso_delete\nchange_me\n"
+    changes = [
+        {"typ": "delete_lines", "line_from": 2, "line_to": 3},
+        {"typ": "replace_text", "find": "change_me", "replace": "CHANGED"},
+    ]
+    result = apply_changes(content, changes)
+    assert result.success is True
+    assert result.applied == 2
+    assert result.new_content == "keep\nCHANGED\n"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: content must be byte-identical when ops are no-ops
+# ---------------------------------------------------------------------------
+
+def test_newline_preservation():
+    """Ensure no rstrip, no normalisation of line endings."""
+    content = "line1\r\nline2\r\nline3\r\n"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "line2\r\n", "replace": "LINE2\r\n"}
+    ])
+    assert result.success is True
+    assert result.new_content == "line1\r\nLINE2\r\nline3\r\n"
+
+
+def test_no_trailing_newline_preserved():
+    """Files without trailing newline must come out without one (unless appended)."""
+    content = "abc"
+    result = apply_changes(content, [
+        {"typ": "replace_text", "find": "abc", "replace": "xyz"}
+    ])
+    assert result.success is True
+    assert result.new_content == "xyz"
+    assert not result.new_content.endswith("\n")

--- a/tests/findings/lib/test_json_extract.py
+++ b/tests/findings/lib/test_json_extract.py
@@ -1,0 +1,87 @@
+"""Tests for findings.lib.json_extract — robust JSON extraction from LLM output.
+
+Run with:
+    PYTHONPATH=scripts python3 -m pytest tests/findings/lib/test_json_extract.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from findings.lib.json_extract import extract_json
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+def test_extract_direct_json():
+    raw = '{"verdict": "APPROVED", "reasoning": "looks good"}'
+    result = extract_json(raw)
+    assert result == {"verdict": "APPROVED", "reasoning": "looks good"}
+
+
+def test_extract_json_in_code_fence():
+    raw = '```json\n{"key": "value"}\n```'
+    result = extract_json(raw)
+    assert result == {"key": "value"}
+
+
+def test_extract_json_in_plain_fence():
+    raw = '```\n{"key": "value"}\n```'
+    result = extract_json(raw)
+    assert result == {"key": "value"}
+
+
+def test_extract_json_after_think_block():
+    raw = (
+        "<think>I need to think about this carefully...</think>\n"
+        '{"analyse": "the fix", "aenderungen": []}'
+    )
+    result = extract_json(raw)
+    assert result == {"analyse": "the fix", "aenderungen": []}
+
+
+def test_extract_json_with_surrounding_text():
+    raw = 'Here is my answer:\n{"verdict": "REJECTED"}\nThat is all.'
+    result = extract_json(raw)
+    assert result == {"verdict": "REJECTED"}
+
+
+def test_extract_json_with_nested_object():
+    raw = '{"outer": {"inner": 42}, "list": [1, 2, 3]}'
+    result = extract_json(raw)
+    assert result == {"outer": {"inner": 42}, "list": [1, 2, 3]}
+
+
+# ---------------------------------------------------------------------------
+# Error / edge-case paths
+# ---------------------------------------------------------------------------
+
+def test_extract_returns_none_for_empty_string():
+    assert extract_json("") is None
+
+
+def test_extract_returns_none_for_no_json():
+    assert extract_json("This is just plain text without any JSON.") is None
+
+
+def test_extract_returns_none_for_invalid_json():
+    assert extract_json("{not valid json}") is None
+
+
+def test_extract_ignores_json_arrays_at_top_level():
+    # We only extract dict objects, not bare arrays
+    raw = '[1, 2, 3]'
+    # extract_json looks for '{' — this has none, so returns None
+    assert extract_json(raw) is None
+
+
+def test_think_block_with_fenced_json():
+    raw = (
+        "<think>reasoning here</think>\n"
+        "```json\n"
+        '{"verdict": "NEEDS_HUMAN", "reasoning": "edge case"}\n'
+        "```"
+    )
+    result = extract_json(raw)
+    assert result == {"verdict": "NEEDS_HUMAN", "reasoning": "edge case"}

--- a/tests/findings/test_finding_fix.py
+++ b/tests/findings/test_finding_fix.py
@@ -1,6 +1,6 @@
 """Integration tests for the finding_fix orchestrator (DAG)."""
 from __future__ import annotations
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pytest
 from pathlib import Path
 from findings.finding_fix import run_finding_fix
@@ -21,11 +21,16 @@ def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
     src.write_text("let x = 1;\n")
 
     with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
-         patch("findings.dag_nodes.apply_fix._call_apply_llm") as mock_apply, \
+         patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
+         patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
          patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
         mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
-        mock_apply.return_value = '{"new_content": "const x = 1;\\n", "diff": "diff"}'
-        from unittest.mock import MagicMock
+        mock_plan.return_value = (
+            '{"analyse": "test fix", "aenderungen": ['
+            '{"typ": "replace_text", "find": "let x = 1;", "replace": "const x = 1;"}'
+            ']}'
+        )
+        mock_review.return_value = '{"verdict": "APPROVED", "reasoning": "looks good"}'
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
 
         result = run_finding_fix(
@@ -36,6 +41,9 @@ def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
 
     assert result.fix_applied is True
     assert result.tests_pass is True
+    assert result.review_verdict == "APPROVED"
+    # File content should have changed
+    assert src.read_text() == "const x = 1;\n"
     # The status should be flipped to 'fixed'
     text = (findings / "F-001.md").read_text()
     assert "status: fixed" in text
@@ -51,16 +59,20 @@ def test_fallback_kicks_in_after_aihub_failure(tmp_path):
     )
     src = tmp_path / "src" / "y.ts"
     src.parent.mkdir(parents=True)
-    src.write_text("a")
+    src.write_text("let a = 1;\n")
 
-    # Simulate aihub failure → fallback to claude haiku
-    with patch("findings.dag_nodes.apply_fix._call_apply_llm") as mock_apply, \
+    # Simulate aihub failure in plan_changes → fallback to claude haiku re-runs plan
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
          patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
          patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
-        # First call (aihub) fails JSON parse, second call (haiku) succeeds
-        mock_apply.side_effect = ["INVALID JSON", '{"new_content":"b","diff":""}']
+        # First call (aihub) fails JSON parse, second call (fallback) succeeds
+        mock_plan.side_effect = [
+            "INVALID JSON",
+            '{"analyse": "fix", "aenderungen": [{"typ": "replace_text", "find": "let a = 1;", "replace": "const a = 1;"}]}',
+        ]
         mock_judge.return_value = '{"is_still_valid": true, "reasoning":"y"}'
-        from unittest.mock import MagicMock
+        mock_review.return_value = '{"verdict": "APPROVED", "reasoning": "looks good"}'
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
 
         result = run_finding_fix(finding_id="F-002", findings_dir=findings, repo_root=tmp_path)
@@ -97,5 +109,44 @@ def test_dag_timeout_aborts_long_running_step(tmp_path, monkeypatch):
 
     # The slow judge should have been timed out; tool_call_errors incremented
     assert result.tool_call_errors >= 1
-    # Fix should NOT have been applied (timeout aborted before apply_fix)
+    # Fix should NOT have been applied (timeout aborted before plan_changes)
     assert result.fix_applied is False
+
+
+def test_review_rejected_skips_tests(tmp_path):
+    """When review_patch returns REJECTED, run_tests must NOT be called."""
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-004.md").write_text(
+        "---\nid: F-004\nseverity: low\narea: ux\ntitle: test rejected\nfile: src/w.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: []\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "w.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("let w = 1;\n")
+
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
+         patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
+         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+        mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
+        mock_plan.return_value = (
+            '{"analyse": "test fix", "aenderungen": ['
+            '{"typ": "replace_text", "find": "let w = 1;", "replace": "const w = 1;"}'
+            ']}'
+        )
+        mock_review.return_value = '{"verdict": "REJECTED", "reasoning": "patch is wrong"}'
+
+        result = run_finding_fix(
+            finding_id="F-004",
+            findings_dir=findings,
+            repo_root=tmp_path,
+        )
+
+    # Review rejected → tests must NOT have been run
+    mock_run.assert_not_called()
+    assert result.review_verdict == "REJECTED"
+    # fix_applied is True (patch was applied), but tests_pass is None
+    assert result.fix_applied is True
+    assert result.tests_pass is None


### PR DESCRIPTION
## Summary

Refactors `/finding-fix` from monolithic LLM-apply to a **plan/apply/review 3-step DAG**. The LLM never produces full file content — only structured operations that a deterministic local patcher applies.

## Why

The previous pipeline asked Qwen-Thinking models to produce `new_content: \"<entire file>\"`. Per official Alibaba/vLLM docs, **thinking-mode does not support structured output**. Empirical: qwen-3.5-122b-sovereign 504-timed out at max_tokens=8000, qwen3-coder-480b returned valid JSON with empty `new_content`.

New design splits the work:

```
plan_changes  (qwen3-coder-480b, temp 0.3)   →  JSON {analyse, aenderungen[]}
apply_patch   (Python, no LLM, deterministic) →  applies operations
review_patch  (gpt-4.1-mini, temp 0.5)        →  APPROVED / REJECTED / NEEDS_HUMAN
run_tests     (existing)                       →  hard gate
update_index  (existing)                       →  status flip
```

## What's in this PR

- **`code_patcher.py`** (338 LOC, 36 tests) — atomic 7-op patcher: `replace_text`, `replace_lines`, `insert_before/after_line`, `delete_lines`, `append_to_file`, `prepend_to_file`. `replace_text` enforces unique-match constraint (prevents silent wrong-replacements).
- **3 new DAG nodes** (`plan_changes`, `apply_patch`, `review_patch`) replacing the old single `apply_fix`.
- **`json_extract.py` helper** with 3-fallback parsing (markdown fence, direct, brace-substring) — handles Qwen-Thinking output quirks.
- **Hardened reviewer prompt** with 5 mandatory structural checks (scope-correctness, syntax, side-effects, AKs, test-impact). \"APPROVED is the exception, not the rule.\"
- **Complete fallback-state-reset** — all pipeline state fields cleared before retry.
- **Documented temperature deviations** — both `temp=0.3` (plan, deterministic JSON) and `temp=0.5` (review, balanced) have inline rationale.

## Live-validated

Smoke-tested against **F-012** (UTC-Date-Handling, low severity, real file): DAG runs end-to-end. Plan succeeds. Patch applies correctly. Review APPROVED. **Tests then catch a structural bug** (helper placed in wrong scope) — proving defense-in-depth. Auto-fallback triggers, file reverted cleanly.

→ Tests are the eventual gate; reviewer is the early filter; both work together.

## Test plan

- [x] Findings unit tests: **113/113 green**
- [x] Vitest regression: **830 passed, 8 skipped**

## Notes

Replaces #120 — same functional content, but cherry-picked cleanly on top of `74dd73e` (post-#119 squash) without history duplication. Internal pattern naming made descriptive (\"plan/apply/review DAG\") instead of borrowed from another project.

## Open follow-ups (NOT in this PR)

- Backlog-extraction sweep against the 36 review files (was 504-blocked before max_tokens fix in #119, should now run)
- More live-runs to tune reviewer-prompt thresholds
- Possible reviewer-model swap (gpt-4.1-mini → qwen3-coder-480b for cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)