### PR TITLE
chore(repo): working-tree hygiene — gitignore + review/findings snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,14 @@ docs/
 
 # Playwright test results
 test-results/
+test-reports/
 playwright-report/
 
 # Vercel
 .vercel/
 supabase/.temp/
 scripts/dev-mcp-server.ts
+
+# Backup files and CI/build run outputs
+*.bak.*
+ci_logs.txt

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -1,29 +1,164 @@
 # Findings Backlog
 
-> Auto-managed by `scripts/findings/extract_findings.py` and `/finding-fix`.
-> Last sync: <pending — first extraction>
-
 | ID | Sev | Area | Title | File | Effort | Status |
 |----|-----|------|-------|------|--------|--------|
-
-## Stats
-
-- Total: 0
-- Critical: 0 / High: 0 / Medium: 0 / Low: 0
-- Open: 0 / In-Progress: 0 / Fixed: 0 / Archived: 0
-
-## Workflow
-
-1. **Extract:** `python3 scripts/findings/extract_findings.py reviews/`
-2. **Status:** `python3 scripts/findings/findings_status.py`
-3. **Fix:** `/finding-fix F-001`  (Slash-Command in Claude Code)
-4. **Routing-Stats (after 4 weeks):** `python3 scripts/findings/findings_routing_stats.py`
-
-## Severity Legend
-
-| | Stufe | SLA |
-|--|-------|-----|
-| ⚫ | critical | <24 h |
-| 🔴 | high | <1 Woche |
-| 🟠 | medium | <1 Monat |
-| 🟡 | low | Backlog |
+| F-001 | 🟠 | other | compareDirectMatches hat 80+ LOC mit tiefer Verschachtelung | src/utils/calculations.ts | 2h | open |
+| F-002 | 🔴 | security | Non-Null Assertions (!) können Runtime-Errors verursachen | src/utils/FairnessCalculator.ts | 1h | open |
+| F-003 | 🟠 | testing | Type-Safety in Tests durch 'as'-Casts verloren | src/utils/__tests__/ScenarioHMK.test.ts | 30m | open |
+| F-004 | 🟠 | other | || statt ?? für Boolean-Checks erhöht Logik-Risiko | src/utils/filterMatches.ts | 30m | open |
+| F-005 | 🟠 | security | Schwacher Fallback-UUID-Generator | src/utils/idGenerator.ts | 45m | open |
+| F-006 | 🟡 | testing | console.log Debug-Output in Tests vorhanden | src/utils/scheduleGenerator_finals_bug.test.ts | 15m | open |
+| F-007 | 🟡 | other | Dead-Code-Kommentar verwirrend | src/utils/knockoutMatchGenerator.ts | 10m | open |
+| F-008 | 🟡 | other | Gemischte Deutsch/Englisch Namen in utils | src/utils/ | 2h | open |
+| F-009 | 🟡 | other | Error Boundaries nicht im Code sichtbar | src/components/ | 1h | open |
+| F-010 | 🟠 | other | cleanupOldLiveMatches hat 70+ LOC mit komplexer Logik | src/utils/storageCleanup.ts | 1.5h | open |
+| F-011 | 🟡 | testing | Test File Size zu groß für Wartbarkeit | src/core/generators/__tests__/playoffGenerator.test.ts | - | open |
+| F-012 | 🟡 | data | Hardcoded Timezones ohne UTC-Handling | src/core/generators/scheduleHelpers.ts | - | open |
+| F-013 | 🔴 | data | Gruppe ohne Feld-Zuordnung möglich | src/features/tournament-creation/Step_GroupsAndFields.tsx | 45m | open |
+| F-014 | 🟠 | data | Team-Löschung bei numberOfTeams inkonsistent | src/features/tournament-creation/Step4_Teams.tsx | 30m | open |
+| F-015 | 🟡 | ux | refereeNames Löschung ohne Warnung | src/features/tournament-creation/components/RefereeSettings.tsx | 30m | open |
+| F-016 | 🟠 | perf | PDF-Generierung ohne Timeout-Handling bei großen Datenmengen | src/components/PDFExportDialog.tsx | 2h | open |
+| F-017 | 🟠 | other | Fehlendes Retry-Feedback bei jsPDF-Fehlern | src/components/PDFExportDialog.tsx | 1h | open |
+| F-018 | 🟡 | data | Schriftart-Embedded für Umlaute nicht im Code sichtbar [REQUIRES_CROSS_CHECK] | src/lib/pdfExporter.ts | 1h | open |
+| F-019 | 🟡 | ux | Clipboard-Fallback für Web Share API nicht im Code sichtbar [REQUIRES_CROSS_CHECK] | src/components/ShareDialog.tsx | 30m | open |
+| F-020 | 🟠 | ux | Kein Deep-Link für geteilte Turniere | src/components/ShareDialog.tsx | 1h | open |
+| F-021 | 🟡 | security | Monitor-URL ohne Auth-Check nicht im Code sichtbar [REQUIRES_CROSS_CHECK] | src/views/MonitorView.tsx | 2h | open |
+| F-022 | ⚫ | a11y | Live-Daten ohne aria-live-Announcements im Cockpit | src/components/Cockpit/MatchTimer.tsx | 1h | open |
+| F-023 | 🔴 | a11y | Toggle-Button ohne aria-expanded State | src/components/ContactForm.tsx | 30m | open |
+| F-024 | 🟡 | a11y | Focus Management in Modals nicht sichtbar [REQUIRES_CROSS_CHECK] | src/components/Dialog/ | 2h | open |
+| F-025 | 🟠 | a11y | Fehlende Skip-to-Content Links | src/App.tsx | 30m | open |
+| F-026 | 🟠 | a11y | Form Labels müssen mit htmlFor verknüpft sein | src/components/Input.tsx | 1h | open |
+| F-027 | 🟠 | i18n | Hardcodierte Icons/Arrows in ContactForm | src/components/ContactForm.tsx | 30m | open |
+| F-028 | 🟡 | i18n | Fehlende Plural-Keys für 'teams' | src/locales/de/admin.json | 15m | open |
+| F-029 | 🟡 | i18n | Zeitformatierung browserabhängig (12h/24h) | src/utils/dateFormatting.ts | 30m | open |
+| F-030 | 🟡 | a11y | Reduced Motion Support für Animationen | src/styles/ | 30m | open |
+| F-031 | 🟡 | a11y | Color Contrast nicht verifizierbar aus Code | src/styles/ | 1h | open |
+| F-032 | 🔴 | data | Keine Race-Condition-Prävention bei Score-Updates | src/features/live-cockpit/ | - | open |
+| F-033 | 🔴 | data | Keine Offline-Resilienz für Score-Updates | src/features/live-cockpit/ | - | open |
+| F-034 | 🔴 | ux | Keine Bestätigung bei Tor-Eingabe | src/features/live-cockpit/ | - | open |
+| F-035 | 🟠 | data | Undo/Redo-History geht bei Tab-Wechsel verloren | src/features/schedule-editor/ScheduleEditor.tsx | - | open |
+| F-036 | 🟠 | ux | Kein 'Spiel läuft'-Indikator im Cockpit | src/features/live-cockpit/ | - | open |
+| F-037 | 🟠 | data | Sortierung bei Punktgleichheit unklar | src/features/schedule-editor/ | - | open |
+| F-038 | 🟡 | perf | Keine Browser-Tab-Drift-Kompensation | src/features/live-cockpit/ | - | open |
+| F-039 | 🟡 | ux | Keine Audio-Feedback bei Spielereignissen | src/features/live-cockpit/ | - | open |
+| F-040 | 🟡 | ux | Timer-Logik für Live-Cockpit nicht im Code sichtbar | src/features/live-cockpit/ | - | open |
+| F-041 | 🟡 | doc | Match-Duration vs. Break-Duration Inkonsistenz | src/types/tournament.ts | - | open |
+| F-042 | 🟠 | perf | Blockierende Storage-Migration bei App-Start | src/core/storage/StorageFactory.ts | 2h | open |
+| F-043 | 🟡 | perf | Kein Code-Splitting für Features sichtbar | src/ | 4h | open |
+| F-044 | 🟡 | perf | vite.config.ts nicht optimiert für Chunks | vite.config.ts | 2h | open |
+| F-045 | 🟡 | perf | i18next Tree Shaking nicht implementiert | src/i18n.ts | 1h | open |
+| F-046 | 🟡 | ux | Service Worker nicht im Code sichtbar | src/ | 2h | open |
+| F-047 | 🟡 | ux | manifest.json nicht im Code sichtbar | public/ | 1h | open |
+| F-048 | 🟡 | ux | Offline-Page fehlt | src/ | 3h | open |
+| F-049 | 🟠 | perf | Blockierende Storage-Migration bei App-Start | src/core/storage/StorageFactory.ts | 2h | open |
+| F-050 | 🟡 | perf | Kein Code-Splitting für Features sichtbar | src/ | 4h | open |
+| F-051 | 🟡 | perf | vite.config.ts nicht optimiert für Chunks | vite.config.ts | 2h | open |
+| F-052 | 🟡 | perf | i18next Tree Shaking nicht implementiert | src/i18n.ts | 1h | open |
+| F-053 | 🟡 | ux | Service Worker nicht im Code sichtbar | src/ | 2h | open |
+| F-054 | 🟡 | ux | manifest.json nicht im Code sichtbar | public/ | 1h | open |
+| F-055 | 🟡 | ux | Offline-Page fehlt | src/ | 3h | open |
+| F-056 | 🟡 | security | Fehlende zentrale Route Guards | src/App.tsx | - | open |
+| F-057 | 🟠 | architecture | Redundante Public Screens (LiveView vs PublicTournament) | src/screens/LiveViewScreen.tsx | - | open |
+| F-058 | 🟡 | ux | Fehlendes 404-Handling für unbekannte Routen | src/App.tsx | - | open |
+| F-059 | 🟠 | ux | Prop Drilling für Navigation (onBack Props) | src/screens/DashboardScreen.tsx | - | open |
+| F-060 | 🟡 | ux | Fehlende Deep-Link-URL für Einstellungen | src/screens/SettingsScreen.tsx | - | open |
+| F-061 | 🔴 | security | Migration Order Dependency Risk in Denormalized RLS | 20260128_004_optimized_rls.sql | 1h | open |
+| F-062 | 🟠 | security | RLS Recursion Risk in tournament_collaborators Policy | 20260128_002_consolidate_rls_v3.sql | 30m | open |
+| F-063 | 🟠 | ux | OptimisticLockError Not Handled in Live-Cockpit UI | src/repositories/SupabaseLiveMatchRepository.ts | 2h | open |
+| F-064 | 🟠 | data | is_public Trigger Missing Soft-Delete Case | 20260121_002_denormalize_owner.sql | 1h | open |
+| F-065 | 🟠 | ux | Missing Sync Status Flag for Offline Changes | src/repositories/OfflineRepository.ts | 3h | open |
+| F-066 | 🟡 | perf | Missing Index on tournament_collaborators for RLS Performance | 20260128_002_consolidate_rls_v3.sql | 15m | open |
+| F-067 | 🟡 | data | Stale Match Recovery Loses Timer Data on Browser Crash | src/repositories/LocalStorageLiveMatchRepository.ts | 1h | open |
+| F-068 | 🟠 | testing | Fragile Time-based Assertions können flaky sein | src/tests/scheduleGenerator.test.ts | 2h | open |
+| F-069 | 🟠 | testing | i18next Mock zu stark vereinfacht | src/tests/setup.ts | 1h | open |
+| F-070 | 🟠 | testing | Schwache Assertions ohne Spezifikation | src/tests/standings.test.ts | 30m | open |
+| F-071 | 🟠 | testing | Fehlende Cleanup-Strategie für localStorage Mock | src/tests/setup.ts | 30m | open |
+| F-072 | 🟠 | perf | Performance-Tests mit zu großzügigen Timeouts | src/tests/scheduler.perf.test.ts | 1h | open |
+| F-073 | 🟡 | testing | E2E-Tests fehlen komplett [REQUIRES_CROSS_CHECK] | e2e/ | 8h | open |
+| F-074 | 🟡 | a11y | Accessibility-Tests fehlen komplett [REQUIRES_CROSS_CHECK] | src/tests/ | 4h | open |
+| F-075 | 🟡 | testing | Supabase Integration nicht getestet [REQUIRES_CROSS_CHECK] | src/services/supabase.ts | 6h | open |
+| F-076 | 🟡 | testing | PWA-Tests fehlen [REQUIRES_CROSS_CHECK] | public/sw.js | 4h | open |
+| F-077 | 🟡 | security | Auth-Flow nicht getestet [REQUIRES_CROSS_CHECK] | src/services/auth.ts | 3h | open |
+| F-078 | 🟡 | testing | Realtime-Tests fehlen [REQUIRES_CROSS_CHECK] | src/services/realtime.ts | 4h | open |
+| F-079 | 🟡 | testing | PDF-Export-Tests fehlen [REQUIRES_CROSS_CHECK] | src/utils/pdfExport.ts | 2h | open |
+| F-080 | 🟠 | testing | Error-Handling nicht umfassend getestet | src/services/ | 4h | open |
+| F-081 | 🟠 | testing | Fragile Time-based Assertions können flaky sein | src/tests/scheduleGenerator.test.ts | 2h | open |
+| F-082 | 🟠 | testing | i18next Mock zu stark vereinfacht | src/tests/setup.ts | 1h | open |
+| F-083 | 🟠 | testing | Schwache Assertions ohne Spezifikation | src/tests/standings.test.ts | 30m | open |
+| F-084 | 🟠 | testing | Fehlende Cleanup-Strategie für localStorage Mock | src/tests/setup.ts | 30m | open |
+| F-085 | 🟠 | perf | Performance-Tests mit zu großzügigen Timeouts | src/tests/scheduler.perf.test.ts | 1h | open |
+| F-086 | 🟡 | testing | E2E-Tests fehlen komplett [REQUIRES_CROSS_CHECK] | e2e/ | 8h | open |
+| F-087 | 🟡 | a11y | Accessibility-Tests fehlen komplett [REQUIRES_CROSS_CHECK] | src/tests/ | 4h | open |
+| F-088 | 🟡 | testing | Supabase Integration nicht getestet [REQUIRES_CROSS_CHECK] | src/services/supabase.ts | 6h | open |
+| F-089 | 🟡 | testing | PWA-Tests fehlen [REQUIRES_CROSS_CHECK] | public/sw.js | 4h | open |
+| F-090 | 🟡 | security | Auth-Flow nicht getestet [REQUIRES_CROSS_CHECK] | src/services/auth.ts | 3h | open |
+| F-091 | 🟡 | testing | Realtime-Tests fehlen [REQUIRES_CROSS_CHECK] | src/services/realtime.ts | 4h | open |
+| F-092 | 🟡 | testing | PDF-Export-Tests fehlen [REQUIRES_CROSS_CHECK] | src/utils/pdfExport.ts | 2h | open |
+| F-093 | 🟠 | testing | Error-Handling nicht umfassend getestet | src/services/ | 4h | open |
+| F-094 | 🔴 | perf | useMatchTimer: requestAnimationFrame für Sekunden-Updates | src/hooks/useMatchTimer.ts | 1h | open |
+| F-095 | 🔴 | perf | useLiveMatches: Map-Referenz ändert sich bei jedem Update | src/hooks/useLiveMatches.ts | 2h | open |
+| F-096 | 🟠 | perf | useAutoSave: JSON.stringify bei jedem Render | src/hooks/useAutoSave.ts | 30m | open |
+| F-097 | 🟠 | perf | useMatchCockpitPro: effectiveSettings ohne useMemo | src/hooks/useMatchCockpitPro.ts | 30m | open |
+| F-098 | 🟠 | perf | useCorporateColors: effectiveSettings ohne useMemo | src/hooks/useCorporateColors.ts | 30m | open |
+| F-099 | 🟠 | perf | useDialogTimer: Interval-Cleanup nicht robust | src/hooks/useDialogTimer.ts | 20m | open |
+| F-100 | 🟡 | perf | useFocusTrap: inertElements Cleanup ohne Existenz-Check | src/hooks/useFocusTrap.ts | 15m | open |
+| F-101 | 🟠 | perf | useMatchSound: Audio-Element nicht bei Sound-Wechsel aktualisiert | src/hooks/useMatchSound.ts | 30m | open |
+| F-102 | 🟡 | other | Deprecated useMatchTimer wird noch exportiert | src/hooks/index.ts | 1h | open |
+| F-103 | ⚫ | a11y | ActionMenu Touch Target unter WCAG Minimum (36x36px) | src/components/ui/ActionMenu.tsx | 30m | open |
+| F-104 | ⚫ | a11y | PasswordInput Toggle nicht keyboard-navigierbar | src/components/ui/PasswordInput.tsx | 15m | open |
+| F-105 | ⚫ | a11y | ColorPicker Presets ohne Focus States | src/components/ui/ColorPicker.tsx | 30m | open |
+| F-106 | ⚫ | a11y | Collapsible Panels ohne aria-pressed State | src/components/ui/CollapsibleInfoPanel.tsx | 20m | open |
+| F-107 | 🔴 | architecture | Inkonsistente Styling-Patterns (Inline vs CSS Modules) | src/components/ui/ | 2d | open |
+| F-108 | 🟠 | architecture | Hardcoded Design Values statt Tokens | src/components/ui/ActionMenu.tsx | 1h | open |
+| F-109 | 🟠 | architecture | Form Component API inkonsistent (error/errorMessage) | src/components/ui/Select.tsx | 2h | open |
+| F-110 | 🟠 | architecture | Animation System inkonsistent (3 Patterns) | src/components/ui/BottomSheet.tsx | 1.5h | open |
+| F-111 | 🟠 | a11y | BottomNavigation ohne Keyboard-Navigation | src/components/ui/BottomNavigation.tsx | 45m | open |
+| F-112 | 🟠 | a11y | Toast role="alert" für alle Typen | src/components/ui/Toast.tsx | 30m | open |
+| F-113 | 🔴 | a11y | Icons ohne zugängliche Alternative | src/components/ui/ | - | open |
+| F-114 | 🟠 | a11y | ConfirmDialog hardcoded aria-labelledby ID | src/components/ui/ConfirmDialog.tsx | 20m | open |
+| F-115 | 🔴 | security | Client-Side Authorization Only | src/features/auth/components/AuthGuard.tsx | 4h | open |
+| F-116 | 🔴 | security | Supabase Service Role Key Exposure Risk | supabase/functions/merge-accounts/index.ts | 1h | open |
+| F-117 | 🔴 | security | Invite Token im URL-Parameter | src/features/auth/components/AuthConfirmPage.tsx | 2h | open |
+| F-118 | 🔴 | security | Keine Rate-Limiting auf Auth-Endpunkten | supabase/functions | 3h | open |
+| F-119 | 🟡 | security | Fehlende Content Security Policy (CSP) | vercel.json | 2h | open |
+| F-120 | 🔴 | security | Email Enumeration durch Fehlermeldungen | src/features/auth/components/LoginScreen.tsx | 1h | open |
+| F-121 | 🔴 | security | Guest Tournament Limits Client-Side | src/features/auth/hooks/useTournamentLimit.ts | 3h | open |
+| F-122 | 🟠 | security | Console Logs in Production | src/features/auth/components/AuthCallback.tsx | 2h | open |
+| F-123 | 🟠 | security | Merge Function SQL Injection Risiko | supabase/functions/merge-accounts/index.ts | 2h | open |
+| F-124 | 🟠 | security | Session Timeout nicht implementiert | supabase | 2h | open |
+| F-125 | 🟠 | security | Kein Audit-Logging implementiert | supabase | 6h | open |
+| F-126 | 🟠 | security | Service Worker Security | public/sw.js | 3h | open |
+| F-127 | 🔴 | security | Client-Side Authorization Only | src/features/auth/components/AuthGuard.tsx | 4h | open |
+| F-128 | 🔴 | security | Supabase Service Role Key Exposure Risk | supabase/functions/merge-accounts/index.ts | 1h | open |
+| F-129 | 🔴 | security | Invite Token im URL-Parameter | src/features/auth/components/AuthConfirmPage.tsx | 2h | open |
+| F-130 | 🔴 | security | Keine Rate-Limiting auf Auth-Endpunkten | supabase/functions | 3h | open |
+| F-131 | 🟡 | security | Fehlende Content Security Policy (CSP) | vercel.json | 2h | open |
+| F-132 | 🔴 | security | Email Enumeration durch Fehlermeldungen | src/features/auth/components/LoginScreen.tsx | 1h | open |
+| F-133 | 🔴 | security | Guest Tournament Limits Client-Side | src/features/auth/hooks/useTournamentLimit.ts | 3h | open |
+| F-134 | 🟠 | security | Console Logs in Production | src/features/auth/components/AuthCallback.tsx | 2h | open |
+| F-135 | 🟠 | security | Merge Function SQL Injection Risiko | supabase/functions/merge-accounts/index.ts | 2h | open |
+| F-136 | 🟠 | security | Session Timeout nicht implementiert | supabase | 2h | open |
+| F-137 | 🟠 | security | Kein Audit-Logging implementiert | supabase | 6h | open |
+| F-138 | 🟠 | security | Service Worker Security | public/sw.js | 3h | open |
+| F-139 | 🔴 | data | Date/ISO-Inkonsistenz in Schemas | src/core/models/TournamentSchema.ts | 2h | open |
+| F-140 | 🟠 | data | Redundante Sport-Felder in TournamentSchema | src/core/models/TournamentSchema.ts | 1h | open |
+| F-141 | 🟠 | data | Fehlende Referenzintegrität für Team/Group IDs | src/core/models/MatchSchema.ts | 3h | open |
+| F-142 | 🟠 | data | Timer-State-Inkonsistenz ohne Validierung | src/core/models/LiveMatch.ts | 2h | open |
+| F-143 | 🟠 | data | Score-Validierung fehlt komplett | src/core/models/MatchSchema.ts | 2h | open |
+| F-144 | 🟠 | security | .passthrough() erlaubt unbekannte Felder | src/core/schemas/CommonSchemas.ts | 1h | open |
+| F-145 | 🟠 | data | Event-Typ-Validierung unvollständig | src/core/models/RuntimeMatchEventSchema.ts | 3h | open |
+| F-146 | 🟠 | architecture | Status-Transition-Validierung fehlt | src/core/models/MatchSchema.ts | - | open |
+| F-147 | 🟡 | architecture | Sport-Erweiterung erfordert Core-Änderungen | src/config/sports/football.ts | 4h | open |
+| F-148 | 🟡 | architecture | AgeClasses nicht sport-neutral | src/config/sports/football.ts | 2h | open |
+| F-149 | 🟡 | architecture | FinalsPreset-Enum nicht erweiterbar | src/types/FinalsPreset.ts | 2h | open |
+| F-150 | 🟡 | architecture | Playoff-Bracket-Generierung nicht im Code sichtbar | src/core/generators/ | 8h | open |
+| F-151 | 🔴 | data | reset_schedule löscht correctionHistory | src/admin/DangerZone/index.tsx | 1h | open |
+| F-152 | 🟠 | data | regenerate_schedule ignoriert finished-Matches | src/admin/DangerZone/index.tsx | 30m | open |
+| F-153 | 🟡 | architecture | Tiebreaker-Implementierung nicht im Code sichtbar | src/core/models/LiveMatch.ts | 4h | open |
+| F-154 | 🟠 | data | Punktgleichheit nicht spezifiziert | src/exports/Exports/index.tsx | 2h | open |
+| F-155 | 🟠 | ux | DangerZone zu mächtig ohne Bestätigung | src/admin/DangerZone/index.tsx | 1h | open |
+| F-156 | 🟠 | ux | Keine Undo-Funktion für Ergebnis-Korrekturen | src/admin/ActivityLog/index.tsx | 3h | open |
+| F-157 | 🟠 | ux | Team-Management während Turnier nicht möglich | src/helpers/TeamHelpers/index.tsx | 4h | open |
+| F-158 | 🟠 | ux | Keine Playoff-Vorschau im Admin-Cockpit | src/admin/Cockpit/index.tsx | 2h | open |
+| F-159 | 🟡 | ux | Auto-Share-Code ohne manuelle Kontrolle | src/admin/Visibility/index.tsx | 1h | open |
+| F-160 | 🟠 | ux | Feld-Zuweisung zu Matches fehlt | src/admin/Settings/index.tsx | 2h | open |

--- a/reviews/2026-03-16_1935_SUMMARY.md
+++ b/reviews/2026-03-16_1935_SUMMARY.md
@@ -1,0 +1,3734 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-03-16 19:35  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 204.9s  
+**Agents:** 15  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Architektur & Schichtenmodell | success | 44.3s | 151.3k | 45277 |
+| 2 | Code-Qualitaet & TypeScript-Patterns | success | 30.5s | 147.0k | 45164 |
+| 3 | UI-Komponenten & Design System | success | 50.0s | 147.8k | 47592 |
+| 4 | PDF-Export, Sharing & Datenausgabe | success | 29.7s | 150.4k | 43574 |
+| 5 | Hooks, State & Context | success | 102.7s | 148.0k | 43768 |
+| 6 | Internationalisierung & Barrierefreiheit | success | 45.3s | 150.6k | 49096 |
+| 7 | Live-Cockpit & Spielsteuerung | success | 50.6s | 148.8k | 43525 |
+| 8 | Performance, Bundle & PWA | success | 44.8s | 32.5k | 12335 |
+| 9 | Screens, Routing & Navigation | success | 38.1s | 150.7k | 42153 |
+| 10 | Security & Datenschutz | success | 53.6s | 151.3k | 44828 |
+| 11 | Sport-Konfiguration & Datenmodell | success | 32.7s | 134.3k | 43459 |
+| 12 | Supabase, Datenbank & Sync | success | 41.7s | 150.3k | 38973 |
+| 13 | Testing & Qualitaetssicherung | success | 45.0s | 99.1k | 33936 |
+| 14 | Turnier-Admin & Playoff-Logik | success | 44.7s | 151.5k | 42083 |
+| 15 | Turnier-Erstellung (Wizard Flow) | success | 56.9s | 149.2k | 44632 |
+
+---
+
+## Architektur & Schichtenmodell
+
+
+
+# Architektur-Review: hallenfussball-pwa
+
+## Zusammenfassung
+Die Architektur folgt einem **Clean Architecture**-Ansatz mit klarer Trennung zwischen **Core (Business Logic)** und **UI (React)**. Das Repository-Pattern wird konsequent für Datenzugriff und Offline-First-Funktionalität eingesetzt. Die Turnierlogik (Generatoren) ist modular und rein funktional aufgebaut, was die Testbarkeit stark erhöht.
+
+## Stärken
+
+1.  **Saubere Schichtenarchitektur:**
+    - `src/core` enthält reine Business-Logik ohne React-Abhängigkeiten (außer Context).
+    - Generatoren (`playoffGenerator`, `fairScheduler`) sind rein funktional und leicht testbar.
+    - Models und Schemas sind zentralisiert und konsistent.
+
+2.  **Robustes Repository Pattern:**
+    - Abstraktion über `ITournamentRepository` ermöglicht einfachen Wechsel zwischen `LocalStorage` und `Supabase`.
+    - `OfflineRepository` Wrapper implementiert Offline-First-Strategie mit Mutation-Queue.
+    - `RepositoryContext` orchestriert die Repository-Auswahl basierend auf Auth-Status.
+
+3.  **Umfassende Validierung:**
+    - Zod-Schemas für alle Domain-Objekte (`Tournament`, `Match`, `Team`).
+    - `passthrough()` verhindert Datenverlust bei unbekannten Feldern (Forward Compatibility).
+    - Umfangreiche Tests für Schemas und Generatoren.
+
+4.  **Fehlerbehandlung:**
+    - Eigene Error-Hierarchie (`AppError`, `RepositoryError`, etc.) mit Feature-Tagging.
+    - Konsistente Behandlung von `AbortError` in `isAbortError`.
+
+5.  **Komplexe Logik-Modularisierung:**
+    - Playoff-Generierung, Spielplan-Erstellung und Schiedsrichter-Zuweisung sind in separaten Modulen gekapselt.
+    - Preset-basierte Playoff-Logik (`top-4`, `top-8`, etc.) ist flexibel konfigurierbar.
+
+## Architektur-Probleme
+
+### 1. Dependency Inversion Verletzung (Critical)
+**Datei:** `src/core/contexts/RepositoryContext.tsx`
+**Problem:** Der Core-Context importiert `useAuth` aus `features/auth`. Das bricht die Abhängigkeitsrichtung (Core sollte nicht von Features abhängen).
+```typescript
+// src/core/contexts/RepositoryContext.tsx
+import { useAuth } from '../../features/auth/hooks/useAuth'; // ❌ Core hängt von Feature ab
+```
+**Auswirkung:** Zirkuläre Abhängigkeiten werden möglich, Core ist nicht mehr unabhängig testbar.
+
+### 2. Date-Handling Inkonsistenz (High)
+**Datei:** `src/core/models/schemas/TournamentSchema.ts`
+**Problem:** `scheduledTime` ist als `z.union([z.string(), z.date()])` definiert, aber im Code oft als `Date`-Objekt behandelt. JSON-Serialisierung wandelt `Date` in String um, was zu Laufzeitfehlern führen kann.
+```typescript
+// Schema
+scheduledTime: z.union([z.string(), z.date()]).optional(),
+
+// Code (scheduleHelpers.ts)
+const matchStart = m.scheduledTime ? new Date(m.scheduledTime) : ... // ⚠️ Risiko bei falschem Typ
+```
+**Auswirkung:** Potenzielle Bugs bei der Zeitberechnung, besonders nach Reload aus LocalStorage.
+
+### 3. Komplexe Generator-Logik (Medium)
+**Datei:** `src/core/generators/scheduleGenerator.ts`
+**Problem:** Die `generateFullSchedule`-Funktion enthält zu viel Logik ("Hybrid Mode", Persistenz-Checks, Fallbacks). Die Funktion ist zu groß und schwer zu warten.
+```typescript
+// scheduleGenerator.ts
+if (hasMatches) {
+  // ... 100+ Zeilen Logik für Persistenz-Mode
+} else {
+  // ... Generierungs-Logik
+}
+```
+**Auswirkung:** Hohe kognitive Last, schwer zu testen, fehleranfällig bei Änderungen.
+
+### 4. Mutation-Queue Type Safety (Medium)
+**Datei:** `src/core/models/schemas/MutationItemSchema.ts`
+**Problem:** `payload: z.unknown()` reduziert Type Safety für Mutationen.
+```typescript
+export const MutationItemSchema = z.object({
+  // ...
+  payload: z.unknown(), // ⚠️ Keine Typprüfung
+  // ...
+});
+```
+**Auswirkung:** Fehlerhafte Payloads werden erst zur Laufzeit erkannt.
+
+### 5. Global State im Context (Low)
+**Datei:** `src/core/contexts/RepositoryContext.tsx`
+**Problem:** `supabaseLiveMatchRepoRef` wird im Context gehalten. Bei mehrfacher Instanziierung (z.B. Strict Mode) kann dies zu Problemen führen.
+```typescript
+const supabaseLiveMatchRepoRef = useRef<SupabaseLiveMatchRepository | null>(null);
+```
+**Auswirkung:** Potenzielle Memory Leaks oder doppelte Subscriptions.
+
+## Konkrete Verbesserungsvorschläge
+
+### 1. Dependency Inversion für Auth
+Erstelle ein Interface für Auth-Status im Core und injiziere es.
+
+```typescript
+// src/core/contexts/AuthContext.ts (neu)
+export interface IAuthProvider {
+  user: { id: string; globalRole?: string } | null;
+  isLoading: boolean;
+}
+
+// src/core/contexts/RepositoryContext.tsx
+export const RepositoryProvider: React.FC<{ 
+  children: React.ReactNode;
+  authProvider: IAuthProvider; // ⚡ Injizieren statt importieren
+}> = ({ children, authProvider }) => {
+  const { user } = authProvider;
+  // ...
+};
+```
+
+### 2. Einheitliches Date-Handling mit Zod Transform
+Nutze `z.preprocess` für konsistente Date-Transformation.
+
+```typescript
+// src/core/models/schemas/TournamentSchema.ts
+const DateSchema = z.preprocess(
+  (arg) => {
+    if (arg instanceof Date) return arg;
+    if (typeof arg === 'string') return new Date(arg);
+    return arg;
+  },
+  z.date()
+);
+
+export const MatchSchema = z.object({
+  // ...
+  scheduledTime: DateSchema.optional(), // ⚡ Immer Date-Objekt im Memory
+});
+```
+
+### 3. Refactoring des Schedule Generators
+Trenne Persistenz-Logik von Generierungs-Logik.
+
+```typescript
+// src/core/generators/scheduleGenerator.ts
+export function generateFullSchedule(tournament: Tournament, locale: 'de' | 'en'): GeneratedSchedule {
+  const matches = hasExistingMatches(tournament) 
+    ? hydrateExistingMatches(tournament) // ⚡ Separate Funktion
+    : generateMatchesFromScratch(tournament); // ⚡ Separate Funktion
+  
+  return buildSchedule(matches, tournament, locale);
+}
+```
+
+### 4. Typed Mutation Payloads
+Verwende Union Types für Payloads statt `z.unknown()`.
+
+```typescript
+// src/core/models/schemas/MutationItemSchema.ts
+const SaveTournamentPayload = z.object({ /* ... */ });
+const UpdateMatchPayload = z.object({ /* ... */ });
+
+const MutationPayload = z.discriminatedUnion('type', [
+  SaveTournamentPayload,
+  UpdateMatchPayload,
+  // ...
+]);
+
+export const MutationItemSchema = z.object({
+  type: z.enum(['SAVE_TOURNAMENT', 'UPDATE_MATCH', ...]),
+  payload: MutationPayload, // ⚡ Typsicher
+  // ...
+});
+```
+
+### 5. Cleanup im RepositoryContext
+Verwende `useRef` für Cleanup-Logik, um doppelte Subscriptions zu vermeiden.
+
+```typescript
+// src/core/contexts/RepositoryContext.tsx
+const cleanupRef = useRef<() => void>();
+
+useEffect(() => {
+  return () => {
+    cleanupRef.current?.();
+  };
+}, []);
+
+// Bei Repository-Wechsel
+if (cleanupRef.current) {
+  cleanupRef.current();
+}
+cleanupRef.current = () => supabaseLiveMatchRepoRef.current?.unsubscribeAll();
+```
+
+## Bewertung
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Trennung der Belange** | 8/10 | Core/Feature-Trennung gut, aber Auth-Coupling im Context |
+| **Testbarkeit** | 9/10 | Funktionale Generatoren und Schemas sind hervorragend testbar |
+| **Skalierbarkeit** | 7/10 | Repository-Pattern skaliert gut, aber Generator-Logik wird komplex |
+| **Type Safety** | 8/10 | Zod + TypeScript gut integriert, aber `z.unknown()` und Date-Probleme |
+| **Wartbarkeit** | 7/10 | Gute Struktur, aber einige Funktionen sind zu komplex (scheduleGenerator) |
+
+**Gesamtbewertung: 7.8/10**
+
+Die Architektur ist für eine PWA mit Offline-First-Anforderungen sehr gut durchdacht. Die größten Schwachstellen liegen im Coupling zwischen Core und Features sowie in der Komplexität einiger Generator-Funktionen. Mit den vorgeschlagenen Verbesserungen kann die Architektur auf 9/10 gehoben werden.
+
+---
+
+## Code-Qualitaet & TypeScript-Patterns
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metric | Score | Status |
+|--------|-------|--------|
+| **Overall Quality** | **7.8/10** | ✅ Good |
+| **Type Safety** | 8.2/10 | ✅ Strong |
+| **Test Coverage** | 8.5/10 | ✅ Excellent |
+| **Maintainability** | 7.5/10 | ⚠️ Moderate |
+| **Performance** | 7.0/10 | ⚠️ Needs Attention |
+
+---
+
+## 🔴 Code Smells (Critical & High Priority)
+
+### 1. **BUG-001: Team Matching Inconsistency**
+**File:** `src/utils/calculations.ts` (Line 35-42)
+**Severity:** 🔴 Critical
+
+```typescript
+// Problem: Mixing team ID and name matching creates ambiguity
+const teamAStanding = standings.find(
+  (s) => s.team.name === match.teamA || s.team.id === match.teamA
+);
+```
+
+**Issue:** `match.teamA` can be either team ID or team name depending on context. This creates fragile code that's hard to debug.
+
+**Recommendation:**
+```typescript
+// Normalize team references to IDs only
+const teamAStanding = standings.find(s => s.team.id === normalizeTeamId(match.teamA));
+```
+
+---
+
+### 2. **Performance: O(n²) Fairness Calculator**
+**File:** `src/utils/FairnessCalculator.ts` (Line 15-25)
+**Severity:** 🟡 Medium
+
+```typescript
+// Current: O(n²) for 64 teams, ~5-10s
+// Test shows: "NOTE: Current baseline after Session 2 is ~5-10s (O(n²))"
+// Before: ~30-35s (O(n³))
+```
+
+**Issue:** While improved from O(n³), still problematic for 128+ teams (skipped test).
+
+**Recommendation:**
+```typescript
+// Consider using a priority queue or heap-based approach
+// Target: O(n log n) for large tournaments
+```
+
+---
+
+### 3. **Dead Code: updateKnockoutMatchesAfterResult**
+**File:** `src/utils/knockoutMatchGenerator.ts` (Line 100+)
+**Severity:** 🟡 Medium
+
+```typescript
+// NOTE: updateKnockoutMatchesAfterResult was removed (dead code - never called)
+```
+
+**Issue:** Commented-out code that should be removed entirely.
+
+**Recommendation:** Remove dead code comments and unused functions.
+
+---
+
+### 4. **Magic Numbers in Tests**
+**File:** `src/utils/__tests__/fairScheduler.minimal.test.ts` (Line 55)
+**Severity:** 🟢 Low
+
+```typescript
+expect(duration).toBeLessThan(45000); // 45s generous timeout
+```
+
+**Issue:** Hard-coded timeout values should be constants.
+
+**Recommendation:**
+```typescript
+const SCHEDULER_TIMEOUT_MS = 45000;
+expect(duration).toBeLessThan(SCHEDULER_TIMEOUT_MS);
+```
+
+---
+
+## 🟡 TypeScript Violations
+
+### 1. **Non-Null Assertions (!)**
+**Files:** Multiple test files
+**Severity:** 🟡 Medium
+
+```typescript
+// src/utils/__tests__/calculations.test.ts (Line 108)
+const team1 = standings.find(s => s.team.name === 'Team 1')!;
+```
+
+**Issue:** Non-null assertions in production code are dangerous. Acceptable in tests but should be minimized.
+
+**Recommendation:** Use proper type guards or optional chaining in production code.
+
+---
+
+### 2. **Type Assertions with `as`**
+**File:** `src/utils/__tests__/ScenarioHMK.test.ts` (Line 20)
+**Severity:** 🟢 Low
+
+```typescript
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+```
+
+**Issue:** Runtime JSON parsing without validation.
+
+**Recommendation:** Use Zod schema validation:
+```typescript
+import { tournamentSchema } from '../types/tournament';
+const importedTournament = tournamentSchema.parse(JSON.parse(fileContent));
+```
+
+---
+
+### 3. **Unused ESLint Disable Comments**
+**File:** `src/utils/calculations.ts` (Line 35)
+**Severity:** 🟢 Low
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Boolean OR: true if either team matches
+```
+
+**Issue:** Some `eslint-disable` comments are overly permissive.
+
+**Recommendation:** Review and remove unnecessary disables.
+
+---
+
+## 📝 Naming Inconsistencies
+
+### 1. **Mixed German/English Naming**
+**Files:** Multiple utility files
+**Severity:** 🟢 Low
+
+```typescript
+// German: getGroupLabel, getGroupShortCode
+// English: generateDisplayNames, resolvePlayoffPlaceholder
+```
+
+**Issue:** Inconsistent naming convention across the codebase.
+
+**Recommendation:** Choose one convention (preferably English for consistency with React/TS ecosystem).
+
+---
+
+### 2. **Inconsistent Variable Naming**
+**File:** `src/utils/calculations.ts` (Line 115)
+**Severity:** 🟢 Low
+
+```typescript
+let _aWins = 0;  // Underscore prefix for unused variable
+```
+
+**Issue:** Inconsistent use of underscore prefix.
+
+**Recommendation:** Use `aWins` and handle properly, or use `_` prefix consistently for intentionally unused variables.
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Excellent Test Coverage**
+**Files:** Multiple test files
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+// Comprehensive test scenarios including edge cases
+it('handles odd teams (13) with BYE rounds', () => { ... });
+it('handles mixed ID and name references', () => { ... });
+it('completes 64 teams (performance baseline)', () => { ... });
+```
+
+**Why it's good:** Tests cover edge cases, performance scenarios, and bug fixes (BUG-001, DEF-003).
+
+---
+
+### 2. **Type-Safe Utility Functions**
+**File:** `src/utils/debug.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+export function debugTap<T>(context: string, label: string): (value: T) => T {
+  return (value: T) => {
+    if (isDev) {
+      console.log(`${context} ${label}:`, value);
+    }
+    return value;
+  };
+}
+```
+
+**Why it's good:** Generic type preservation, production-safe (stripped in production).
+
+---
+
+### 3. **Graceful Fallbacks**
+**File:** `src/utils/idGenerator.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+if (crypto?.randomUUID) {
+  return crypto.randomUUID();
+}
+// Fallback: timestamp + random (simulated UUID-ish)
+```
+
+**Why it's good:** Progressive enhancement with fallback for older browsers.
+
+---
+
+### 4. **Comprehensive Error Handling**
+**File:** `src/utils/soundStorage.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+export async function storeCustomSound(
+  tournamentId: string,
+  file: File
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateAudioFile(file);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+  // ... with try-catch and proper error messages
+}
+```
+
+**Why it's good:** Structured error responses, validation before processing.
+
+---
+
+## 🛠 Refactoring Recommendations (Prioritized)
+
+### **Priority 1: Critical (Fix Immediately)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 1 | Team ID/Name matching ambiguity | 2h | 🔴 High |
+| 2 | Add Zod validation for JSON imports | 3h | 🔴 High |
+| 3 | Remove dead code & comments | 1h | 🟡 Medium |
+
+### **Priority 2: High (Next Sprint)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 4 | Optimize FairnessCalculator for 128+ teams | 8h | 🟡 Medium |
+| 5 | Standardize naming convention (German/English) | 4h | 🟢 Low |
+| 6 | Replace magic numbers with constants | 2h | 🟢 Low |
+
+### **Priority 3: Medium (Backlog)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 7 | Add TypeScript strict mode flags | 4h | 🟡 Medium |
+| 8 | Improve ESLint rule configuration | 2h | 🟢 Low |
+| 9 | Add integration tests for scheduler | 6h | 🟡 Medium |
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Category | Score | Notes |
+|----------|-------|-------|
+| **Type Safety** | 8.2/10 | Strong typing, some `as` casts |
+| **Test Coverage** | 8.5/10 | Excellent edge case coverage |
+| **Performance** | 7.0/10 | O(n²) scheduler needs optimization |
+| **Maintainability** | 7.5/10 | Good structure, some naming issues |
+| **Error Handling** | 8.0/10 | Comprehensive, structured errors |
+| **Documentation** | 8.0/10 | Good JSDoc, some TODOs |
+| **Security** | 7.5/10 | Input validation present, could be stricter |
+
+---
+
+## 🎯 Action Items
+
+### Immediate (This Week)
+```bash
+# 1. Fix team matching ambiguity
+# 2. Add Zod validation for imports
+# 3. Clean up dead code
+```
+
+### Short-term (Next Sprint)
+```bash
+# 4. Optimize scheduler performance
+# 5. Standardize naming conventions
+# 6. Add performance benchmarks
+```
+
+### Long-term (Next Quarter)
+```bash
+# 7. Implement TypeScript strict mode
+# 8. Add integration test suite
+# 9. Performance monitoring setup
+```
+
+---
+
+## 📋 Summary
+
+**Strengths:**
+- ✅ Excellent test coverage with edge cases
+- ✅ Strong type safety overall
+- ✅ Good error handling patterns
+- ✅ Comprehensive documentation
+
+**Weaknesses:**
+- ⚠️ Team ID/name matching ambiguity
+- ⚠️ Performance issues with large tournaments
+- ⚠️ Some dead code and magic numbers
+- ⚠️ Naming convention inconsistencies
+
+**Overall Assessment:** The codebase is **production-ready** with solid foundations. The identified issues are mostly optimizations rather than blockers. Focus on Priority 1 items before scaling to larger tournaments.
+
+---
+
+*Report generated by Senior TypeScript/React Developer Review*
+*Date: 2024-01-XX*
+*Project: hallenfussball-pwa (626 files, ~24,000 LOC)*
+
+---
+
+## UI-Komponenten & Design System
+
+
+
+# UI-Komponenten-Review: hallenfussball-pwa
+
+## Executive Summary
+Das Design-System ist **konsistent aufgebaut** und nutzt Design Tokens (`cssVars`) effektiv. Die Komponenten sind **mobile-first** konzipiert (Touch-Targets, Bottom Navigation). Allerdings gibt es signifikante **Accessibility-Lücken** (fehlende Keyboard-Navigation, semantische Fehler) und **Inkonsistenzen** in der Implementierung (Inline-Styles vs. CSS-Classes, Hooks-Regeln).
+
+---
+
+## 1. Design-Token-Verstöße & Konsistenz
+
+### 🔴 Hardcodierte Werte
+- **`ActionMenu`**: `zIndex: 1100` ist hardcodiert. Sollte ein Token sein (z.B. `zIndex.dropdown`).
+- **`BottomNavigation`**: `zIndex: 1000` ist hardcodiert.
+- **`ConfirmDialog`**: `zIndex: 10000` ist hardcodiert.
+- **`ToastContainer`**: `bottom: 24, right: 24` sind hardcodierte Pixel-Werte.
+
+### 🟡 Inline-Styles vs. CSS-Classes
+- **`ActionMenu`**: `onMouseEnter`/`onMouseLeave` manipulieren direkt `e.currentTarget.style`. Das ist **anti-pattern** für React (Performance, State-Management).
+- **`Button`**: Nutzt `transitions` aus `styles/motion`, aber andere Komponenten nutzen Inline-Transition-Strings.
+- **`Skeleton`**: Nutzt CSS-Module (`Skeleton.module.css`), was **besser** ist als Inline-Styles.
+
+### 🟢 Positive Beispiele
+- **`Input`**, **`Select`**, **`Combobox`**: Nutzen konsistent `cssVars` für Farben, Abstände und Typografie.
+- **`TeamAvatar`**: Nutzt `AVATAR_SIZES` Objekt für konsistente Größen.
+
+---
+
+## 2. Accessibility-Verstöße (WCAG 2.1 AA)
+
+### 🔴 Kritische Verstöße
+| Komponente | Problem | WCAG Kriterium |
+|------------|---------|----------------|
+| **ActionMenu** | Keine Pfeiltasten-Navigation im Menü (nur Escape zum Schließen). | 2.1.1 Keyboard |
+| **Card** | `onClick` auf `div` ohne `role="button"` und `tabIndex="0"`. | 4.1.2 Name, Role, Value |
+| **CollapsibleInfoPanel** | `role="button"` auf `div` statt semantischem `<button>`. | 4.1.2 Name, Role, Value |
+| **PasswordInput** | `tabIndex={-1}` auf Toggle-Button (nicht fokussierbar). | 2.1.1 Keyboard |
+| **LogoUploadDialog** | DropZone hat `onClick` aber keine Keyboard-Interaktion. | 2.1.1 Keyboard |
+
+### 🟡 Mäßige Verstöße
+| Komponente | Problem | WCAG Kriterium |
+|------------|---------|----------------|
+| **ActionMenu** | `aria-label="Aktionen"` ist statisch, sollte kontextabhängig sein. | 1.3.1 Info and Relationships |
+| **Combobox** | `aria-activedescendant` fehlt für die hervorgehobene Option. | 1.3.1 Info and Relationships |
+| **SyncIndicator** | `title` statt `aria-label` auf Compact-Indicator. | 1.1.1 Non-text Content |
+| **ConfirmDialog** | `isOpen` default ist `true` (Dialog erscheint sofort beim Import). | 2.4.3 Focus Order |
+| **ConnectionStatusBar** | `title` statt `aria-label` auf Refresh-Button. | 1.1.1 Non-text Content |
+
+### 🟢 Positive Beispiele
+- **Skeleton**: `role="status"`, `aria-busy="true"` korrekt gesetzt.
+- **Toast**: `role="alert"`, `aria-live="polite"` korrekt gesetzt.
+- **Input**: `aria-invalid`, `aria-describedby` korrekt gesetzt.
+- **BottomNavigation**: `aria-current="page"` korrekt gesetzt.
+
+---
+
+## 3. Inkonsistenzen & Code-Qualität
+
+### 🔴 React Hooks Rules
+- **`ActionMenu`**: `if (!visible) return null;` **nach** `useEffect` und `useCallback`. Das verletzt die **Rules of Hooks**. Hooks müssen immer in der gleichen Reihenfolge aufgerufen werden.
+
+### 🟡 Typisierung
+- **`BottomNavigation`**: `activeTab` Prop ist `string`, aber `onTabChange` erwartet `BottomNavTab`.
+- **`ConfirmDialog`**: `isOpen` default ist `true`, was zu unerwartetem Verhalten führt.
+- **`Icons`**: `Icons` Objekt ist nicht typisiert (keine TypeScript-Interface für `Icons` Keys).
+
+### 🟡 State-Management
+- **`ActionMenu`**: `isHovered` State in `ActionMenuItemButton` ist unnötig, da `:hover` CSS ausreicht.
+- **`Button`**: `isPressed` State für Press-Effekt ist gut, aber `prefersReducedMotion` wird in `useEffect` geprüft (sollte `matchMedia` direkt sein).
+
+### 🟢 Positive Beispiele
+- **`useId`**: Wird in `Input`, `BottomSheet`, `CollapsibleInfoPanel` korrekt für `aria-describedby`/`aria-labelledby` genutzt.
+- **`Skeleton`**: `SkeletonPresets` Objekt für wiederverwendbare Konfigurationen.
+
+---
+
+## 4. Verbesserungsvorschläge
+
+### 🔴 Priorität 1 (Accessibility & Bugs)
+1. **`ActionMenu`**:
+   - Hooks vor `visible`-Check verschieben.
+   - Keyboard-Navigation (Pfeiltasten) implementieren.
+   - `aria-label` dynamisch machen.
+2. **`Card`**:
+   - Wenn klickbar: `<button>` statt `<div>` oder `role="button"` + `tabIndex="0"` + `onKeyDown`.
+3. **`PasswordInput`**:
+   - `tabIndex={-1}` entfernen.
+4. **`CollapsibleInfoPanel`**:
+   - Header als `<button>` statt `<div>` mit `role="button"`.
+
+### 🟡 Priorität 2 (Konsistenz)
+1. **Design Tokens**:
+   - `zIndex` Werte in `design-tokens` auslagern (z.B. `zIndex.dropdown = 1100`).
+   - `ToastContainer` Positionierung in Tokens auslagern.
+2. **Inline-Styles**:
+   - `ActionMenu` Hover-Effekte in CSS-Classes auslagern.
+   - `Button` Press-Effekt in CSS-Classes auslagern.
+3. **Typisierung**:
+   - `BottomNavigation` `activeTab` Typisierung verschärfen.
+   - `Icons` Objekt typisieren.
+
+### 🟢 Priorität 3 (Optimierung)
+1. **`ActionMenu`**: `isHovered` State entfernen, CSS `:hover` nutzen.
+2. **`Button`**: `prefersReducedMotion` direkt in `useEffect` initialisieren.
+3. **`ConfirmDialog`**: `isOpen` default auf `false` setzen.
+
+---
+
+## 5. UI Component Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Design System** | 8/10 | Konsistente Nutzung von `cssVars`, aber einige Hardcodierungen. |
+| **Accessibility** | 5/10 | Viele kritische Verstöße (Keyboard, semantische HTML). |
+| **Code Quality** | 7/10 | Gute Typisierung, aber Hooks-Regeln werden verletzt. |
+| **Mobile UX** | 9/10 | Touch-Targets, Bottom Navigation, Safe Areas sind gut umgesetzt. |
+| **Performance** | 7/10 | Inline-Styles und State-Management könnten optimiert werden. |
+
+### **Gesamtscore: 7/10**
+
+**Fazit**: Das UI-System ist **funktional und mobile-optimiert**, aber **Accessibility muss dringend verbessert werden**. Die Hooks-Verletzung in `ActionMenu` ist ein kritischer Bug, der zu unerwartetem Verhalten führen kann. Die Konsistenz zwischen Inline-Styles und CSS-Classes sollte vereinheitlicht werden.
+
+---
+
+## PDF-Export, Sharing & Datenausgabe
+
+
+
+# Code Review: PDF-Export, Sharing & Datenausgabe
+
+## 📊 Export Score: **6/10**
+
+---
+
+## 🔴 Export-Bugs
+
+### 1. **PDF-Generierung ohne Font-Handling**
+```tsx
+// src/components/dialogs/PDFExportDialog.tsx
+await exportScheduleToPDF(updatedSchedule, includeStandings ? standings : undefined, {
+  locale: 'de',
+  includeScores,
+  includeStandings,
+  ...(tournament.organizer?.trim() ? { organizerName: tournament.organizer } : {}),
+  hallName: getLocationName(tournament),
+});
+```
+
+**Problem**: `exportScheduleToPDF` Implementation nicht im Code sichtbar. Bei jsPDF sind Umlaute (ä, ö, ü, ß) und Sonderzeichen ohne Font-Embedding **nicht darstellbar**.
+
+**Risiko**: PDF-Export bricht bei deutschen Team-Namen oder Orten mit Umlauten.
+
+**Empfehlung**:
+```ts
+// In pdfExporter.ts
+import { FontLoader } from 'jspdf';
+const pdf = new jsPDF();
+pdf.addFont('DejaVuSans.ttf', 'DejaVuSans', 'normal');
+pdf.setFont('DejaVuSans');
+```
+
+### 2. **Keine Fehlerbehandlung bei PDF-Generierung**
+```tsx
+try {
+  await exportScheduleToPDF(...);
+  setTimeout(() => { onClose(); setIsGenerating(false); }, 500);
+} catch (err) {
+  console.error('PDF generation failed:', err);
+  setError(t('pdfExport.error'));
+  setIsGenerating(false);
+}
+```
+
+**Problem**: Fehler wird nur im Dialog angezeigt, kein Fallback (z.B. Browser-Print).
+
+**Empfehlung**:
+```tsx
+catch (err) {
+  console.error('PDF generation failed:', err);
+  setError(t('pdfExport.error'));
+  setIsGenerating(false);
+  // Fallback: Browser-Print
+  if (confirm('PDF-Generierung fehlgeschlagen. Browser-Druck verwenden?')) {
+    window.print();
+  }
+}
+```
+
+### 3. **Keine Layout-Validierung vor Export**
+- Lange Team-Namen werden nicht abgeschnitten
+- Keine Prüfung ob alle Daten für PDF verfügbar sind
+- Keine Seitenbreiten-Validierung
+
+---
+
+## 🟡 Fehlende Export-Formate
+
+| Format | Status | Priorität |
+|--------|--------|-----------|
+| PDF | ✅ Implementiert | - |
+| CSV | ❌ Nur Import | Hoch |
+| Excel (.xlsx) | ❌ Nicht vorhanden | Mittel |
+| JSON Export | ❌ Nur Import | Mittel |
+| Print-Layout | ❌ Kein @media print | Hoch |
+| QR-Code Export | ❌ Nicht vorhanden | Mittel |
+
+**Empfehlung**:
+```tsx
+// Export-Dialog erweitern
+const exportFormats = [
+  { id: 'pdf', label: 'PDF', icon: <Icons.Download /> },
+  { id: 'csv', label: 'CSV', icon: <Icons.Table /> },
+  { id: 'json', label: 'JSON', icon: <Icons.Code /> },
+  { id: 'print', label: 'Drucken', icon: <Icons.Printer /> },
+];
+```
+
+---
+
+## 🟠 Sharing-UX-Probleme
+
+### 1. **ShareDialog Implementation nicht sichtbar**
+```tsx
+// src/components/ScheduleActionButtons.tsx
+<ShareDialog
+  isOpen={showShareDialog}
+  onClose={() => setShowShareDialog(false)}
+  tournamentId={tournament.id}
+  tournamentTitle={tournament.title}
+  shareCode={tournament.shareCode}
+  isPublic={tournament.isPublic}
+/>
+```
+
+**Problem**: `ShareDialog` nicht im Code. Unklar ob:
+- Web Share API genutzt wird (native Mobile Sharing)
+- QR-Code generiert wird
+- Deep-Links funktionieren
+
+**Empfehlung**:
+```tsx
+// Web Share API mit Fallback
+const handleShare = async () => {
+  const shareData = {
+    title: tournament.title,
+    text: `Schau dir das Turnier an: ${tournament.title}`,
+    url: `${window.location.origin}/t/${tournament.shareCode}`,
+  };
+
+  if (navigator.share) {
+    await navigator.share(shareData);
+  } else {
+    // Fallback: Copy to Clipboard
+    await navigator.clipboard.writeText(shareData.url);
+    showSuccess(t('share.copied'));
+  }
+};
+```
+
+### 2. **Keine Monitor-URL für öffentliche Anzeigetafel**
+- Keine separate `monitor`-Route sichtbar
+- Keine QR-Code Generierung für Live-Tracking
+- Keine Deep-Links zu spezifischen Spielen
+
+**Empfehlung**:
+```tsx
+// Monitor-URL generieren
+const monitorUrl = `${window.location.origin}/monitor/${tournament.shareCode}`;
+const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(monitorUrl)}`;
+```
+
+### 3. **Keine Copy-to-Clipboard für Links**
+- Turnier-Link kann nicht kopiert werden
+- Keine "Link teilen"-Funktion
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Dialog-basierter Export mit Optionen**
+```tsx
+// PDFExportDialog.tsx
+const [includeScores, setIncludeScores] = useState(hasScores);
+const [includeStandings, setIncludeStandings] = useState(true);
+```
+- Nutzer kann wählen ob Ergebnisse/Tabellen enthalten sein sollen
+- Loading State (`isGenerating`) verhindert Mehrfachklicks
+- Error Handling mit Benutzer-Feedback
+
+### 2. **Import/Export Templates**
+```tsx
+// ImportTemplates.ts
+export const JSON_TEMPLATE = { ... };
+export const CSV_TEMPLATE = `Team,Gruppe\n...`;
+export const downloadTemplate = (type: 'json' | 'csv') => { ... };
+```
+- Vorlagen für Import
+- CSV und JSON unterstützt
+- Template-Download als Button
+
+### 3. **i18n Integration**
+```tsx
+const { t } = useTranslation('tournament');
+title={t('pdfExport.title')}
+```
+- Alle Export-Labels übersetzbar
+- Konsistente UX über Sprachen
+
+### 4. **Responsive Action Buttons**
+```tsx
+// ScheduleActionButtons.tsx
+const fabContainerStyle: CSSProperties = {
+  position: 'fixed',
+  bottom: `calc(${layoutHeights.bottomNav} + ${cssVars.spacing.lg} + env(safe-area-inset-bottom, 0px))`,
+  right: cssVars.spacing.lg,
+  zIndex: 100,
+};
+```
+- Mobile FAB-Buttons
+- Desktop normale Buttons
+- Safe-Area-Handling für iOS
+
+---
+
+## 📋 Empfehlungen (Priorisiert)
+
+### **High Priority**
+1. **PDF Font-Embedding für Umlaute**
+   - DejaVu Sans oder Roboto Font in jsPDF integrieren
+   - Test mit Team-Namen wie "TSV München 1860"
+
+2. **Print-Layout (@media print)**
+   ```css
+   @media print {
+     .schedule-display {
+       page-break-after: always;
+     }
+     .no-print {
+       display: none;
+     }
+   }
+   ```
+
+3. **Web Share API mit Fallback**
+   - Native Sharing auf Mobile
+   - Clipboard-Fallback auf Desktop
+
+### **Medium Priority**
+4. **CSV Export (nicht nur Import)**
+   - Export von Spielplan und Tabellen
+   - Download als Blob
+
+5. **QR-Code für Monitor-URL**
+   - Generiere QR-Code für öffentliche Anzeigetafel
+   - In PDF und Share-Dialog integrieren
+
+6. **Deep-Links zu Spielen**
+   - `/tournament/:shareCode/match/:matchId`
+   - Für Live-Tracking und Korrektur
+
+### **Low Priority**
+7. **Excel Export (.xlsx)**
+   - Für Organiser mit komplexen Daten
+   - Bibliothek: `xlsx` oder `exceljs`
+
+8. **Export History**
+   - Letzten Export speichern
+   - "Neu generieren" vs. "Letzte Version herunterladen"
+
+---
+
+## 🎯 Fazit
+
+**Stärken**:
+- Dialog-basierter Export mit Optionen
+- Import/Export Templates vorhanden
+- Responsive UI für Mobile/Desktop
+
+**Schwächen**:
+- PDF-Generierung ohne Font-Handling (kritisch!)
+- Keine Print-Layouts
+- Sharing-Funktionen unklar (Dialog nicht sichtbar)
+- Keine CSV/JSON Exporte
+
+**Nächste Schritte**:
+1. `exportScheduleToPDF` Implementation prüfen (Font-Handling)
+2. Print-Stylesheets hinzufügen
+3. ShareDialog mit Web Share API implementieren
+4. CSV Export hinzufügen
+
+**Export Score: 6/10** - Grundfunktionen vorhanden, aber kritische Lücken bei Umlauten und Sharing.
+
+---
+
+## Hooks, State & Context
+
+
+
+Hier ist das strukturierte Review der Hooks und Contexts für das **hallenfussball-pwa** Projekt.
+
+## 📊 State Management Score: 8/10
+
+**Begründung:** Die Architektur ist insgesamt sehr solide. Die Trennung von UI-Logik (Hooks) und Geschäftslogik (Services/Repositories) ist gut umgesetzt. Der `RepositoryContext` ist ein starkes Muster für die Datenbeschaffung. Es gibt jedoch einige kritische Performance-Probleme bei Timer-Hooks und einen funktionellen Bug in `useLongPress`, der behoben werden muss.
+
+---
+
+## 🚨 Re-Render-Probleme
+
+### 1. `useClickOutside` & `useClickOutsideMultiple`
+**Problem:** Der `handler` ist in der Dependency-Array des `useEffect`. Wenn der übergebene Handler im Eltern-Component nicht mit `useCallback` stabilisiert ist, wird der Event-Listener bei jedem Render entfernt und neu angehängt.
+**Folge:** Performance-Overhead, potenzielle Race Conditions.
+**Fix:**
+```ts
+// In useClickOutside.ts
+useEffect(() => {
+  if (!enabled) return;
+  const listener = (event: MouseEvent | TouchEvent) => {
+    // ... logic
+  };
+  document.addEventListener('mousedown', listener);
+  // ...
+  return () => {
+    document.removeEventListener('mousedown', listener);
+    // ...
+  };
+}, [ref, enabled]); // handler entfernen!
+// Oder handler in Ref speichern, wie in useDialogTimer
+```
+
+### 2. `useMatchTimerExtended` & `useLiveProgress`
+**Problem:** Diese Hooks geben bei jedem Tick (jede Sekunde) ein **neues Objekt** zurück (`MatchTimerResult` bzw. `UseLiveProgressReturn`).
+**Folge:** Wenn diese Hooks in einer Liste von Matches verwendet werden, re-rendern alle Eltern-Components bei jeder Sekunde, selbst wenn sich nur die Zeit ändert.
+**Fix:**
+*   Nutze `React.memo` für die Komponenten, die den Timer anzeigen.
+*   Oder zerlege den Hook: Gib nur `elapsedSeconds` zurück und berechne die Formate im Component (weniger Objekte).
+
+### 3. `useLiveMatches`
+**Problem:** `liveMatches` ist eine `Map`. Bei jedem Update wird eine **neue Map-Instanz** erstellt (`new Map(...)`).
+**Folge:** Alle Consumer, die `liveMatches` direkt verwenden, re-rendern, auch wenn sich nur ein Match geändert hat.
+**Fix:**
+*   Nutze `useMemo` im Consumer, um spezifische Matches zu selektieren.
+*   Besser: Gib `getMatchById` zurück und lass den Consumer `useMemo` nutzen.
+
+---
+
+## ⚠️ Memory Leaks & Cleanup
+
+### 1. `useLongPress` (Kritisch)
+**Problem:** `isPressed` wird als `isPressedRef.current` zurückgegeben. Refs lösen **keine Re-Renders** aus.
+**Folge:** Die UI wird nicht aktualisiert, wenn der Press-Status sich ändert (z.B. Button-Feedback).
+**Fix:**
+```ts
+const [isPressed, setIsPressed] = useState(false);
+// ...
+setIsPressed(true); // in handlePressStart
+setIsPressed(false); // in handlePressEnd
+return { ..., isPressed };
+```
+
+### 2. `useMatchSound`
+**Problem:** `audioRef.current` wird nicht explizit auf `null` gesetzt beim Unmount.
+**Folge:** Das Audio-Element bleibt im Speicher, bis GC greift.
+**Fix:**
+```ts
+useEffect(() => {
+  return () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null; // Explicit cleanup
+    }
+    if (customUrlRef.current) {
+      URL.revokeObjectURL(customUrlRef.current);
+    }
+  };
+}, []);
+```
+
+### 3. `useMonitorHeartbeats`
+**Problem:** `refreshStatuses` wird in einem `setInterval` verwendet. Die Funktion selbst ist `useCallback`-gememoized, aber das `setInterval` hängt von `tournamentId` ab.
+**Folge:** Wenn `tournamentId` sich ändert, wird das alte Interval nicht sofort gestoppt, bevor das neue startet (kurzes Overlap).
+**Fix:**
+*   `useRef` für das Interval-ID speichern und im Cleanup explizit `clearInterval` aufrufen.
+
+---
+
+## 🛑 Anti-Patterns
+
+### 1. `useMatchExecution` ("God Hook" Tendenz)
+**Problem:** Der Hook enthält extrem viel Logik (Initialisierung, Status-Handling, Scoring, Tiebreaker, Skip, Undo, Sync). Er ist über 200 Zeilen lang und hat viele Abhängigkeiten.
+**Folge:** Schwer testbar, schwer zu warten, führt zu großen Re-Render-Bereichen.
+**Empfehlung:**
+*   Spalte die Handler-Logik in separate Hooks auf (z.B. `useMatchScoring`, `useMatchStatus`).
+*   Oder delegiere mehr Logik an `MatchExecutionService` und reduziere den Hook auf State-Management.
+
+### 2. `useLocalStorage`
+**Problem:** `setValue` führt `JSON.stringify` bei jedem Set aus.
+**Folge:** Bei großen Objekten (z.B. ganze Turniere) Performance-Overhead.
+**Empfehlung:**
+*   Prüfe vorher, ob sich der Wert wirklich geändert hat (`JSON.stringify(old) !== JSON.stringify(new)`).
+
+### 3. `useAuthTimeoutToast`
+**Problem:** `showWarning` ist in den Dependencies. Wenn `ToastContext` nicht `useCallback` für `showWarning` nutzt, läuft der Effekt bei jedem Render.
+**Empfehlung:**
+*   `showWarning` im ToastContext mit `useCallback` stabilisieren.
+
+---
+
+## ✅ Positive Patterns
+
+1.  **`useDialogTimer` (Stale Closure Fix):**
+    *   Nutzt `onExpireRef` um den Callback aktuell zu halten, ohne den Effekt neu zu starten. Das ist der korrekte Weg für Timer-Callbacks.
+    ```ts
+    const onExpireRef = useRef(onExpire);
+    useEffect(() => { onExpireRef.current = onExpire; }, [onExpire]);
+    // Nutzung: onExpireRef.current?.();
+    ```
+
+2.  **`useIsMobile` (Performance):**
+    *   Nutzt `matchMedia` statt `window.addEventListener('resize')`. Das ist performanter, da es nur bei Breakpoint-Überschreitung feuert.
+
+3.  **`RepositoryContext` (Singleton Pattern):**
+    *   Nutzt `useRef` (`supabaseLiveMatchRepoRef`), um Repository-Instanzen über den Lebenszyklus des Providers hinweg stabil zu halten, auch wenn `user` sich ändert (wichtig für Realtime-Subscriptions).
+
+4.  **`useFocusTrap` (Accessibility):**
+    *   Korrekte Implementierung von `inert` Attributen und Fokus-Restoration. Sehr gut für WCAG-Konformität.
+
+5.  **`useMatchSound` (Async Safety):**
+    *   Nutzt `isMounted` Flag in `useEffect` um State-Updates nach Unmount zu verhindern.
+
+---
+
+## 🛠️ Konkrete Handlungsempfehlungen
+
+1.  **Priorität 1 (Bugfix):** `useLongPress` korrigieren (`isPressed` muss State sein).
+2.  **Priorität 2 (Performance):** `useClickOutside` Dependency-Array bereinigen (`handler` entfernen).
+3.  **Priorität 3 (Optimierung):** Timer-Hooks (`useMatchTimerExtended`) so umbauen, dass sie nicht bei jedem Tick ein neues Objekt zurückgeben, oder Consumer mit `React.memo` schützen.
+4.  **Priorität 4 (Refactoring):** `useMatchExecution` in kleinere Hooks aufteilen, um die Komplexität zu reduzieren.
+
+**Gesamturteil:** Das Team hat ein sehr hohes Verständnis für React Hooks (Refs, Cleanup, Dependencies). Die Architektur ist skalierbar. Mit den oben genannten Fixes (insbesondere `useLongPress` und `useClickOutside`) wäre das State-Management auf Production-Level 10/10.
+
+---
+
+## Internationalisierung & Barrierefreiheit
+
+
+
+# i18n & Accessibility Review: hallenfussball-pwa
+
+## Zusammenfassung
+Das Projekt zeigt eine **exzellente Grundstruktur** für Internationalisierung und Barrierefreiheit. Die Trennung in Namespaces, die Typisierung via TypeScript und die Nutzung von `Intl` für Datumsformate sind Best Practices. Die Accessibility-Implementierung ist bewusst angelegt (ARIA-Labels, Live-Regions), muss aber in der Komponentenebene konsequent umgesetzt werden.
+
+---
+
+## 1. i18n-Lücken & Analyse
+
+### ✅ Starke Punkte
+*   **Namespace-Struktur:** Klare Trennung (`common`, `auth`, `cockpit`, etc.) verhindert "Translation Bloat".
+*   **Typisierung:** `src/i18n/types.ts` nutzt Module-Augmentation für **Type-Safety** bei `t()`. Das verhindert Tippfehler bei Keys zur Compile-Zeit.
+*   **Pluralisierung:** Korrekte Nutzung von `one`/`other` (z.B. `gamesRunning_one` vs `gamesRunning_other`) in DE und EN.
+*   **Datumsformate:** `src/i18n/utils/dateFormatting.ts` nutzt `Intl.DateTimeFormat` basierend auf `i18n.language`. Das ist der richtige Weg (keine manuellen String-Manipulationen).
+*   **Fallback:** `returnNull: false` sorgt dafür, dass Keys angezeigt werden, falls Übersetzungen fehlen (besser als leere Strings).
+
+### ⚠️ Potenzielle Lücken & Risiken
+1.  **Vollständigkeit der EN-Übersetzungen:**
+    *   Bei einem schnellen Abgleich der JSON-Strukturen (DE vs. EN) sieht es konsistent aus.
+    *   **Risiko:** Dynamische Inhalte (z.B. Teamnamen, Fehlermeldungen von Supabase) sind nicht übersetzbar.
+    *   **Empfehlung:** Stelle sicher, dass alle Fehlermeldungen aus `auth.json` auch in EN vorhanden sind. (Im Review-Code waren sie vorhanden, aber prüfe `wizard.json` auf "Coming Soon"-Texte).
+2.  **Hardcodierte Icons/Texte:**
+    *   In `ContactForm.tsx`: `showExtended ? '▼' : '▶'`.
+    *   **Problem:** Diese Symbole sind technisch Text. Screenreader könnten sie vorlesen ("Down Arrow", "Right Arrow").
+    *   **Fix:** Nutze `aria-hidden="true"` für dekorative Icons oder nutze SVG-Icons mit `aria-label` wenn sie interaktiv sind.
+3.  **Plural-Regeln für EN:**
+    *   `gamesRunning_one` vs `gamesRunning_other` ist korrekt.
+    *   **Achtung:** Prüfe `admin.json` -> `groups_one` vs `groups_other`. In EN ist "Group" (singular) und "Groups" (plural). Das ist korrekt.
+4.  **Fallback-Sprache:**
+    *   Fallback ist `de`. Wenn ein Nutzer `en` wählt, aber eine Übersetzung fehlt, wird `de` angezeigt.
+    *   **Empfehlung:** Für eine PWA, die international sein soll, sollte der Fallback `en` sein (oder `de` wenn DE die Primärsprache ist). Aktuell ist `de` als Fallback gesetzt, was für den deutschen Markt okay ist.
+
+---
+
+## 2. WCAG 2.1 AA Verstöße & Risiken
+
+### 🔴 Kritisch (High Severity)
+1.  **Live-Regionen im Cockpit:**
+    *   **Problem:** `cockpit.json` definiert `ariaLive` Keys (`running`, `paused`, `ended`).
+    *   **Risiko:** Wenn diese nicht in einer `<div role="status" aria-live="polite">` (oder `assertive` für Tore) im Cockpit gerendert werden, **erfahren Screenreader-Nutzer nichts vom Spielverlauf**.
+    *   **Empfehlung:** Implementiere ein `useEffect` im Cockpit, das bei Statusänderungen den Text in einem unsichtbaren Live-Region-Container aktualisiert.
+2.  **Fokus-Management in Dialogen:**
+    *   **Problem:** Dialoge wie `cardDialog`, `timeAdjust`, `penaltyShootout` sind modal.
+    *   **Risiko:** Wenn der Fokus beim Öffnen nicht in den Dialog springt und beim Schließen zurück zum Auslöser, ist die Navigation für Tastaturnutzer kaputt.
+    *   **Empfehlung:** Nutze eine Bibliothek wie `@radix-ui/react-dialog` oder implementiere `focus-trap` manuell.
+3.  **Touch Targets (PWA):**
+    *   **Problem:** Buttons im Cockpit (z.B. "Tor hinzufügen") müssen auf Touchscreens gut bedienbar sein.
+    *   **Risiko:** Wenn `padding` zu klein ist (< 44px/48px), ist die Bedienung auf dem Handy frustrierend.
+    *   **Empfehlung:** Prüfe `cssVars` auf `minTouchTarget: 48px`.
+
+### 🟠 Mittel (Medium Severity)
+1.  **Farbkontraste:**
+    *   **Problem:** `cssVars.colors.primary` etc. sind nicht im Code definiert.
+    *   **Risiko:** Wenn `primary` zu hell ist (z.B. Hellgrün auf Weiß), ist der Text nicht lesbar (WCAG AA: 4.5:1).
+    *   **Empfehlung:** Nutze Tools wie "Stark" oder "axe DevTools", um Kontraste zu prüfen.
+2.  **Fehlermeldungen:**
+    *   **Problem:** `ErrorBoundary.tsx` zeigt `error.message` an.
+    *   **Risiko:** Technische Fehlermeldungen sind für Nutzer verwirrend.
+    *   **Empfehlung:** Zeige nur den `t('errorBoundary.message')` an. `error.message` nur im `pre`-Tag für Entwickler (wie bereits implementiert).
+3.  **Icons ohne Text:**
+    *   **Problem:** `ContactForm.tsx` nutzt `▶` / `▼` als Text.
+    *   **Risiko:** Screenreader lesen "Right Triangle" / "Down Triangle".
+    *   **Empfehlung:** `aria-hidden="true"` auf diese Elemente setzen.
+
+### 🟢 Gering (Low Severity)
+1.  **Skip Links:**
+    *   **Problem:** Keine "Skip to Content"-Links sichtbar.
+    *   **Empfehlung:** Füge einen unsichtbaren Link am Anfang des `<body>` hinzu, der zum Hauptinhalt springt.
+2.  **Formular-Labels:**
+    *   **Problem:** `ContactForm` nutzt `label={t(...)}`. Das ist gut.
+    *   **Empfehlung:** Stelle sicher, dass `id` auf Input und `htmlFor` auf Label übereinstimmen.
+
+---
+
+## 3. Screenreader-Probleme (Live-Daten)
+
+### Das größte Risiko: Live-Cockpit
+Da dies eine **Live-Scoreboard-App** ist, ist die Barrierefreiheit für Screenreader-Nutzer extrem wichtig.
+
+1.  **Timer-Updates:**
+    *   **Problem:** Wenn der Timer jede Sekunde aktualisiert wird, darf das **nicht** `aria-live="polite"` sein, da es sonst jede Sekunde vorgelesen wird ("5 Minuten", "4 Minuten 59 Sekunden"...).
+    *   **Lösung:** Nutze `aria-live="off"` für den Timer selbst. Lies nur **Statusänderungen** vor (z.B. "Spiel gestartet", "Halbzeit", "Spiel beendet").
+2.  **Tore:**
+    *   **Problem:** Ein Tor muss sofort und deutlich angekündigt werden.
+    *   **Lösung:** Nutze `aria-live="assertive"` für Toresignale.
+    *   **Code-Beispiel:**
+        ```tsx
+        <div role="status" aria-live="assertive" className="sr-only">
+          {t('cockpit.toast.goalScored', { teamName: team })}
+        </div>
+        ```
+3.  **Statusänderungen:**
+    *   Die `ariaLive` Keys in `cockpit.json` sind gut.
+    *   **Aber:** Sie müssen dynamisch in den DOM eingefügt werden, wenn sich der Status ändert.
+
+---
+
+## 4. Positive Patterns
+
+1.  **Type-Safe i18n:** Die Nutzung von `CustomTypeOptions` in `types.ts` ist ein **Best Practice**. Es verhindert, dass falsche Keys verwendet werden.
+2.  **Offline-First i18n:** Alle Lokales werden gebündelt (`static imports`). Das ist perfekt für eine PWA, da keine Netzwerklatenz beim Sprachwechsel entsteht.
+3.  **Semantisches HTML:** `ErrorBoundary` nutzt `role="alert"`. Das ist korrekt für Fehlermeldungen.
+4.  **Datumsformatierung:** `Intl.DateTimeFormat` ist der richtige Weg für i18n-freundliche Datumsformate.
+5.  **Aria-Labels für Aktionen:** Viele Buttons haben `AriaLabel` Keys (z.B. `undoAria`, `pauseAria`). Das zeigt, dass Accessibility von Anfang an mitgedacht wurde.
+
+---
+
+## 5. Scores
+
+### i18n Score: **9/10**
+*   **Begründung:** Exzellente Struktur, Typisierung und Pluralisierung.
+*   **Abzug:** -1 für potenzielle Lücken in EN-Übersetzungen (müssen manuell geprüft werden) und die Nutzung von Text-Icons (`▶`) statt SVGs mit `aria-hidden`.
+
+### Accessibility Score: **8/10**
+*   **Begründung:** Starke Basis (ARIA-Labels, semantisches HTML, Live-Region-Keys vorhanden).
+*   **Abzug:** -2 für das Risiko bei Live-Updates (Timer-Flut) und Fokus-Management in Modals (muss im Component-Code geprüft werden).
+
+---
+
+## 6. Konkrete Handlungsempfehlungen
+
+1.  **Live-Regionen im Cockpit implementieren:**
+    *   Erstelle eine `useLiveAnnouncement` Hook, die Statusänderungen (`running` -> `paused`) in einem `aria-live` Container aktualisiert.
+    *   Stelle sicher, dass der Timer **nicht** jede Sekunde vorgelesen wird.
+2.  **Fokus-Trap für Dialoge:**
+    *   Nutze `react-focus-lock` oder implementiere ein `useEffect` im `Dialog`-Component, das den Fokus beim Öffnen in den Dialog setzt und beim Schließen zurück.
+3.  **Icons bereinigen:**
+    *   Ersetze `▶` / `▼` in `ContactForm.tsx` durch SVG-Icons und füge `aria-hidden="true"` hinzu.
+4.  **Touch Targets prüfen:**
+    *   Stelle sicher, dass alle interaktiven Elemente mindestens **48x48px** groß sind (insbesondere im Cockpit auf Mobilgeräten).
+5.  **EN-Übersetzungen validieren:**
+    *   Führe einen automatisierten Test durch, der prüft, ob alle DE-Keys auch in EN existieren (z.B. mit einem Script, das die JSON-Keys vergleicht).
+
+**Fazit:** Das Projekt ist technisch sehr gut aufgestellt. Mit der konsequenten Umsetzung der Live-Regionen und Fokus-Management wird es eine exzellente barrierefreie PWA.
+
+---
+
+## Live-Cockpit & Spielsteuerung
+
+
+
+## QA-Review: Live-Cockpit & Spielsteuerung
+
+**⚠️ Wichtiger Hinweis vorab:**
+Der bereitgestellte Code (`src/features/schedule-editor/...`) betrifft den **Spielplan-Editor** (Planung vor dem Turnier), nicht das **Live-Cockpit** (Steuerung während des Spiels, Timer, Tore).
+Da das eigentliche Live-Cockpit fehlt, analysiere ich hier die **Vorbereitung der Datenbasis** (Schedule Editor) und leite daraus **kritische Risiken** für das fehlende Live-Cockpit ab.
+
+---
+
+### 1. Kritische Timing-Bugs & Sync-Risiken
+
+Da das Live-Cockpit-Code fehlt, basieren diese Punkte auf der Architektur des Editors und typischen Fallstricken bei Realtime-Apps.
+
+*   **Race Conditions bei Spielstart (Hochrisiko):**
+    *   Im `ScheduleEditor` wird `matchStatus` via `skipMatch`/`unskipMatch` geändert.
+    *   **Risiko:** Wenn das Live-Cockpit den Status auf `running` setzt, während der Editor noch Konflikte prüft (`useMatchConflicts`), kann es zu Inkonsistenzen kommen.
+    *   **Empfehlung:** Der `matchStatus` muss im Live-Cockpit atomar mit dem Timer-Start synchronisiert werden (Supabase Transaction).
+*   **Timer-Drift im Browser:**
+    *   Im Editor wird `Date.now()` für Timestamps genutzt.
+    *   **Risiko:** Im Live-Cockpit darf der Timer nicht auf `setInterval` basieren, da Tabs im Hintergrund pausieren.
+    *   **Empfehlung:** Server-seitige Zeitquelle nutzen (`supabase.now()`) und Client-seitig nur die Differenz berechnen.
+*   **Realtime-Sync-Latenz:**
+    *   Der Editor nutzt `useReducer` für lokalen State.
+    *   **Risiko:** Wenn zwei User gleichzeitig Tore eintragen (z.B. Trainer A und B), kann es zu Überschreibungen kommen, wenn keine Optimistic UI mit Conflict Resolution (z.B. Last-Write-Wins oder CRDT) implementiert ist.
+
+### 2. Logik-Fehler & Datenintegrität
+
+Der `ScheduleEditor` zeigt eine sehr robuste Logik, die als Fundament für das Cockpit dienen muss.
+
+*   **Konflikterkennung (`useMatchConflicts`):**
+    *   ✅ **Stark:** `detectTeamConflicts` und `detectRefereeConflicts` sind gut getestet und nutzen `useMemo` für Performance.
+    *   ⚠️ **Risiko:** Die Logik ignoriert `finished` und `skipped` Matches. Im Live-Cockpit muss sichergestellt sein, dass ein Spiel nicht beendet wird, bevor der Status korrekt gesetzt ist (Vermeidung von "Ghost Goals").
+*   **Undo/Redo (`useScheduleEditor`):**
+    *   ✅ **Stark:** `useReducer` mit `undoStack` und `redoStack` ist sauber implementiert.
+    *   ⚠️ **Risiko:** Im Live-Cockpit ist "Undo" bei Toren kritisch. Ein "Undo" muss nicht nur den Score, sondern auch die Spielzeit und Event-Logs zurücksetzen.
+*   **Datenvalidierung:**
+    *   ✅ **Stark:** Zod-Typen werden implizit genutzt (durch TS).
+    *   ⚠️ **Risiko:** Fehlt im Code sichtbar. Im Live-Cockpit müssen Tore und Zeitstempel serverseitig validiert werden (Zod im Supabase Edge Function), um Manipulationen zu verhindern.
+
+### 3. UX-Probleme unter Zeitdruck (Halle-Szenario)
+
+*   **Drag & Drop (`DraggableMatch`):**
+    *   ✅ **Positiv:** `@dnd-kit` mit `PointerSensor` und `TouchSensor` ist gut für Mobile/Tablet geeignet.
+    *   ⚠️ **Risiko:** Im Live-Cockpit darf kein Drag & Drop für Tore verwendet werden. Das muss ein **großer, eindeutiger Button** sein (Touch-Friendly, 44px+).
+*   **Konflikt-Feedback (`ConflictDialog`):**
+    *   ✅ **Positiv:** Klare Trennung von `error` und `warning`.
+    *   ⚠️ **Risiko:** Im Live-Betrieb darf ein Konflikt-Dialog das Spiel nicht blockieren. Es braucht ein "Toast"-Notification-System, nicht ein Modal.
+*   **Offline-First:**
+    *   ❌ **Fehlend:** Im Code keine PWA-Caching-Strategie für den Editor sichtbar.
+    *   **Kritisch:** In der Halle ist das WLAN oft schlecht. Das Live-Cockpit muss **Offline-Queue** für Tore haben und später synchronisieren.
+
+### 4. Positive Patterns (Best Practices)
+
+*   **Typ-Sicherheit:** Durchgängig TypeScript mit `Match`, `Team`, `Tournament` Types. Reduziert Runtime-Fehler massiv.
+*   **Testabdeckung:** Sehr gute Unit-Tests für `useMatchConflicts` und `autoReassign`. Das gibt Sicherheit bei Änderungen.
+*   **State Management:** `useReducer` statt `useState` für komplexe Editor-Logik ist die richtige Wahl.
+*   **Komponenten-Architektur:** Saubere Trennung von `ScheduleEditor` (Container), `DraggableMatch` (UI) und `useScheduleEditor` (Logic).
+
+### 5. Gap-Analyse: Fehlende Live-Cockpit-Komponenten
+
+Basierend auf dem fehlenden Code muss das Live-Cockpit folgende Features enthalten, die im Editor nicht relevant sind:
+
+1.  **Timer-Service:**
+    *   Muss server-seitige Zeit nutzen.
+    *   Muss Pause/Resume/Stop exakt synchronisieren.
+2.  **Score-Board:**
+    *   Große Buttons (+1, +2, +3).
+    *   Undo-Funktion mit Bestätigung (z.B. "Tor zurücknehmen?").
+3.  **Realtime-Channel:**
+    *   Supabase `subscribe` auf `matches` Tabelle.
+    *   Optimistic UI für sofortiges Feedback.
+4.  **Anzeigetafel (Monitor):**
+    *   Separate View (`/monitor`), die nur liest und nicht schreibt.
+    *   Auto-Refresh oder WebSocket-Stream.
+
+---
+
+### Live-Cockpit Score
+
+Da der eigentliche Code für das Live-Cockpit fehlt, kann ich diesen nicht direkt bewerten. Ich bewerte hier die **Bereitschaft der Architektur** basierend auf dem Schedule-Editor.
+
+| Kategorie | Score | Kommentar |
+| :--- | :---: | :--- |
+| **Code-Qualität (Editor)** | **9/10** | Sehr sauber, gut getestet, typisiert. |
+| **Datenintegrität** | **8/10** | Konflikterkennung ist robust, aber Server-Validation fehlt sichtbar. |
+| **Realtime-Readiness** | **6/10** | Editor ist lokal fokussiert. Live-Sync muss noch implementiert werden. |
+| **UX für Stress-Szenario** | **7/10** | Editor ist gut, aber Live-Buttons fehlen (müssen groß/kontrastreich sein). |
+| **Gesamt (Architektur)** | **7.5/10** | Solide Basis, aber das kritische Live-Cockpit fehlt noch. |
+
+### Fazit & Nächste Schritte
+
+Der **Schedule-Editor** ist hervorragend implementiert und bietet eine stabile Datenbasis. Für das **Live-Cockpit** müssen jedoch folgende Punkte priorisiert werden:
+
+1.  **Timer-Logik:** Nicht client-seitig basierend auf `Date.now()`, sondern server-seitig validieren.
+2.  **Offline-Queue:** Tore müssen lokal gespeichert und bei Netzwerkwiederherstellung synchronisiert werden.
+3.  **Konflikt-Handling:** Was passiert, wenn zwei Trainer gleichzeitig ein Tor eintragen? (Server-Transaction nötig).
+4.  **UI für Live:** Trennung von "Planung" (Editor) und "Steuerung" (Cockpit). Das Cockpit muss simpler und robuster sein (weniger Klicks, mehr Bestätigungen).
+
+**Empfehlung:** Bitte den Code für `src/features/live-cockpit/` bereitstellen, um die spezifischen Timer- und Sync-Bugs zu analysieren.
+
+---
+
+## Performance, Bundle & PWA
+
+
+
+# 🚀 Performance & PWA Audit: hallenfussball-pwa
+
+Basierend auf dem analysierten Code (Storage-Layer) und dem Projekt-Kontext (Vite 7, React 19, Supabase, PWA).
+
+---
+
+## 🔴 Critical Issues (Sofortige Risiken)
+
+| Issue | Schweregrad | Beschreibung |
+| :--- | :--- | :--- |
+| **Blocking Storage Init** | 🔴 Hoch | `createStorage()` wird im App-Start-Flow wahrscheinlich `await`et. Die `autoMigrate()`-Logik prüft `isMigrationNeeded()` (LS vs. IDB Keys). Bei großen LS-Datenmengen kann dies den **First Contentful Paint (FCP)** verzögern. |
+| **Offline-First Lücke** | 🔴 Hoch | Der Code speichert Daten lokal, aber es fehlt im vorliegenden Code die **Service Worker Caching-Strategie**. Ohne SW-Caching für API-Requests (Supabase) ist die App bei Netzausfall nur teilweise nutzbar (nur gespeicherte Daten, keine Live-Updates). |
+| **Realtime Memory Leaks** | 🟠 Mittel | `Supabase Realtime` Listener werden oft nicht sauber cleanuped. Bei Navigation (React Router) müssen `channel.unsubscribe()` aufgerufen werden, sonst steigt der **Memory Usage** bei jedem Seitenwechsel. |
+| **jsPDF Bundle Bloat** | 🟠 Mittel | `jsPDF` ist eine riesige Abhängigkeit (~500KB+). Wenn es beim Initial Load importiert wird, blockiert es den Main Thread. |
+
+---
+
+## 📦 Bundle-Optimierungen (Vite 7 & React 19)
+
+Da die `vite.config.ts` nicht im Code-Review enthalten ist, basieren diese Empfehlungen auf Best Practices für den Stack:
+
+### 1. Code Splitting & Manual Chunks
+Vite 7 optimiert standardmäßig gut, aber große Libraries müssen explizit getrennt werden.
+**Empfehlung:**
+```ts
+// vite.config.ts
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        'vendor-react': ['react', 'react-dom', 'react-router'],
+        'vendor-supabase': ['@supabase/supabase-js'],
+        'vendor-pdf': ['jspdf', 'jspdf-autotable'], // WICHTIG: PDF separat laden
+        'vendor-i18n': ['i18next', 'react-i18next']
+      }
+    }
+  }
+}
+```
+
+### 2. Lazy Loading für `jsPDF`
+Vermeide Top-Level-Importe für PDF-Generierung. Nutze dynamische Imports nur bei Bedarf (z.B. "Export"-Button Klick).
+```ts
+// src/features/export/exportTournament.ts
+export const generatePDF = async (data: Tournament) => {
+  const { jsPDF } = await import('jspdf'); // Dynamic Import
+  // ... PDF Logic
+};
+```
+**Impact:** Reduziert Initial Bundle Size um ca. **300-500 KB**.
+
+### 3. Tree Shaking bei `i18next`
+Stelle sicher, dass nur genutzte Übersetzungen geladen werden.
+**Check:** Werden alle Sprach-Dateien (`de.json`, `en.json`) im Bundle gebündelt?
+**Fix:** Nutze `i18next-http-backend` mit Lazy Loading der Sprach-Dateien, statt sie alle im `main.js` zu haben.
+
+### 4. React 19 Compiler
+Aktiviere den React Compiler (falls noch nicht geschehen), um unnötige Re-Renders zu eliminieren.
+```ts
+// vite.config.ts
+react: {
+  compiler: true // Experimental, aber Performance-Boost
+}
+```
+
+---
+
+## 📱 PWA-Lücken (Offline & Install)
+
+Der Storage-Layer ist exzellent für **Datenpersistenz**, aber eine PWA benötigt mehr als nur `IndexedDB`.
+
+### 1. Service Worker Strategie (Missing)
+Der Code zeigt keine SW-Konfiguration. Für eine Turnier-App ist eine **Stale-While-Revalidate** Strategie für API-Daten und **Cache-First** für Assets (Bilder, CSS) essenziell.
+**Empfehlung:** Konfiguriere `vite-plugin-pwa` mit Workbox-Strategien:
+```ts
+// vite.config.ts
+VitePWA({
+  registerType: 'autoUpdate',
+  workbox: {
+    globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+    runtimeCaching: [
+      {
+        urlPattern: /^https:\/\/api\.supabase\.co.*/i,
+        handler: 'StaleWhileRevalidate', // API-Daten schnell laden, im Hintergrund aktualisieren
+        options: {
+          cacheName: 'supabase-cache',
+          expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 }, // 24h
+        },
+      },
+    ],
+  },
+})
+```
+
+### 2. Manifest & Icons
+Prüfe `public/manifest.json`.
+*   **Icons:** Sind 512x512 und 192x192 vorhanden?
+*   **Display Mode:** `standalone` oder `fullscreen` für den "App-Feeling"-Effekt auf dem Monitor/Anzeigetafel?
+*   **Theme Color:** Passt zur Branding?
+
+### 3. Install-Prompt UX
+Der Code enthält keinen `beforeinstallprompt` Handler.
+**Empfehlung:** Implementiere einen "App installieren"-Button im UI, der nur angezeigt wird, wenn `window.addEventListener('beforeinstallprompt')` feuert. Verstecke den Standard-Browser-Install-Button.
+
+### 4. Offline-Fallback UI
+Da `IndexedDBAdapter` Daten speichert, muss die UI wissen, ob sie offline ist.
+**Implementierung:**
+```ts
+// src/hooks/useOnlineStatus.ts
+export const useOnlineStatus = () => {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  useEffect(() => {
+    const update = () => setIsOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+  return isOnline;
+};
+```
+*Zeige ein Banner an: "Offline-Modus: Änderungen werden lokal gespeichert und synchronisiert, sobald das Netzwerk wieder da ist."*
+
+---
+
+## ✅ Positive Patterns (Best Practices)
+
+1.  **Storage Abstraction (Adapter Pattern):**
+    *   `IStorageAdapter` Interface ermöglicht einfaches Mocking für Tests.
+    *   Fallback-Logik (`IndexedDB` → `LocalStorage`) ist robust implementiert (`StorageFactory.ts`).
+    *   **Impact:** Erhöht Stabilität in Browsern mit eingeschränkter IDB-Unterstützung (z.B. Safari Private Mode).
+
+2.  **Sichere Migration:**
+    *   `migrateToIndexedDB` prüft Datenintegrität (`verifyValue`) nach dem Schreiben.
+    *   `dryRun` Option ist exzellent für Debugging.
+    *   `clearSource` ist standardmäßig `false` (Safety First).
+
+3.  **Quota Monitoring:**
+    *   `QuotaMonitor` nutzt die moderne `navigator.storage.estimate()` API.
+    *   Warnschwellen (80% / 95%) helfen, Speicherüberlauf-Errors (`QuotaExceededError`) proaktiv zu behandeln.
+
+4.  **Singleton Pattern:**
+    *   `StorageFactory` verhindert mehrfache IDB-Initialisierungen (`initializationPromise`), was Race Conditions und Performance-Einbrüche beim Start verhindert.
+
+5.  **Type Safety:**
+    *   Generische Typen `<T>` in `get/set` Methoden sorgen für TypeScript-Sicherheit bei gespeicherten Objekten (z.B. `Tournament`, `Team`).
+
+---
+
+## 📊 Performance Score
+
+| Kategorie | Score | Kommentar |
+| :--- | :--- | :--- |
+| **Bundle Size** | 7/10 | Guter Code, aber Risiko durch `jsPDF` und fehlendes Splitting im Code-Review. |
+| **Runtime Perf** | 8/10 | Storage-Layer ist effizient. React 19 Compiler könnte helfen. |
+| **PWA Readiness** | 6/10 | Daten-Persistenz ist top, aber Service Worker & Offline-UI fehlen im Code. |
+| **Code Quality** | 9/10 | Exzellente Struktur, Testing, Error Handling und Typisierung. |
+| **Gesamt** | **7.5/10** | **Solide Basis, benötigt PWA-Config-Fokus.** |
+
+### Nächste Schritte (Action Items)
+1.  **Vite Config prüfen:** `manualChunks` für `jsPDF` und `i18next` hinzufügen.
+2.  **Service Worker:** `vite-plugin-pwa` Konfiguration auf `StaleWhileRevalidate` für Supabase-API setzen.
+3.  **Offline-UI:** `useOnlineStatus` Hook implementieren und UI-Feedback bei Netzausfall hinzufügen.
+4.  **Memory Check:** Prüfen, ob Supabase Realtime-Listener bei `useEffect` Cleanup (`return () => channel.unsubscribe()`) entfernt werden.
+
+---
+
+## Screens, Routing & Navigation
+
+
+
+# 📱 Routing & Navigation Review: hallenfussball-pwa
+
+## Executive Summary
+
+Die App hat eine solide Basis mit URL-State-Sync und Lazy-Loading, zeigt aber **kritische Inkonsistenzen bei Public Views** und **fehlende Route Guards**. Die Navigation ist teilweise verwirrend durch redundante Screens und unklare Back-Button-Logik.
+
+---
+
+## 🔴 Routing-Probleme
+
+### 1. **Drei Public View Screens (Redundanz)**
+```
+❌ PublicLiveViewScreen.tsx      → /live/:shareCode
+❌ PublicTournamentViewScreen.tsx → /tournament/:id
+❌ LiveViewScreen.tsx             → /live/:shareCode (ähnlich wie #1)
+```
+**Problem**: Drei Screens für gleiche Funktionalität → Wartungsaufwand, Inkonsistenzen, Verwirrung.
+
+**Lösung**: Ein Screen mit Parameter-Adapter:
+```tsx
+// /live/:code OR /tournament/:id → Unified PublicViewScreen
+const route = useParams();
+const shareCode = route.code;
+const tournamentId = route.id;
+```
+
+### 2. **Fehlende Route Guards**
+```tsx
+// ❌ Keine Auth-Prüfung in TournamentManagementScreen
+export const TournamentManagementScreen: React.FC = ({ tournamentId }) => {
+  // Wer darf hier hin? Organiser? Admin?
+}
+```
+**Problem**: Jeder kann Turnier-Management-URL aufrufen → Datenlecks.
+
+**Lösung**:
+```tsx
+<Route path="/tournament/:id/*" element={<ProtectedRoute><TournamentManagementScreen /></ProtectedRoute>} />
+```
+
+### 3. **Inkonsistente URL-Muster**
+```
+✅ /tournament/:id/schedule
+✅ /tournament/:id/management
+✅ /live/:shareCode
+❌ /test-live (Dev-Only, sollte /dev/test-live sein)
+❌ /privacy (sollte /legal/privacy sein)
+❌ /impressum (sollte /legal/impressum sein)
+```
+
+### 4. **Missing 404 Route**
+Kein `*` Catch-All Route → Benutzer sehen leere Seite bei falscher URL.
+
+---
+
+## 🟡 Navigation-UX-Probleme
+
+### 1. **Back-Button-Logik inkonsistent**
+```tsx
+// DashboardScreen
+const onBack = () => navigate(-1); // ❌ Browser History nicht immer vorhanden
+
+// LegalPageLayout
+const onBack = () => navigate(-1); // ❌ Wohin zurück? Dashboard? Home?
+```
+**Problem**: Bei direktem Link (z.B. `/impressum`) gibt es kein "Zurück".
+
+**Lösung**:
+```tsx
+const onBack = () => {
+  if (window.history.length > 1) {
+    navigate(-1);
+  } else {
+    navigate('/'); // Fallback
+  }
+};
+```
+
+### 2. **Tournament Creation Wizard - History Clutter**
+```tsx
+// Jede Step-Änderung pushet History
+void navigate(newPath, { replace: true }); // ✅ Gut
+// Aber: Browser Back-Button führt durch ALLE Steps
+```
+**Problem**: User will zurück zum Dashboard, landet aber in Step 3.
+
+**Lösung**:
+```tsx
+// Ersten Entry im History Stack markieren
+const wizardStartRef = useRef(false);
+useEffect(() => {
+  if (!wizardStartRef.current) {
+    navigate(-1); // Remove wizard entry from history
+    wizardStartRef.current = true;
+  }
+}, []);
+```
+
+### 3. **Settings Screen - Kein Clear Exit**
+```tsx
+// SettingsScreen.tsx
+const onBack = () => navigate(-1); // ❌ Wohin?
+```
+**Problem**: User kommt von Dashboard → Settings → Back → Dashboard. Aber was wenn von Tournament Management?
+
+**Lösung**:
+```tsx
+interface SettingsScreenProps {
+  onBack?: () => void;
+  defaultBackPath?: string; // '/dashboard' | '/tournament/:id'
+}
+```
+
+### 4. **Mobile Bottom Nav - "More" Menu**
+```tsx
+// TournamentManagementScreen
+const handleMobileNavChange = (tab: BottomNavTab) => {
+  if (tab === 'more') {
+    setShowMoreMenu(true); // ❌ BottomSheet ohne URL-Sync
+  }
+};
+```
+**Problem**: BottomSheet ist nicht URL-synced → Refresh verliert Zustand.
+
+**Lösung**:
+```tsx
+// Query param für More-Menu
+const [showMore, setShowMore] = useSearchParams('more');
+```
+
+---
+
+## 🟠 Deep-Link-Lücken
+
+### 1. **Kein direkter Link zu Match im Cockpit**
+```tsx
+// ✅ exists: ?matchId=xyz in URL
+// ❌ Aber: Keine URL-Generierung von ScheduleTab
+```
+**Problem**: User kann Spielstand nicht teilen.
+
+**Lösung**:
+```tsx
+// In ScheduleDisplay
+const shareMatchLink = `${window.location.origin}/tournament/${id}/management?matchId=${match.id}`;
+```
+
+### 2. **Wizard Steps - URL Sync funktioniert, aber...**
+```tsx
+// ✅ /tournament/create?step=3
+// ❌ Aber: Keine Validierung → /tournament/create?step=999 crashet
+```
+**Problem**: Ungültige Step-Parameter führen zu Error.
+
+**Lösung**:
+```tsx
+const urlStep = getStepFromSearchParams(searchParams);
+const safeStep = Math.max(1, Math.min(6, urlStep)); // Clamp to valid range
+```
+
+### 3. **Live View - Filter nicht persistent**
+```tsx
+// ✅ URL syncs: ?g=A&p=groupStage&s=live
+// ❌ Aber: Keine "Share View"-Funktion
+```
+**Problem**: User kann gefilterte Ansicht nicht teilen.
+
+**Lösung**:
+```tsx
+const shareViewLink = `${window.location.origin}/live/${shareCode}${window.location.search}`;
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **URL-State-Sync (Excellent!)**
+```tsx
+// ✅ Wizard Steps
+const newPath = buildWizardStepPath(newStep as WizardStep, existingTournament?.id);
+void navigate(newPath, { replace: true });
+
+// ✅ Tournament Tabs
+void navigate(buildTournamentTabPath(tournamentId, newTab));
+
+// ✅ Live View Filters
+updateUrlParams({ g: group, p: phase, s: status });
+```
+**Bewertung**: 9/10 - Sehr gut implementiert mit `replace: true` für History-Cleanup.
+
+### 2. **Lazy Loading (Performance)**
+```tsx
+// ✅ Settings Screen
+export { SettingsScreen } from '../features/settings/components/SettingsScreen';
+
+// ✅ Wizard Steps
+const Step1_SportAndType = lazy(() =>
+  import('../features/tournament-creation').then(module => ({ default: module.Step1_SportAndType }))
+);
+```
+**Bewertung**: 8/10 - Gute Code-Splitting-Strategie.
+
+### 3. **Legal Page Layout (Consistency)**
+```tsx
+// ✅ Shared Layout
+<LegalPageLayout title="Datenschutzerklärung" onBack={onBack}>
+  {/* Content */}
+</LegalPageLayout>
+```
+**Bewertung**: 9/10 - Konsistente UX für alle Legal-Pages.
+
+### 4. **Error & Loading States**
+```tsx
+// ✅ Clear states
+if (loadingError) {
+  return <div style={errorStyle}>❌ {loadingError}</div>;
+}
+if (isLoading) {
+  return <div style={loadingStyle}>Turnier wird geladen...</div>;
+}
+```
+**Bewertung**: 8/10 - Gute User Feedback.
+
+---
+
+## 📊 Navigation Score
+
+| Kategorie | Score | Notes |
+|-----------|-------|-------|
+| **Route Structure** | 6/10 | Redundante Public Views, fehlende Guards |
+| **URL State Sync** | 9/10 | Excellent implementation |
+| **Back Navigation** | 5/10 | Inconsistent, no fallback logic |
+| **Deep Linking** | 6/10 | Basic support, missing share features |
+| **Mobile UX** | 7/10 | Bottom nav good, More menu needs URL sync |
+| **Error Handling** | 8/10 | Clear states, missing 404 route |
+| **Performance** | 8/10 | Good lazy loading |
+
+### **Gesamtnote: 6.5/10**
+
+---
+
+## 🎯 Top 5 Prioritized Fixes
+
+### **P1 - Critical**
+1. **Consolidate Public Views** → 1 Screen statt 3
+2. **Add Route Guards** → Auth-Check für Management-Screens
+3. **Add 404 Route** → Catch-all handler
+
+### **P2 - High**
+4. **Fix Back-Button Logic** → Fallback zu `/` wenn keine History
+5. **URL-Sync Bottom Sheet** → Query param für More-Menu
+
+### **P3 - Medium**
+6. **Add Share Links** → Match, Filtered Views, Wizard Steps
+7. **Validate URL Parameters** → Clamp invalid values
+8. **Add Breadcrumbs** → Navigation context
+
+---
+
+## 💡 Quick Wins
+
+```tsx
+// 1. Add 404 Route (5 min)
+<Route path="*" element={<NotFoundScreen />} />
+
+// 2. Fix Back Button (10 min)
+const safeBack = () => {
+  if (window.history.length > 1) navigate(-1);
+  else navigate('/');
+};
+
+// 3. Consolidate Public Views (1h)
+// Merge PublicLiveViewScreen + PublicTournamentViewScreen + LiveViewScreen
+```
+
+---
+
+## 📝 Recommended Route Structure
+
+```tsx
+// src/router.tsx
+const router = createBrowserRouter([
+  // Public Routes
+  { path: '/', element: <DashboardScreen /> },
+  { path: '/legal/privacy', element: <DatenschutzScreen /> },
+  { path: '/legal/impressum', element: <ImpressumScreen /> },
+  
+  // Protected Routes
+  {
+    path: '/tournament/create',
+    element: <ProtectedRoute><TournamentCreationScreen /></ProtectedRoute>,
+    children: [
+      { path: '?step=:step', element: <WizardSteps /> }
+    ]
+  },
+  {
+    path: '/tournament/:id',
+    element: <ProtectedRoute><TournamentManagementScreen /></ProtectedRoute>,
+    children: [
+      { path: 'schedule', element: <ScheduleTab /> },
+      { path: 'management', element: <ManagementTab /> },
+      { path: 'monitor', element: <MonitorTab /> },
+      { path: 'settings', element: <SettingsTab /> },
+    ]
+  },
+  
+  // Public Live View (Unified)
+  { path: '/live/:code', element: <PublicLiveViewScreen /> },
+  
+  // 404
+  { path: '*', element: <NotFoundScreen /> },
+]);
+```
+
+---
+
+**Fazit**: Solide technische Basis, aber UX-Konsistenz und Security-Guards benötigen dringend Aufmerksamkeit. Mit den P1-Fixes kann die Note auf **8/10** steigen.
+
+---
+
+## Security & Datenschutz
+
+
+
+# 🔒 Security Audit Report: hallenfussball-pwa
+
+**Audit Date:** 2025-01-24  
+**Auditor:** Application Security Engineer  
+**Scope:** Authentication, Authorization, Data Protection, PWA Security  
+**Code Reviewed:** ~150k LOC (Auth Components, Edge Functions, Storage Layer)
+
+---
+
+## 📊 Security Score: **6.5/10**
+
+| Category | Score | Status |
+|----------|-------|--------|
+| Authentication | 7/10 | ⚠️ Needs Hardening |
+| Authorization | 4/10 | 🔴 Critical Gap |
+| Data Protection | 6/10 | ⚠️ Partial |
+| PWA Security | 5/10 | ⚠️ Missing Headers |
+| Input Validation | 7/10 | ✅ Good |
+
+---
+
+## 🔴 CRITICAL FINDINGS (Fix Immediately)
+
+### 1. **Missing Row Level Security (RLS) Policies**
+**Severity:** 🔴 Critical  
+**Location:** Supabase Database (not in code, but implied)  
+**Risk:** Client-side `AuthGuard` can be bypassed via API calls
+
+**Issue:**
+```tsx
+// src/features/auth/components/AuthGuard.tsx
+// Client-side only protection - NO server-side enforcement
+if (!user) {
+  onUnauthenticated?.();
+  return <div>Bitte melde dich an...</div>;
+}
+```
+
+**Impact:** Attacker can directly call Supabase API and access/modify any tournament data without authentication.
+
+**Recommendation:**
+```sql
+-- Enable RLS on ALL tables
+ALTER TABLE tournaments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams ENABLE ROW LEVEL SECURITY;
+
+-- Create policies (example)
+CREATE POLICY "Users can view own tournaments"
+ON tournaments FOR SELECT
+USING (auth.uid() IN (SELECT user_id FROM memberships WHERE tournament_id = tournaments.id));
+
+CREATE POLICY "Only members can modify tournaments"
+ON tournaments FOR ALL
+USING (auth.uid() IN (SELECT user_id FROM memberships WHERE tournament_id = tournaments.id));
+```
+
+---
+
+### 2. **Sensitive Tokens in URL Parameters**
+**Severity:** 🔴 Critical  
+**Location:** `AuthConfirmPage.tsx`, `InviteAcceptScreen.tsx`  
+**Risk:** Tokens logged in browser history, server logs, referer headers
+
+**Issue:**
+```tsx
+// src/features/auth/components/AuthConfirmPage.tsx
+const token = searchParams.get('token') ?? searchParams.get('token_hash');
+// Token visible in URL: /auth/confirm?token=abc123...
+
+// src/features/auth/components/InviteAcceptScreen.tsx
+void navigate(`/invite?token=${encodeURIComponent(token)}`, { replace: true });
+```
+
+**Impact:**
+- Browser history exposes tokens
+- Server logs may capture tokens
+- Referer header leaks tokens to third parties
+- Shared screen shows tokens
+
+**Recommendation:**
+```tsx
+// Use POST request instead of URL params
+const handleConfirm = async () => {
+  // Store token in memory only, not URL
+  const result = await supabase.auth.verifyOtp({
+    token_hash: token, // Supabase handles this securely
+    type: 'email',
+  });
+  // Clear token from memory immediately
+  // Redirect without token in URL
+  void navigate(redirectTo, { replace: true });
+};
+
+// For invites, use short-lived tokens + POST verification
+```
+
+---
+
+### 3. **No Content Security Policy (CSP)**
+**Severity:** 🔴 Critical  
+**Location:** Vercel Configuration (not in code)  
+**Risk:** XSS attacks, unauthorized script execution
+
+**Issue:** No CSP headers configured for PWA deployment.
+
+**Impact:**
+- XSS vulnerabilities can execute arbitrary scripts
+- Data exfiltration via malicious scripts
+- PWA can be hijacked
+
+**Recommendation:**
+```json
+// vercel.json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://*.vercel.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### 4. **No Rate Limiting on Auth Endpoints**
+**Severity:** 🔴 Critical  
+**Location:** Supabase Auth Configuration  
+**Risk:** Brute force attacks, credential stuffing, DoS
+
+**Issue:** No visible rate limiting on login, password reset, or magic link endpoints.
+
+**Impact:**
+- Unlimited login attempts
+- Password spraying attacks
+- Magic link flooding
+
+**Recommendation:**
+```typescript
+// In Supabase Dashboard → Auth → Rate Limiting
+// OR implement via Edge Functions
+
+// Example: Rate limit middleware
+export const rateLimit = (maxRequests: number, windowMs: number) => {
+  const requests = new Map<string, number[]>();
+  
+  return async (req: Request) => {
+    const ip = req.headers.get('x-forwarded-for') || 'unknown';
+    const now = Date.now();
+    const windowStart = now - windowMs;
+    
+    const userRequests = requests.get(ip) || [];
+    const validRequests = userRequests.filter(time => time > windowStart);
+    
+    if (validRequests.length >= maxRequests) {
+      return new Response('Too many requests', { status: 429 });
+    }
+    
+    validRequests.push(now);
+    requests.set(ip, validRequests);
+  };
+};
+```
+
+---
+
+## 🟠 HIGH FINDINGS (Before Next Release)
+
+### 5. **Session Timeout Not Configured**
+**Severity:** 🟠 High  
+**Location:** Supabase Auth Configuration  
+**Risk:** Stolen sessions remain valid indefinitely
+
+**Issue:** No session expiration policy visible. Default Supabase sessions may persist too long.
+
+**Recommendation:**
+```typescript
+// In Supabase Dashboard → Auth → Settings
+// Set session duration to 1 hour for sensitive operations
+// Implement refresh token rotation
+
+// In client code
+const { data: { session } } = await supabase.auth.getSession();
+if (session && Date.now() > session.expires_at * 1000 - 300000) {
+  // Refresh 5 minutes before expiry
+  await supabase.auth.refreshSession();
+}
+```
+
+---
+
+### 6. **No Account Lockout After Failed Attempts**
+**Severity:** 🟠 High  
+**Location:** `LoginScreen.tsx`, `RegisterScreen.tsx`  
+**Risk:** Brute force attacks on user accounts
+
+**Issue:**
+```tsx
+// src/features/auth/components/LoginScreen.tsx
+// No tracking of failed attempts
+const handleSubmit = async (e: React.FormEvent) => {
+  // ... login attempt
+  // No counter for failed attempts
+};
+```
+
+**Recommendation:**
+```typescript
+// Implement in Edge Function or Supabase Auth settings
+// Lock account after 5 failed attempts for 15 minutes
+
+// Client-side tracking (supplementary)
+const failedAttempts = localStorage.getItem('login_attempts');
+if (parseInt(failedAttempts || '0') >= 5) {
+  setError('Too many failed attempts. Try again in 15 minutes.');
+  return;
+}
+```
+
+---
+
+### 7. **Invite Tokens Not Short-Lived**
+**Severity:** 🟠 High  
+**Location:** `InviteDialog.tsx`, `InviteLinkDialog.tsx`  
+**Risk:** Stolen invite links can be used indefinitely
+
+**Issue:**
+```tsx
+// src/features/auth/components/InviteDialog.tsx
+const [expiresInDays, setExpiresInDays] = useState<number>(7);
+// User can select "Unbegrenzt" (0 days)
+```
+
+**Recommendation:**
+```typescript
+// Enforce maximum expiry in backend
+const MAX_INVITE_EXPIRY_DAYS = 7;
+
+// In Edge Function validation
+if (expiresInDays > MAX_INVITE_EXPIRY_DAYS) {
+  throw new Error('Invite expiry too long');
+}
+
+// Default to 24 hours for security
+const [expiresInDays, setExpiresInDays] = useState<number>(1);
+```
+
+---
+
+### 8. **No Input Sanitization for User-Generated Content**
+**Severity:** 🟠 High  
+**Location:** Tournament names, team names, user names  
+**Risk:** XSS via tournament/team names displayed in UI
+
+**Issue:**
+```tsx
+// src/features/auth/components/MemberList.tsx
+<p style={styles.memberName}>
+  {user?.name ?? 'Unbekannt'}
+</p>
+// No sanitization of user input
+```
+
+**Recommendation:**
+```typescript
+// Use DOMPurify or similar
+import DOMPurify from 'dompurify';
+
+const sanitize = (input: string) => DOMPurify.sanitize(input);
+
+// In display components
+<p>{sanitize(user?.name ?? 'Unbekannt')}</p>
+
+// OR use React's built-in escaping (preferred)
+// React automatically escapes text content
+// Only use dangerouslySetInnerHTML with sanitized content
+```
+
+---
+
+## 🟡 MEDIUM FINDINGS (Backlog)
+
+### 9. **No Audit Logging**
+**Severity:** 🟡 Medium  
+**Risk:** No visibility into security events
+
+**Recommendation:**
+```typescript
+// Log security events
+const logSecurityEvent = async (event: string, userId: string, details: object) => {
+  await supabase.from('security_logs').insert({
+    event_type: event,
+    user_id: userId,
+    details,
+    ip_address: '...',
+    timestamp: new Date().toISOString(),
+  });
+};
+
+// Log: login_success, login_failed, password_reset, role_change, etc.
+```
+
+---
+
+### 10. **No 2FA Support for Admin Accounts**
+**Severity:** 🟡 Medium  
+**Risk:** Admin accounts compromised via phishing
+
+**Recommendation:**
+```typescript
+// Implement TOTP-based 2FA
+// Store TOTP secret encrypted in database
+// Require 2FA for admin actions (role changes, tournament deletion)
+```
+
+---
+
+### 11. **Sensitive Data in LocalStorage**
+**Severity:** 🟡 Medium  
+**Location:** `IStorageAdapter.ts`  
+**Risk:** XSS can access stored tokens
+
+**Recommendation:**
+```typescript
+// Use httpOnly cookies instead of LocalStorage
+// OR encrypt sensitive data before storage
+
+// Example encryption
+import { encrypt, decrypt } from './crypto';
+
+const setSecure = async (key: string, value: string) => {
+  const encrypted = await encrypt(value);
+  await localStorage.setItem(key, encrypted);
+};
+```
+
+---
+
+### 12. **No Secure Cookie Flags**
+**Severity:** 🟡 Medium  
+**Risk:** Session hijacking via network attacks
+
+**Recommendation:**
+```typescript
+// If using cookies, set secure flags
+// In Vercel config or Supabase settings
+{
+  "secure": true,
+  "httpOnly": true,
+  "sameSite": "strict"
+}
+```
+
+---
+
+## ✅ POSITIVE FINDINGS
+
+1. **Good Auth Flow Design** - Magic links, OAuth, and password flows are well-structured
+2. **Token Validation** - Invite tokens are validated before use
+3. **Account Merge Security** - Edge function properly validates JWT and uses transactions
+4. **Focus Trap Implementation** - Good accessibility/security for modals
+5. **Offline Handling** - Graceful degradation when cloud unavailable
+6. **Type Safety** - TypeScript reduces injection risks
+7. **Error Handling** - User-friendly error messages without leaking internals
+
+---
+
+## 🛡️ SECURITY HARDENING RECOMMENDATIONS
+
+### Immediate Actions (Week 1)
+1. **Enable Supabase RLS** on all tables
+2. **Configure CSP headers** in Vercel
+3. **Set session timeout** to 1 hour
+4. **Enable rate limiting** on auth endpoints
+5. **Remove tokens from URL** - use POST for verification
+
+### Short Term (Month 1)
+1. Implement account lockout policy
+2. Add audit logging table
+3. Sanitize all user-generated content
+4. Set invite token expiry to 24 hours max
+5. Add security headers (X-Frame-Options, etc.)
+
+### Long Term (Quarter 1)
+1. Implement 2FA for admin accounts
+2. Add security event monitoring
+3. Implement secure session storage
+4. Add security training for developers
+5. Schedule regular security audits
+
+---
+
+## 📋 COMPLIANCE CHECKLIST
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| GDPR Data Minimization | ⚠️ Partial | Review what data is collected |
+| GDPR Right to Erasure | ❌ Missing | Need account deletion flow |
+| GDPR Data Export | ❌ Missing | Need data export feature |
+| Cookie Consent | ❌ Missing | Need consent banner |
+| Security Headers | ❌ Missing | Configure in Vercel |
+| RLS Policies | ❌ Missing | Critical for Supabase |
+| Rate Limiting | ❌ Missing | Configure in Supabase |
+| Audit Logging | ❌ Missing | Implement logging |
+| 2FA Support | ❌ Missing | For admin accounts |
+| Session Timeout | ⚠️ Partial | Configure in Supabase |
+
+---
+
+## 🎯 PRIORITY ACTION PLAN
+
+| Priority | Action | Owner | Deadline |
+|----------|--------|-------|----------|
+| 🔴 P0 | Enable Supabase RLS on all tables | Backend | 3 days |
+| 🔴 P0 | Configure CSP + Security Headers | DevOps | 3 days |
+| 🔴 P0 | Remove tokens from URL | Frontend | 1 week |
+| 🟠 P1 | Implement rate limiting | Backend | 1 week |
+| 🟠 P1 | Set session timeout | Backend | 1 week |
+| 🟠 P1 | Add account lockout | Backend | 2 weeks |
+| 🟡 P2 | Implement audit logging | Backend | 1 month |
+| 🟡 P2 | Sanitize user content | Frontend | 1 month |
+| 🟡 P2 | Add 2FA for admins | Fullstack | 2 months |
+
+---
+
+**Final Recommendation:** The application has good security foundations but lacks critical server-side protections. **Do not deploy to production** until RLS policies and security headers are implemented. The current score of 6.5/10 indicates significant security gaps that could lead to data breaches.
+
+**Next Audit:** Schedule follow-up audit after P0 items are completed.
+
+---
+
+## Sport-Konfiguration & Datenmodell
+
+
+
+# Code Review: Sport-Konfiguration & Datenmodell
+
+## Executive Summary
+
+Das Datenmodell ist **grundsätzlich solide** mit guter Trennung zwischen Runtime- und Persistenz-Modellen. Die Sport-Konfiguration ist gut strukturiert, aber es gibt kritische Inkonsistenzen bei Typ-Definitionen und fehlende Geschäftsregel-Validierungen.
+
+---
+
+## 1. Modell-Probleme
+
+### 🔴 Kritisch
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Doppelte Typ-Definitionen** | `types/tournament.ts` vs `config/sports/types.ts` | `SportId` wird an zwei Stellen definiert → Inkonsistenz-Risiko |
+| **Date-Handling** | `TournamentSchema.ts` | `scheduledTime?: Date` → JSON serialisiert zu String, Zod transformiert nicht automatisch |
+| **Fehlende Match-Constraints** | `MatchSchema` | Keine Validierung: `teamA !== teamB`, `teamA/teamB existieren in teams[]` |
+| **Tiebreaker-Logik** | `football.ts` | `canDrawInFinals: false` + `hasShootout: true` → Was wenn Shootout deaktiviert? |
+
+### 🟡 Mittel
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Status-Duplikation** | `LiveMatch.ts` vs `tournament.ts` | `MatchStatus` in beiden Dateien definiert |
+| **Passthrough-Risiko** | Alle Schemas | `.passthrough()` kann Datenkorruption verschleiern |
+| **Versionierung** | `LiveMatch.ts` | `version`-Feld existiert, aber kein Optimistic-Locking-Workflow |
+| **Redundante Felder** | `TournamentSchema` | `sport` (legacy) + `sportId` (neu) → Inkonsistenz möglich |
+
+### 🟢 Gering
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Score-Validierung** | `MatchSchema` | Keine Prüfung: `scoreA/scoreB` müssen mit `events` übereinstimmen |
+| **Gruppen-Referenzen** | `TournamentSchema` | `group` in Match muss in `groups[]` existieren |
+
+---
+
+## 2. Schema-Lücken
+
+### 🔴 Unvalidierte Eingaben
+
+```typescript
+// ❌ Problem: matchId ist optional, sollte required sein
+export const RuntimeMatchEventSchema = z.object({
+  id: z.string(),
+  matchId: z.string().optional(), // ← Sollte required sein!
+  // ...
+});
+
+// ❌ Problem: Keine Cross-Field-Validierung
+export const MatchSchema = z.object({
+  teamA: z.string(),
+  teamB: z.string(),
+  // ❌ Keine Prüfung: teamA !== teamB
+  // ❌ Keine Prüfung: teamA/teamB existieren in teams[]
+});
+
+// ❌ Problem: Date-Transformation fehlt
+export const MatchSchema = z.object({
+  scheduledTime: z.union([z.string(), z.date()]).optional(),
+  // ❌ Sollte transformieren: z.preprocess(...)
+});
+```
+
+### 🟡 Fehlende Geschäftsregeln
+
+```typescript
+// ❌ Keine Validierung für Finals-Logik
+// Wenn hasQuarterfinal=true, dann muss hasSemifinal=true sein
+// (Constraint existiert in tournamentSchemas.ts, aber nicht im Match-Schema)
+
+// ❌ Keine Prüfung: scoreA/scoreB >= 0
+// ❌ Keine Prüfung: events.timestampSeconds monoton steigend
+```
+
+---
+
+## 3. Erweiterbarkeits-Probleme
+
+### 🔴 Hardcoded Sport-Registry
+
+```typescript
+// ❌ Neue Sportart erfordert Code-Änderung
+export const sportRegistry = new Map<SportId, SportConfig>([
+  ['football-indoor', footballIndoorConfig],
+  ['football-outdoor', footballOutdoorConfig],
+  // ← Hand-Registrierung, keine dynamische Erweiterung
+]);
+```
+
+**Lösung:** Plugin-System oder dynamisches Laden aus DB/Config-File.
+
+### 🟡 Limitierte Tiebreaker-Modi
+
+```typescript
+export type TiebreakerMode =
+  | 'shootout'
+  | 'overtime-then-shootout'
+  | 'goldenGoal';
+// ❌ Keine Erweiterung ohne Code-Änderung
+```
+
+### 🟡 Age Classes nicht konfigurierbar
+
+```typescript
+// ❌ Hardcoded in Config, nicht pro-Tournament anpassbar
+ageClasses: [
+  { value: 'G-Jugend', label: 'G-Jugend (U7)', minAge: 5, maxAge: 7 },
+  // ...
+]
+```
+
+### 🟢 Positiv: DFB-Patterns
+
+```typescript
+// ✅ DFB_ROUND_ROBIN_PATTERNS ist erweiterbar
+// ✅ Unterstützt 2-18 Teams mit BYE-Logik
+```
+
+---
+
+## 4. Positive Patterns
+
+### ✅ Starke Trennung von Concerns
+
+```typescript
+// ✅ LiveMatch (Runtime) vs Match (Persistenz)
+export interface LiveMatch { /* Timer, Events, Status */ }
+export interface Match { /* DB-Schema, korrigierte Ergebnisse */ }
+```
+
+### ✅ Zod-Validierung mit Tests
+
+```typescript
+// ✅ Umfassende Testabdeckung
+describe('TournamentSchema round-trip', () => {
+  it('validates a complete tournament with all sub-schemas', () => {
+    // ...
+  });
+});
+```
+
+### ✅ Forward Compatibility
+
+```typescript
+// ✅ .passthrough() erhält unbekannte Felder
+export const TournamentSchema = z.object({
+  // ...
+}).passthrough();
+```
+
+### ✅ Legacy-Migration
+
+```typescript
+// ✅ BC-Funktionen für Migration
+export function legacySportToSportId(sport: 'football' | 'other'): SportId;
+export function sportIdToLegacySport(sportId: SportId): 'football' | 'other';
+```
+
+### ✅ Type-Safe Enums
+
+```typescript
+// ✅ Exhaustive Checks möglich
+export type MatchStatus = 'scheduled' | 'waiting' | 'running' | 'finished' | 'skipped';
+```
+
+---
+
+## 5. Datenmodell Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Typ-Sicherheit** | 8/10 | Gute TypeScript-Nutzung, aber Doppeldefinitionen |
+| **Validierung** | 6/10 | Zod vorhanden, aber fehlende Geschäftsregeln |
+| **Erweiterbarkeit** | 6/10 | Sport-Registry ist hardcoded |
+| **Datenintegrität** | 7/10 | Passthrough gut, aber Cross-Field-Validierung fehlt |
+| **Testabdeckung** | 9/10 | Umfassende Tests für Schemas und Configs |
+| **Dokumentation** | 8/10 | Gute JSDoc-Kommentare, aber fehlende Invarianten |
+
+### **Gesamtscore: 7.3/10**
+
+---
+
+## 6. Kritische Empfehlungen
+
+### 🔴 Sofort (P0)
+
+1. **Einheitliche SportId-Definition**
+   ```typescript
+   // src/config/sports/types.ts exportieren und importieren
+   export type { SportId } from './types';
+   // In types/tournament.ts entfernen
+   ```
+
+2. **Date-Transformation hinzufügen**
+   ```typescript
+   scheduledTime: z.preprocess(
+     (arg) => typeof arg === 'string' ? new Date(arg) : arg,
+     z.date().optional()
+   )
+   ```
+
+3. **Match-Constraints validieren**
+   ```typescript
+   z.object({
+     teamA: z.string(),
+     teamB: z.string(),
+   }).refine(data => data.teamA !== data.teamB, {
+     message: 'Teams müssen unterschiedlich sein'
+   })
+   ```
+
+### 🟡 Kurzfristig (P1)
+
+4. **Sport-Registry dynamisch machen**
+   ```typescript
+   // Config-File oder DB statt hardcoded Map
+   export async function loadSportRegistry(): Promise<Map<SportId, SportConfig>>;
+   ```
+
+5. **Cross-Field-Validierung**
+   ```typescript
+   // Prüfen: teamA/teamB existieren in teams[]
+   // Prüfen: group existiert in groups[]
+   ```
+
+### 🟢 Mittelfristig (P2)
+
+6. **Tiebreaker-Logik erweitern**
+   ```typescript
+   // Konfigurierbare Tiebreaker pro Tournament
+   tiebreaker: {
+     mode: TiebreakerMode,
+     enabled: boolean,
+     duration?: number
+   }
+   ```
+
+7. **Optimistic Locking implementieren**
+   ```typescript
+   // version-basierte Konflikterkennung bei Concurrent Updates
+   ```
+
+---
+
+## 7. Zusammenfassung
+
+**Stärken:**
+- ✅ Gute Trennung Runtime vs. Persistenz
+- ✅ Umfassende Zod-Validierung mit Tests
+- ✅ Type-Safe Enums und Discriminated Unions
+- ✅ Legacy-Migration unterstützt
+
+**Schwächen:**
+- ❌ Doppelte Typ-Definitionen
+- ❌ Fehlende Cross-Field-Validierung
+- ❌ Hardcoded Sport-Registry
+- ❌ Date-Handling nicht robust
+
+**Empfehlung:** Die Architektur ist solide, aber **Business-Logic-Validierungen** müssen in die Schemas integriert werden, bevor das System production-ready ist.
+
+---
+
+## Supabase, Datenbank & Sync
+
+
+
+# Supabase/PostgreSQL Architektur-Review: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt eine **hochgradig durchdachte Offline-First-Architektur** mit professioneller RLS-Implementierung, Optimistic Locking und granularer Synchronisation. Die Architektur ist für Multi-User-Szenarien und Live-Synchronisation gut vorbereitet.
+
+---
+
+## 🔴 Kritische DB/Auth-Probleme
+
+### 1. RLS Policy-Konflikte & Cleanup-Risiko
+**Problem:** Migration `20260128_002_consolidate_rls_v3.sql` erstellt v3-Policies, aber `20260128_006_drop_old_policies.sql` (nicht im Code) wird benötigt.
+
+**Risiko:** Wenn v2-Policies nicht explizit gelöscht werden, können sie mit v3 kollidieren oder veraltete Zugriffsrechte gewähren.
+
+**Lösung:**
+```sql
+-- Vor dem Deployment prüfen:
+SELECT tablename, policyname, roles, cmd, qual, with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+ORDER BY tablename, policyname;
+
+-- Alte Policies explizit löschen (in einer separaten Migration)
+DROP POLICY IF EXISTS "tournaments_select_v2" ON tournaments;
+DROP POLICY IF EXISTS "teams_select_v2" ON teams;
+-- ... alle v2 Policies
+```
+
+### 2. Optimistic Locking Race Condition bei Match-Initialisierung
+**Problem:** In `SupabaseLiveMatchRepository.save()`:
+```ts
+// Version-Mismatch bei "not_started" Status wird als Initialisierung behandelt
+if (currentMatch && (currentMatch.match_status === 'not_started' || ...)) {
+  // Retry mit currentVersion
+}
+```
+
+**Risiko:** Wenn ein Match parallel von zwei Clients initialisiert wird, kann dies zu inkonsistenten `live_state`-Daten führen.
+
+**Lösung:**
+- Match-Initialisierung sollte atomar über eine **Edge Function** erfolgen
+- Oder: `live_state` nur einmalig setzen (INSERT statt UPDATE)
+
+### 3. Anonymous User Limit - RLS vs. Function
+**Problem:** Die Limit-Prüfung erfolgt in der RLS-Policy (`tournaments_insert_v3`), aber die Funktion `count_active_tournaments()` hat `SECURITY DEFINER`.
+
+**Risiko:** Wenn jemand direkt SQL ausführt (nicht über Edge Functions), kann das Limit umgangen werden.
+
+**Lösung:**
+- `count_active_tournaments()` sollte **nicht** `SECURITY DEFINER` sein
+- Oder: Limit auch in der Edge Function prüfen (dual validation)
+
+### 4. Denormalized Owner Sync - Trigger Race Condition
+**Problem:** Trigger `sync_owner_from_tournament()` setzt `owner_id` bei INSERT, aber wenn `tournaments`-Tabelle später geändert wird, bleiben `teams`/`matches` veraltet.
+
+**Risiko:** Inkonsistente `owner_id`-Werte nach `tournament.owner_id`-Änderung.
+
+**Lösung:**
+- Trigger auf `tournaments`-UPDATE hinzufügen, der alle Kinder aktualisiert
+- Oder: `owner_id` in RLS-Policies dynamisch aus `tournaments` berechnen (langsamer, aber sicherer)
+
+---
+
+## 🟡 Sync-Probleme
+
+### 1. Version-Inkrementierung in LocalStorageRepository
+**Problem:**
+```ts
+// LocalStorageRepository.save()
+list[index] = { ...tournament, version: currentVersion + 1, ... };
+```
+
+**Risiko:** Bei Offline-Operationen wird die Version **lokal** inkrementiert, aber die Cloud-Version bleibt gleich. Nach Sync kann es zu Konflikten kommen.
+
+**Lösung:**
+- Version sollte **nur** bei Cloud-Sync aktualisiert werden
+- LocalStorage sollte `pendingVersion` separat tracken
+- `OfflineRepository.syncUp()` sollte Version-Konflikte explizit auflösen
+
+### 2. Granular Sync - Delta-Erkennung unvollständig
+**Problem:** `OfflineRepository.syncTournamentDelta()` prüft nur `version`, nicht strukturelle Änderungen.
+
+**Risiko:** Wenn Teams umbenannt werden (gleiche IDs), wird Full-Save ausgelöst (ineffizient).
+
+**Lösung:**
+- Hash-basierte Delta-Erkennung (z.B. `JSON.stringify(matches)` hash)
+- Oder: `match_events` statt `matches` für Score-Updates verwenden
+
+### 3. MutationQueue - Keine Retry-Backoff-Strategie
+**Problem:** `MutationQueue` queueing ist implementiert, aber kein exponentieller Backoff bei wiederholten Fehlern.
+
+**Risiko:** Bei instabiler Verbindung werden viele Requests gesendet, was zu Rate-Limiting führen kann.
+
+**Lösung:**
+```ts
+// In MutationQueue
+private async processQueue() {
+  let retryCount = 0;
+  while (this.queue.length > 0) {
+    try {
+      await this.processMutation(this.queue[0]);
+      retryCount = 0;
+    } catch (error) {
+      retryCount++;
+      const delay = Math.min(1000 * Math.pow(2, retryCount), 30000);
+      await sleep(delay);
+    }
+  }
+}
+```
+
+---
+
+## 🟢 Optimierungspotenzial
+
+### 1. RLS Performance - Denormalisierung ist gut!
+**Status:** ✅ **Ausgezeichnet**
+- `owner_id` und `is_public` auf allen Child-Tabellen
+- Vermeidet `EXISTS`-Subqueries in RLS
+- **100x schneller** als JOIN-basierte Policies
+
+**Empfehlung:**
+- `owner_id` auf `NOT NULL` setzen (nach Backfill)
+- Index auf `(owner_id, is_public)` für kombinierte Queries
+
+### 2. Index-Strategie
+**Status:** ✅ **Sehr gut**
+- FK-Indexes für `team_a_id`, `team_b_id` (kritisch für LiveMatch)
+- Audit-Trail-Indexes für `last_modified_by`
+- Cleanup von ungenutzten `is_public`-Indexes
+
+**Empfehlung:**
+- Partial Index für `is_public = true` (bereits vorhanden)
+- `EXCLUDE`-Index für `share_code` (bereits vorhanden)
+- Consider: `BRIN`-Index für `updated_at` (zeitbasierte Queries)
+
+### 3. Optimistic Locking Implementation
+**Status:** ✅ **Professionell**
+- `version`-Spalte auf allen relevanten Tabellen
+- Trigger-basierte Auto-Inkrementierung
+- CAS-Pattern in `SupabaseLiveMatchRepository.save()`
+
+**Empfehlung:**
+- `version`-Spalte auch auf `tournaments` (fehlt aktuell)
+- `version`-Check auch in `updateMatches()` (nicht nur `save()`)
+
+### 4. Realtime Subscriptions Cleanup
+**Problem:** `SupabaseLiveMatchRepository` speichert Subscriptions in `Map`, aber kein `unsubscribe()` bei Component-Unmount.
+
+**Risiko:** Memory Leaks bei häufigen Navigationen.
+
+**Lösung:**
+```ts
+// In SupabaseLiveMatchRepository
+async unsubscribe(tournamentId: string) {
+  const channel = this.subscriptions.get(tournamentId);
+  if (channel) {
+    await supabase.removeChannel(channel);
+    this.subscriptions.delete(tournamentId);
+  }
+}
+```
+
+### 5. Edge Function - Rate Limiting
+**Problem:** `validate-registration-code` hat kein Rate Limiting.
+
+**Risiko:** Brute-Force-Angriffe auf Registrierungs-Codes.
+
+**Lösung:**
+- Supabase Edge Functions Rate Limiting aktivieren
+- Oder: Redis-basiertes Rate Limiting in der Function
+
+---
+
+## ✅ Positive Patterns
+
+### 1. Offline-First mit Granularer Sync
+**Exzellent:**
+- `OfflineRepository` mit LocalStorage + Cloud
+- Granularer Sync (Metadata vs. Matches)
+- MutationQueue für persistente Hintergrund-Sync
+
+### 2. Anonymous User Merge Flow
+**Exzellent:**
+- Edge Function `merge-accounts` mit Service Role
+- Atomare PostgreSQL-Funktion `merge_user_data()`
+- Validierung vor und nach dem Merge
+
+### 3. RLS mit Denormalisierung
+**Exzellent:**
+- `owner_id` auf allen Tabellen
+- Trigger-basierte Synchronisation
+- Partial Indexes für `is_public = true`
+
+### 4. Optimistic Locking mit Version
+**Exzellent:**
+- Trigger-basierte Auto-Inkrementierung
+- CAS-Pattern in Repository
+- `OptimisticLockError` für UI-Feedback
+
+### 5. Security Hardening
+**Exzellent:**
+- `SECURITY DEFINER` mit `SET search_path = public, pg_temp`
+- Keine direkten `auth.uid()` in Funktionen (vermeidet RLS-Recursion)
+- Edge Functions mit JWT-Validierung
+
+---
+
+## 📊 Supabase Score: **8.5/10**
+
+| Kategorie | Score | Bewertung |
+|-----------|-------|-----------|
+| **RLS Security** | 9/10 | Sehr gut, aber Cleanup nötig |
+| **Schema Design** | 9/10 | Denormalisierung exzellent |
+| **Sync Architecture** | 8/10 | Offline-First gut, Version-Handling verbesserbar |
+| **Auth Integration** | 9/10 | Merge-Flow professionell |
+| **Performance** | 8/10 | Indexe gut, aber Realtime Cleanup fehlt |
+| **Error Handling** | 7/10 | Retry-Strategie unvollständig |
+| **Maintainability** | 8/10 | Migrationen gut strukturiert |
+
+---
+
+## 🚀 Priorisierte Action Items
+
+### P0 (Kritisch)
+1. **RLS Policy Cleanup** - Alte v2-Policies explizit löschen
+2. **Version-Handling Fix** - LocalStorage Version nicht inkrementieren vor Cloud-Sync
+3. **Realtime Cleanup** - `unsubscribe()` bei Component-Unmount
+
+### P1 (Hoch)
+4. **Retry-Backoff** - Exponentieller Backoff in MutationQueue
+5. **Match Initialization** - Atomare Initialisierung via Edge Function
+6. **Owner Sync Trigger** - Trigger auf `tournaments.UPDATE` für Kinder
+
+### P2 (Mittel)
+7. **Version auf tournaments** - `version`-Spalte auch auf `tournaments`
+8. **Rate Limiting** - Für `validate-registration-code`
+9. **BRIN Index** - Für `updated_at`-basierte Queries
+
+---
+
+## 📝 Zusammenfassung
+
+Die Architektur ist **professionell und production-ready** mit wenigen kritischen Lücken. Die Denormalisierungs-Strategie für RLS ist exzellent, und das Offline-First-Design mit granularer Sync ist für eine PWA ideal. Die größten Risiken liegen in der **RLS-Policy-Konsistenz** und **Version-Handling** bei Offline-Operationen.
+
+**Empfehlung:** P0-Items vor Production-Release fixen, P1-Items im nächsten Sprint.
+
+---
+
+## Testing & Qualitaetssicherung
+
+
+
+# 🧪 Test-Strategie Analyse: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt **starke Unit-Test-Abdeckung für Business-Logic** (Schedule-Generierung, Standings-Berechnung, Playoff-Resolver), aber **kritische Lücken** in E2E, Integration und UI-Testing. Die Test-Infrastruktur ist solide aufgebaut, deckt aber nicht die gesamte Anwendung ab.
+
+---
+
+## 📊 Testing Score: **4.2/10**
+
+| Kategorie | Score | Status |
+|-----------|-------|--------|
+| Unit Tests (Business Logic) | 7.5/10 | ✅ Gut |
+| Component Tests | 0/10 | ❌ Fehlend |
+| Integration Tests | 2/10 | ⚠️ Minimal |
+| E2E Tests | 0/10 | ❌ Fehlend |
+| Accessibility Tests | 0/10 | ❌ Fehlend |
+| Performance Tests | 1/10 | ⚠️ Baseline vorhanden |
+| Security Tests | 0/10 | ❌ Fehlend |
+| PWA/Offline Tests | 0/10 | ❌ Fehlend |
+
+---
+
+## 🔴 Testlücken (Ungetestete Kritische Pfade)
+
+### 1. **Supabase Integration & Realtime**
+```
+❌ Keine Tests für:
+   - Supabase Auth Flow (Login, Register, Password Reset)
+   - Realtime Subscription (Live-Score Updates)
+   - Database CRUD Operations
+   - Row-Level Security Policies
+   - Offline Sync mit Supabase
+```
+
+**Impact:** 🔴 **KRITISCH** - Kern-Features der PWA
+
+### 2. **React Components**
+```
+❌ Keine Component Tests für:
+   - Tournament Wizard (Multi-Step Form)
+   - Live-Cockpit (Timer, Score-Entry)
+   - Playoff Bracket Visualization
+   - PDF Export Functionality
+   - Monitor/Anzeigetafel View
+```
+
+**Impact:** 🔴 **KRITISCH** - UI-Interaktionen nicht validiert
+
+### 3. **E2E User Flows**
+```
+❌ Keine E2E Tests für:
+   - Turnier-Erstellung bis Publishing
+   - Live-Score Entry während Turnier
+   - Public View (Zuschauer)
+   - Multi-User Concurrent Access
+   - Mobile Responsiveness
+```
+
+**Impact:** 🔴 **KRITISCH** - User Experience nicht validiert
+
+### 4. **Accessibility (a11y)**
+```
+❌ Keine Accessibility Tests:
+   - Screen Reader Compatibility
+   - Keyboard Navigation
+   - Color Contrast
+   - ARIA Labels
+   - Focus Management
+```
+
+**Impact:** 🟡 **HOCH** - Compliance-Risiko
+
+### 5. **PWA Features**
+```
+❌ Keine PWA Tests:
+   - Service Worker Caching
+   - Offline Functionality
+   - Install Prompt
+   - Background Sync
+   - Push Notifications
+```
+
+**Impact:** 🟡 **HOCH** - PWA-Kernfeatures nicht validiert
+
+---
+
+## ⚠️ Test-Qualitätsprobleme
+
+### 1. **Fragile Test-Daten**
+```typescript
+// src/test-data/mockTournament.ts
+// Problem: Hardcodierte Team-Namen und IDs
+const MOCK_TEAMS: Team[] = [
+  { id: 'team-1', name: 'TSV Grünwald', ... },
+  { id: 'team-2', name: 'FC Bayern München II', ... },
+  // ...
+];
+```
+**Problem:** Test-Daten sind nicht isoliert, können bei Änderungen brechen.
+
+**Lösung:** Factory Pattern konsistent verwenden (wie in `factories.ts`)
+
+### 2. **Missing Test Coverage für Edge Cases**
+```typescript
+// fairScheduler.minimal.test.ts
+it.skip('completes 128 teams (stress test - KNOWN ISSUE)', () => {
+  // ⚠️ Bekannter Bug, aber nicht dokumentiert oder gefixt
+});
+```
+**Problem:** Bekannte Bugs werden mit `.skip()` umgangen statt gefixt.
+
+**Lösung:** Known Issues im Issue-Tracker dokumentieren, nicht in Tests
+
+### 3. **Inconsistent Team Matching**
+```typescript
+// calculations.test.ts
+it('matches teams by name', () => {
+  teamA: 'Team 1' // String Name
+});
+
+it('matches teams by ID (edge case)', () => {
+  teamA: 'team-1' // ID
+});
+```
+**Problem:** Inkonsistente Team-Referenzierung (Name vs ID) kann zu Bugs führen.
+
+**Lösung:** Einheitliche ID-basierte Referenzierung erzwingen
+
+### 4. **No Test Coverage for Error Handling**
+```typescript
+// Keine Tests für:
+- Network Failures
+- Supabase Errors
+- Invalid Input Validation
+- Timeout Scenarios
+```
+
+### 5. **Missing Snapshot Tests**
+```typescript
+// Keine Snapshot Tests für:
+- UI Component Rendering
+- PDF Output Structure
+- Bracket Visualization
+```
+
+---
+
+## 🎯 Fehlende Test-Typen
+
+| Test-Typ | Status | Priorität |
+|----------|--------|-----------|
+| **E2E Tests (Playwright)** | ❌ Fehlend | 🔴 P1 |
+| **Accessibility Tests (axe-core)** | ❌ Fehlend | 🔴 P1 |
+| **Component Tests (RTL)** | ❌ Fehlend | 🔴 P1 |
+| **Supabase Integration Tests** | ❌ Fehlend | 🔴 P1 |
+| **Realtime Tests (WebSocket)** | ❌ Fehlend | 🟡 P2 |
+| **Performance Tests (Lighthouse)** | ⚠️ Baseline | 🟡 P2 |
+| **Security Tests (OWASP)** | ❌ Fehlend | 🟡 P2 |
+| **PWA Tests (Workbox)** | ❌ Fehlend | 🟡 P2 |
+| **Visual Regression Tests** | ❌ Fehlend | 🟢 P3 |
+| **Contract Tests (API)** | ❌ Fehlend | 🟢 P3 |
+
+---
+
+## 📋 Empfehlungen (Priorisiert)
+
+### 🔴 **P1 - Kritisch (Sofort umsetzen)**
+
+#### 1. E2E Test-Setup mit Playwright
+```bash
+npm install -D @playwright/test
+```
+
+**Test-Coverage:**
+```typescript
+// tests/e2e/tournament-creation.spec.ts
+test('should create and publish a tournament', async ({ page }) => {
+  await page.goto('/');
+  await page.click('button:has-text("Neues Turnier")');
+  // ... Wizard Steps
+  await expect(page).toHaveURL(/\/tournament\/\w+$/);
+});
+```
+
+#### 2. Component Test-Setup mit React Testing Library
+```typescript
+// src/components/__tests__/LiveScoreInput.test.tsx
+test('should update score on button click', async () => {
+  const { user } = render(<LiveScoreInput />);
+  await user.click(screen.getByRole('button', { name: '+1' }));
+  expect(screen.getByText('1')).toBeInTheDocument();
+});
+```
+
+#### 3. Accessibility Tests
+```typescript
+// tests/a11y/tournament-view.spec.ts
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+test('should have no accessibility violations', async () => {
+  const { container } = render(<TournamentView />);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+### 🟡 **P2 - Hoch (Nächste Sprint)**
+
+#### 4. Supabase Integration Tests
+```typescript
+// src/integration/__tests__/supabase.spec.ts
+import { createClient } from '@supabase/supabase-js';
+
+test('should create tournament in database', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const { data, error } = await supabase
+    .from('tournaments')
+    .insert({ title: 'Test' });
+  
+  expect(error).toBeNull();
+  expect(data).toBeDefined();
+});
+```
+
+#### 5. Realtime Tests
+```typescript
+// src/integration/__tests__/realtime.spec.ts
+test('should receive live score updates', async () => {
+  const subscription = supabase
+    .channel('scores')
+    .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'matches' }, (payload) => {
+      expect(payload.new.scoreA).toBe(2);
+    })
+    .subscribe();
+  
+  // Trigger update
+  await supabase.from('matches').update({ scoreA: 2 }).eq('id', 'match-1');
+  
+  subscription.unsubscribe();
+});
+```
+
+#### 6. Performance Baseline
+```typescript
+// tests/performance/schedule-generation.spec.ts
+test('should generate schedule for 64 teams in <5s', async () => {
+  const start = performance.now();
+  await generateSchedule(64);
+  const duration = performance.now() - start;
+  expect(duration).toBeLessThan(5000);
+});
+```
+
+### 🟢 **P3 - Mittel (Langfristig)**
+
+#### 7. Visual Regression Tests
+```typescript
+// tests/visual/bracket.spec.ts
+import { matchSnapshot } from '@applitools/eyes-playwright';
+
+test('should render bracket correctly', async ({ page }) => {
+  await page.goto('/tournament/bracket');
+  await matchSnapshot('bracket-view');
+});
+```
+
+#### 8. Contract Tests für API
+```typescript
+// tests/contract/api.spec.ts
+import { Pact } from '@pact-foundation/pact';
+
+test('should match tournament API contract', async () => {
+  // Verify API responses match expected schema
+});
+```
+
+---
+
+## 🏗️ Test-Strategie Verbesserungen
+
+### 1. **Test-Pyramide Optimierung**
+
+```
+        E2E (5-10%)
+       /    \
+      /      \
+ Integration (20-30%)
+    /          \
+   /            \
+Component (30-40%)
+  /              \
+ /                \
+Unit (40-50%)
+```
+
+**Aktuell:** 90% Unit, 10% Sonstiges  
+**Ziel:** 50% Unit, 30% Component, 15% Integration, 5% E2E
+
+### 2. **Test-Daten-Management**
+
+```typescript
+// src/test/factories.ts (erweitern)
+export const createTournamentFactory = factory<Tournament>({
+  id: () => `tournament-${uuid()}`,
+  title: () => `Test Tournament ${random()}`,
+  teams: (n) => createMockTeams(n),
+  matches: (t) => createMockMatches(t.teams),
+});
+
+// Usage
+const tournament = createTournamentFactory.build({
+  numberOfTeams: 8,
+  groupSystem: 'roundRobin',
+});
+```
+
+### 3. **CI/CD Integration**
+
+```yaml
+# .github/workflows/test.yml
+name: Test Suite
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci
+      - run: npm run test:unit
+      - run: npm run test:integration
+      - run: npm run test:e2e
+      - run: npm run test:a11y
+      - run: npm run test:coverage
+```
+
+### 4. **Test Coverage Thresholds**
+
+```json
+// package.json
+{
+  "scripts": {
+    "test:coverage": "vitest run --coverage"
+  },
+  "coverage": {
+    "thresholds": {
+      "lines": 80,
+      "functions": 80,
+      "branches": 70,
+      "statements": 80
+    }
+  }
+}
+```
+
+---
+
+## 📈 Roadmap
+
+| Phase | Zeitraum | Ziele |
+|-------|----------|-------|
+| **Phase 1** | Sprint 1-2 | E2E Tests, Component Tests, Accessibility |
+| **Phase 2** | Sprint 3-4 | Supabase Integration, Realtime Tests |
+| **Phase 3** | Sprint 5-6 | Performance, Security, PWA Tests |
+| **Phase 4** | Sprint 7+ | Visual Regression, Contract Tests |
+
+---
+
+## 🎯 Fazit
+
+**Stärken:**
+- ✅ Solide Unit-Test-Infrastruktur (Vitest, Factories)
+- ✅ Gute Business-Logic Abdeckung
+- ✅ Design Token Synchronisation getestet
+
+**Schwächen:**
+- ❌ Keine E2E/Integration Tests
+- ❌ Keine Component Tests
+- ❌ Keine Accessibility/PWA Tests
+- ⚠️ Bekannte Bugs werden umgangen statt gefixt
+
+**Empfehlung:** Test-Strategie um **E2E und Component Tests** erweitern, um Produktions-Release-Sicherheit zu gewährleisten. Priorität auf **kritische User Flows** (Turnier-Erstellung, Live-Score) setzen.
+
+---
+
+## Turnier-Admin & Playoff-Logik
+
+
+
+# 🏆 Tournament Admin & Playoff Logic Review
+
+## Executive Summary
+
+Die Admin-Struktur ist **exzellent** (modular, responsive, UX-fokussiert), aber die **Playoff-Logik und Turnier-Engine** sind in den bereitgestellten Dateien **nicht implementiert**. Die Admin-Features sind "Container" für Funktionen, die in anderen Modulen liegen müssen.
+
+---
+
+## 🔍 Systematische Analyse
+
+### 1. **Playoff-Bracket-Generierung**
+
+**Status:** ❌ **NICHT IM CODE VORHANDEN**
+
+- Keine `PlayoffBracketGenerator`-Komponente gefunden
+- Keine `generatePlayoffBracket()`-Funktion in den Imports
+- `generateFullSchedule()` wird in `ExportsCategory.tsx` importiert, aber nicht implementiert
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/playoffBracketGenerator.ts
+function generatePlayoffBracket(
+  teams: Team[], 
+  groupStandings: GroupStandings[],
+  bracketSize: number
+): Match[] {
+  // 1. Seeding: 1. Platz Gruppe A vs 4. Platz Gruppe B
+  // 2. Bracket-Struktur: Quarter → Semi → Final
+  // 3. Bye-Handling bei ungerader Teamzahl
+}
+```
+
+**Logik-Fehler:**
+- Kein Seeding-Algorithmus (1. vs Letzter)
+- Keine Bracket-Struktur-Validierung
+- Keine Kreuzspiel-Logik (A1 vs B4, B1 vs A4)
+
+---
+
+### 2. **Tiebreaker-Regeln**
+
+**Status:** ⚠️ **PARTIELL IMPLEMENTIERT**
+
+In `LiveMatch.ts` existieren Tiebreaker-Typen:
+```typescript
+export type TiebreakerMode = 'shootout' | 'overtime-then-shootout' | 'goldenGoal';
+```
+
+**Fehlende Implementierung:**
+- Keine `calculateStandings()`-Logik für Gruppenphase (Punkte → Tordifferenz → Tore → Direkter Vergleich)
+- Keine `resolveTiebreaker()`-Funktion für Playoff-Endstand
+- Keine Los-Entscheidung bei Gleichstand
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/utils/tiebreakerResolver.ts
+function resolveTiebreaker(
+  teams: Team[], 
+  matches: Match[]
+): Team[] {
+  // 1. Punkte
+  // 2. Tordifferenz
+  // 3. Gegentore
+  // 4. Direkter Vergleich
+  // 5. Los
+}
+```
+
+---
+
+### 3. **Bye-Handling (Freilose)**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `ByeMatch`-Logik in `LiveMatch.ts`
+- Keine automatische Weitergabe bei Freilos
+- Keine "Walkover"-Regelung
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/byeHandler.ts
+function handleBye(match: Match): Match {
+  // Team A gewinnt automatisch 3:0 (oder 0:0)
+  // Team B rückt ins nächste Runde
+  // Match wird als "finished" markiert
+}
+```
+
+---
+
+### 4. **Team-Zurückziehung**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `withdrawTeam()`-Funktion
+- Keine Neuberechnung des Brackets bei Ausscheiden
+- Keine "Walkover"-Regel für verbleibende Teams
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/teamWithdrawalService.ts
+function handleTeamWithdrawal(
+  tournament: Tournament,
+  teamId: string
+): Tournament {
+  // 1. Alle verbleibenden Matches des Teams als "forfeit" markieren
+  // 2. Gegner rücken automatisch weiter
+  // 3. Bracket neu berechnen
+}
+```
+
+---
+
+### 5. **Nachträgliche Ergebnisänderungen**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `ActivityLogCategory.tsx`:
+```typescript
+if (match.correctionHistory && match.correctionHistory.length > 0) {
+  match.correctionHistory.forEach((correction: CorrectionEntry) => {
+    // Historie wird protokolliert
+  });
+}
+```
+
+**Fehlende Logik:**
+- Keine automatische Neuberechnung der Tabelle nach Korrektur
+- Keine Validierung (darf Ergebnis nach Playoff-Start geändert werden?)
+- Keine Benachrichtigung an betroffene Teams
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/resultCorrectionService.ts
+function correctMatchResult(
+  matchId: string,
+  newScore: Score,
+  reason: string
+): Tournament {
+  // 1. Alte Werte in correctionHistory speichern
+  // 2. Tabelle neu berechnen
+  // 3. Bracket neu berechnen (wenn in Playoffs)
+  // 4. ActivityLog eintragen
+}
+```
+
+---
+
+### 6. **Turnier-Abbruch**
+
+**Status:** ✅ **IMPLEMENTIERT (DANGER ZONE)**
+
+In `DangerZoneCategory.tsx`:
+```typescript
+case 'end_tournament':
+  onTournamentUpdate({
+    ...tournament,
+    dashboardStatus: 'finished',
+    updatedAt: now,
+  });
+  break;
+```
+
+**Fehlende Logik:**
+- Keine "Endstand"-Berechnung (wer ist Gewinner?)
+- Keine "Abbruch-Protokoll"-Funktion
+- Keine Export-Funktion für abgebrochene Turniere
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/tournamentAbbruchService.ts
+function abortTournament(
+  tournament: Tournament,
+  reason: string
+): Tournament {
+  // 1. Status auf 'aborted' setzen
+  // 2. Endstand basierend auf aktuellem Stand berechnen
+  // 3. Abbruch-Protokoll erstellen
+}
+```
+
+---
+
+### 7. **Spielplan-Regenerierung**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `DangerZoneCategory.tsx`:
+```typescript
+case 'regenerate_schedule': {
+  const resetMatches = tournament.matches.map(match => {
+    if (match.matchStatus === 'finished') {
+      return match; // Keep finished matches
+    }
+    return {
+      ...match,
+      matchStatus: 'scheduled' as const,
+      scoreA: undefined,
+      scoreB: undefined,
+      // ...
+    };
+  });
+  // ...
+}
+```
+
+**Fehlende Logik:**
+- Keine `generateSchedule()`-Funktion (nur Reset)
+- Keine Validierung (darf Spielplan nach Turnierstart geändert werden?)
+- Keine Konflikt-Erkennung (Zeitplan-Überlappungen)
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/scheduleGenerator.ts
+function regenerateSchedule(
+  tournament: Tournament,
+  options: ScheduleOptions
+): Match[] {
+  // 1. Alle nicht-beendeten Matches zurücksetzen
+  // 2. Neue Zeitpläne berechnen
+  // 3. Konflikte vermeiden
+}
+```
+
+---
+
+### 8. **Multi-Gruppen → Playoff Übergang**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `generatePlayoffQualifiers()`-Funktion
+- Keine Kreuzspiel-Logik (A1 vs B4)
+- Keine "Beste 2. Platz"-Logik
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/playoffQualifiersGenerator.ts
+function generatePlayoffQualifiers(
+  groups: Group[],
+  playoffFormat: 'roundOf16' | 'quarterfinal' | 'semifinal'
+): Match[] {
+  // 1. Gruppensieger und beste Zweite ermitteln
+  // 2. Kreuzspiele generieren
+  // 3. Bracket erstellen
+}
+```
+
+---
+
+### 9. **Dritter-Platz-Spiel**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `thirdPlaceMatch`-Option
+- Keine Integration in Bracket
+- Keine Export-Funktion
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/thirdPlaceMatchGenerator.ts
+function generateThirdPlaceMatch(
+  semiFinalLosers: Team[]
+): Match {
+  // Spiel zwischen den Verlierern der Halbfinale
+}
+```
+
+---
+
+### 10. **Export (PDF)**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `ExportsCategory.tsx`:
+```typescript
+const schedule = useMemo(() => {
+  return generateFullSchedule(tournament);
+}, [tournament]);
+
+const standings = useMemo(() => {
+  return calculateStandings(tournament.teams, tournament.matches, tournament);
+}, [tournament]);
+```
+
+**Fehlende Logik:**
+- Keine `generateFullSchedule()`-Implementierung
+- Keine `calculateStandings()`-Implementierung
+- Keine Playoff-Bracket-Export-Funktion
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/lib/pdfExporter.ts
+function exportPlayoffBracketPDF(tournament: Tournament): Blob {
+  // Bracket als PDF rendern
+}
+```
+
+---
+
+## 📊 Admin-UX-Probleme
+
+| Problem | Schweregrad | Beschreibung |
+|---------|-------------|--------------|
+| **Keine Playoff-Übersicht** | 🔴 Hoch | Kein Bracket-Viewer im Admin Center |
+| **Keine Live-Bracket-Updates** | 🔴 Hoch | Bracket wird nicht in Echtzeit aktualisiert |
+| **Keine Tiebreaker-Visualisierung** | 🟡 Mittel | Admin sieht nicht, wer bei Gleichstand weiterkommt |
+| **Keine Team-Status-Übersicht** | 🟡 Mittel | Wer ist qualifiziert? Wer ausgeschieden? |
+| **Keine "Was-wäre-wenn"-Simulation** | 🟢 Niedrig | Admin kann nicht testen, was bei bestimmten Ergebnissen passiert |
+
+---
+
+## 🔧 Fehlende Edge Cases
+
+1. **Ungerade Teamzahl in Playoffs** → Bye-Handling
+2. **Mehrere Teams mit gleichen Punkten** → Tiebreaker-Kaskade
+3. **Spielabbruch durch Wetter/Verletzung** → Walkover-Regel
+4. **Team scheidet nach Playoff-Start aus** → Bracket-Neuberechnung
+5. **Zeitplan-Konflikte** → Feld-Überlappungserkennung
+6. **Mehrere Playoffs gleichzeitig** → Feld-Zuweisung
+7. **Golden Goal vs. Penalty** → Konfigurations-Option
+8. **Dritter-Platz-Spiel optional** → Toggle im Setup
+
+---
+
+## 🎯 Tournament Admin Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Admin-UI/UX** | 9/10 | Exzellente Struktur, responsive, modular |
+| **Playoff-Logik** | 2/10 | Nicht implementiert |
+| **Tiebreaker-Regeln** | 3/10 | Nur Typ-Definitionen, keine Logik |
+| **Bye-Handling** | 1/10 | Nicht implementiert |
+| **Team-Zurückziehung** | 1/10 | Nicht implementiert |
+| **Ergebnis-Korrektur** | 6/10 | Historie vorhanden, aber keine Neuberechnung |
+| **Turnier-Abbruch** | 5/10 | Status-Änderung vorhanden, aber keine Endstand-Berechnung |
+| **Spielplan-Regenerierung** | 4/10 | Reset vorhanden, aber keine Generierung |
+| **Multi-Gruppen → Playoff** | 1/10 | Nicht implementiert |
+| **Dritter-Platz-Spiel** | 1/10 | Nicht implementiert |
+| **Export** | 4/10 | PDF-Dialog vorhanden, aber keine Implementierung |
+| **Inkonsistenzen** | 7/10 | Admin-Struktur ist konsistent, aber Logik fehlt |
+
+### **Gesamtscore: 4.5/10**
+
+---
+
+## 🚀 Empfehlungen
+
+### **Kurzfristig (1-2 Wochen)**
+1. **Implementiere `calculateStandings()`** mit Tiebreaker-Logik
+2. **Implementiere `generatePlayoffBracket()`** mit Seeding
+3. **Füge `ByeMatch`-Logik** hinzu
+4. **Implementiere `correctMatchResult()`** mit Neuberechnung
+
+### **Mittelfristig (1-2 Monate)**
+1. **Bracket-Viewer-Komponente** im Admin Center
+2. **Team-Zurückziehungs-Workflow**
+3. **Dritter-Platz-Spiel-Option**
+4. **Live-Bracket-Updates** via Supabase Realtime
+
+### **Langfristig (3-6 Monate)**
+1. **"Was-wäre-wenn"-Simulation**
+2. **Automatische Tiebreaker-Erkennung**
+3. **Multi-Field-Playoff-Management**
+4. **Export von Bracket als Bild/PDF**
+
+---
+
+## 📝 Fazit
+
+Die **Admin-Struktur ist hervorragend**, aber die **Turnier-Engine (Playoff-Logik, Tiebreaker, Bracket-Generierung)** fehlt vollständig. Die Admin-Features sind "Container" für Funktionen, die in `src/core/generators/` und `src/core/services/` implementiert werden müssen.
+
+**Priorität:** Implementiere zuerst `calculateStandings()` und `generatePlayoffBracket()`, da dies die Basis für alle anderen Features ist.
+
+---
+
+## Turnier-Erstellung (Wizard Flow)
+
+
+
+# QA-Review: Turnier-Erstellungs-Wizard (hallenfussball-pwa)
+
+Als QA-Engineer und UX-Spezialist habe ich den Wizard-Flow und die zugehörigen Komponenten analysiert. Der Wizard ist funktional sehr umfangreich, weist jedoch einige kritische Logikfehler und UX-Schwachstellen auf, die vor dem Release behoben werden sollten.
+
+## 1. Logik-Fehler im Wizard oder Generator
+
+### **CRITICAL: Division durch Null in `DurationEstimate`**
+*   **Ort:** `src/features/tournament-creation/components/DurationEstimate.tsx`
+*   **Problem:** Die Berechnung `groupPhaseSlotsNeeded = Math.ceil(groupPhaseMatches / fields)` kann zu einer Division durch Null führen, wenn `numberOfFields` auf 0 gesetzt wird (obwohl der Stepper `min={1}` hat, kann der State inkonsistent sein).
+*   **Code:**
+    ```typescript
+    const groupPhaseSlotsNeeded = Math.ceil(groupPhaseMatches / fields); // fields kann 0 sein!
+    ```
+*   **Fix:** Sicherstellen, dass `fields` mindestens 1 ist, bevor dividiert wird.
+
+### **HIGH: Team-Count Synchronisation in `Step4_Teams`**
+*   **Ort:** `src/features/tournament-creation/Step4_Teams.tsx`
+*   **Problem:** Wenn `numberOfTeams` erhöht wird (z.B. von 4 auf 6), wird die Teams-Liste nicht automatisch erweitert. Der Button `needsMoreTeams` wird angezeigt, aber das Hinzufügen ist manuell. Wenn der User den Wizard verlässt und zurückkehrt, ist der State inkonsistent.
+*   **Code:**
+    ```typescript
+    const needsMoreTeams = teams.length < numberOfTeams;
+    // ...
+    if (needsMoreTeams && (
+      <Button onClick={handleGenerateTeams}>...
+    ```
+*   **Fix:** Automatische Generierung von Platzhaltern, wenn `numberOfTeams` erhöht wird, oder klare Fehlermeldung, wenn nicht genug Teams vorhanden sind.
+
+### **MEDIUM: `numberOfGroups` State-Leck**
+*   **Ort:** `src/features/tournament-creation/Step2_ModeAndSystem.tsx`
+*   **Problem:** `numberOfGroups` bleibt im State, auch wenn `groupSystem` auf `roundRobin` gewechselt wird. Das kann zu Verwirrung führen, wenn der User später wieder auf `groupsAndFinals` wechselt (alte Gruppenzahl wird übernommen).
+*   **Fix:** `numberOfGroups` zurücksetzen, wenn `groupSystem` gewechselt wird.
+
+### **MEDIUM: Referee Config Typisierung**
+*   **Ort:** `src/features/tournament-creation/components/RefereeSettings.tsx`
+*   **Problem:** `handleNameChange` castet `refereeConfig` zu `RefereeConfig`, was zu Laufzeitfehlern führen kann, wenn die Struktur nicht exakt passt.
+*   **Code:**
+    ```typescript
+    onUpdate('refereeConfig', { ...refereeConfig, refereeNames: updatedNames } as RefereeConfig);
+    ```
+*   **Fix:** Typsichere Updates ohne Cast.
+
+## 2. Fehlende Validierungen (Pflichtfelder, Grenzwerte)
+
+### **CRITICAL: `startDate` in der Vergangenheit**
+*   **Ort:** `src/features/tournament-creation/Step3_Metadata.tsx`
+*   **Problem:** Es wird nicht geprüft, ob das gewählte Datum in der Vergangenheit liegt.
+*   **Fix:** Validierung hinzufügen: `if (new Date(value) < new Date()) { setError('Datum in der Vergangenheit'); }`
+
+### **HIGH: Team-Namen Validierung**
+*   **Ort:** `src/features/tournament-creation/Step4_Teams.tsx`
+*   **Problem:** Team-Namen können leer sein, obwohl `Input` `required` hat. Die Validierung wird nicht im `onSubmit` oder `onSave` geprüft.
+*   **Fix:** Explizite Prüfung auf leere Team-Namen vor dem Speichern.
+
+### **MEDIUM: ShortCode Eindeutigkeit**
+*   **Ort:** `src/features/tournament-creation/components/NameGrid.tsx`
+*   **Problem:** ShortCodes (z.B. "HN" für Feld) werden nicht auf Eindeutigkeit geprüft. Zwei Felder könnten denselben ShortCode haben.
+*   **Fix:** `checkDuplicate` auch für `shortCode` implementieren.
+
+### **LOW: `numberOfReferees` auf 0 setzen**
+*   **Ort:** `src/features/tournament-creation/components/RefereeSettings.tsx`
+*   **Problem:** Der Stepper erlaubt `min={1}`, aber wenn der User manuell auf 0 ändert, kann es zu Fehlern kommen.
+*   **Fix:** `min={1}` erzwingen.
+
+## 3. UX-Probleme im Wizard-Flow
+
+### **HIGH: Mobile Team-Verwaltung (`Step4_Teams`)**
+*   **Problem:** Auf kleinen Bildschirmen ist die Team-Liste schwer zu bedienen. Die `teamRow` ist zu komplex für Mobile (Avatar, Name, Expand, Delete, Group Selector).
+*   **Code:**
+    ```css
+    .teamRow {
+      display: flex;
+      flex-direction: column; /* Mobile */
+    }
+    ```
+*   **Fix:** Auf Mobile die Gruppe und Farben in ein Collapsible-Panel auslagern, um Platz zu sparen.
+
+### **MEDIUM: Zu viele Optionen in `Step2_ModeAndSystem`**
+*   **Problem:** Der Schritt ist überladen. Viele Konfigurationsoptionen (DFB, Referee, Time, Finals) sind auf einmal sichtbar.
+*   **Fix:** Collapsible Sections für weniger wichtige Optionen (z.B. Referee, Finals) verwenden, um den Fokus zu lenken.
+
+### **MEDIUM: `FinalsConfiguration` Warnungen**
+*   **Problem:** Warnungen wie "Top-8 mit nur 2 Gruppen" sind nicht immer klar. Der User versteht nicht, warum das Problem ist.
+*   **Fix:** Erklärender Text hinzufügen: "Top-8 erfordert mindestens 4 Gruppen, da sonst nicht genug Teams für das Viertelfinale vorhanden sind."
+
+### **LOW: `BambiniSettings` Checkboxen**
+*   **Problem:** Die Checkboxen für "Ergebnisse verbergen" sind nicht intuitiv. Der User muss raten, was passiert.
+*   **Fix:** Tooltip oder Hilfetext hinzufügen: "Wenn aktiviert, werden Ergebnisse und Tabellen für die Öffentlichkeit ausgeblendet."
+
+## 4. Edge Cases die nicht abgedeckt sind
+
+### **CRITICAL: `numberOfFields` = 0**
+*   **Ort:** `DurationEstimate.tsx`
+*   **Problem:** Wenn `numberOfFields` auf 0 gesetzt wird (trotz `min={1}` im Stepper), führt dies zu einer Division durch Null.
+*   **Fix:** `min={1}` erzwingen und State validieren.
+
+### **HIGH: Gruppe ohne Feld-Zuordnung**
+*   **Ort:** `Step_GroupsAndFields.tsx`
+*   **Problem:** Wenn eine Gruppe keinem Feld zugeordnet ist, kann der Spielplan nicht generiert werden.
+*   **Fix:** Validierung hinzufügen: "Jede Gruppe muss mindestens einem Feld zugeordnet sein."
+
+### **MEDIUM: Team-Löschung bei `numberOfTeams`**
+*   **Ort:** `Step4_Teams.tsx`
+*   **Problem:** Wenn ein Team gelöscht wird, aber `numberOfTeams` gleich bleibt, ist die Liste inkonsistent.
+*   **Fix:** `numberOfTeams` automatisch anpassen oder Warnung anzeigen.
+
+### **LOW: `refereeNames` bei `numberOfReferees` Änderung**
+*   **Ort:** `RefereeSettings.tsx`
+*   **Problem:** Wenn `numberOfReferees` erhöht wird, werden neue Namen initialisiert. Wenn verringert, werden Namen gelöscht. Das ist okay, aber der User sollte gewarnt werden.
+*   **Fix:** Bestätigung anzeigen, wenn Namen gelöscht werden.
+
+## 5. Tournament Creation Score
+
+**Score: 7/10**
+
+**Begründung:**
+*   **Stärken:** Der Wizard ist sehr umfangreich und bietet viele Konfigurationsmöglichkeiten. Die UX ist auf Desktop gut, mit vielen visuellen Hilfen (Warnungen, Vorschauen).
+*   **Schwächen:** Es gibt kritische Logikfehler (Division durch Null, State-Inkonsistenzen) und fehlende Validierungen (Datum in der Vergangenheit, leere Team-Namen). Die Mobile-UX ist verbesserungswürdig.
+*   **Empfehlung:** Vor dem Release die kritischen Logikfehler beheben und die Validierungen erweitern. Die Mobile-UX sollte optimiert werden, um die Bedienung auf Smartphones zu erleichtern.
+
+**Priorisierte To-Dos:**
+1.  **Division durch Null in `DurationEstimate` beheben.** (CRITICAL)
+2.  **`startDate` Validierung hinzufügen.** (CRITICAL)
+3.  **Team-Namen Validierung vor dem Speichern.** (HIGH)
+4.  **Mobile Team-Verwaltung vereinfachen.** (HIGH)
+5.  **State-Inkonsistenzen bei `numberOfGroups` und `numberOfTeams` beheben.** (MEDIUM)
+
+---
+

--- a/reviews/2026-03-16_1935_architecture.md
+++ b/reviews/2026-03-16_1935_architecture.md
@@ -1,0 +1,290 @@
+# Code Review: Architektur & Schichtenmodell
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 44.3s  
+**Status:** success  
+**Code-Kontext:** 151,308 Zeichen  
+
+<details><summary>Thinking Process (4,738 Zeichen)</summary>
+
+Der Nutzer möchte eine Architektur-Analyse einer React/TypeScript PWA für Hallenfussball-Turniere.
+Ich habe eine große Menge an Code-Dateien erhalten, die verschiedene Aspekte der Architektur abdecken:
+- Repository Context (Dependency Injection / Repository Pattern)
+- Error Handling (Custom Error Hierarchy)
+- Generators (Playoff, Schedule, Referee)
+- Models & Schemas (Zod Validation)
+
+Ich muss als erfahrener Software-Architekt agieren und ein strukturiertes Review liefern.
+
+**Analyse der Architektur:**
+
+1.  **Schichtenarchitektur:**
+    - `src/core`: Enthält Models, Repositories, Services, Generators. Das ist die Business-Logic-Schicht.
+    - `src/features`: (Implizit erwähnt, z.B. `features/auth/hooks/useAuth`)
+    - `src/components`: UI-Komponenten (nicht im Code, aber impliziert).
+    - Die Trennung zwischen Core (Business Logic) und UI (React) scheint gut zu sein. `RepositoryContext` koppelt Core an React, aber das ist notwendig für Dependency Injection im UI-Kontext.
+
+2.  **Dependency Flow:**
+    - `RepositoryContext` importiert aus `features/auth`. Das ist ein potenzielles Problem (Core hängt von Features ab). Normalerweise sollte Core unabhängig sein.
+    - Generators sind in `core/generators` und scheinen rein funktional zu sein (keine React Imports). Das ist gut.
+    - Models/Schemas sind in `core/models`.
+
+3.  **Repository Pattern:**
+    - Es gibt Interfaces (`ITournamentRepository`) und Implementierungen (`LocalStorageRepository`, `SupabaseRepository`, `OfflineRepository`).
+    - Der `OfflineRepository` wrapper scheint eine Offline-First-Strategie zu implementieren.
+    - Der `RepositoryContext` wählt zur Laufzeit die Implementierung basierend auf Auth-Status und Supabase-Konfiguration aus. Das ist flexibel.
+
+4.  **Type System & Validation:**
+    - Zod-Schemas werden für Runtime-Validierung verwendet (`TournamentSchema`, `MatchSchema`).
+    - TypeScript-Typen werden aus den Schemas abgeleitet (`z.infer`).
+    - Es gibt Tests für die Schemas. Das ist sehr gut.
+    - `passthrough()` wird verwendet, um Datenverlust bei unbekannten Feldern zu vermeiden (gut für Forward Compatibility).
+
+5.  **Generators:**
+    - `playoffGenerator`, `scheduleGenerator`, `refereeAssigner`, `fairScheduler`.
+    - Diese Module sind rein funktional und testbar.
+    - Die Logik für Playoff-Generierung ist komplex (Presets, Abhängigkeiten).
+    - `fairScheduler` versucht, Fairness bei der Spielplanerstellung zu optimieren (Restzeiten, Feldverteilung).
+
+6.  **Error Handling:**
+    - Eigene Error-Hierarchie (`AppError`, `RepositoryError`, etc.).
+    - `isAbortError` Utility zur Behandlung von Abbruchfehlern.
+    - Tests für Error-Klassen vorhanden.
+
+7.  **State Management / Data Flow:**
+    - `RepositoryContext` zentralisiert den Datenzugriff.
+    - Mutationen werden über Repositories gesteuert.
+    - Es gibt ein `MutationItemSchema` für Offline-Queues (Mutation Queue).
+
+**Stärken:**
+- Saubere Trennung von Business Logic (`core`) und UI.
+- Robustes Repository Pattern mit Offline-First-Unterstützung.
+- Umfassende Zod-Validierung mit Tests.
+- Funktionale Generatoren für komplexe Turnierlogik.
+- Gute Error-Handling-Strategie.
+
+**Schwächen / Probleme:**
+- **Circular Dependency / Coupling:** `RepositoryContext` importiert `useAuth` aus `features/auth`. Das bricht die Abhängigkeitsrichtung (Core sollte nicht von Features abhängen).
+- **Complexity in Generators:** Der `scheduleGenerator` und `fairScheduler` sind sehr komplex. Die Logik für "Hybrid Mode" (bestehende Matches vs. Generierung) ist fehleranfällig.
+- **Date Handling:** `scheduledTime` ist in Schema `string | date`, aber im Code oft `Date`. Das kann zu Inkonsistenzen führen (JSON Serialisierung).
+- **Global State:** Der `RepositoryContext` hält Referenzen (`useRef`) für Repositories. Das ist okay, aber die Cleanup-Logik (`useEffect`) muss sorgfältig sein.
+- **Type Safety:** `z.unknown()` für Mutation Payloads ist notwendig, aber reduziert Type Safety.
+- **Hardcoded Logic:** Playoff-Logik ist stark in den Generatoren verankert. Änderungen erfordern Code-Änderungen.
+
+**Verbesserungsvorschläge:**
+- Dependency Inversion für Auth (Interface statt konkreter Hook).
+- Einheitliches Date-Handling (ISO Strings in DB/Storage, Date Objects im Memory).
+- Refactoring der Generator-Logik in kleinere, testbare Einheiten.
+- Verwendung von `z.preprocess` für Date-Transformationen.
+
+**Bewertung:**
+- Die Architektur ist solide für eine PWA mit Offline-First-Anforderungen.
+- Die Trennung von Core und UI ist gut gelungen.
+- Die Komplexität der Turnierlogik wird durch funktionale Generatoren gut beherrscht.
+- Das Coupling in `RepositoryContext` ist der größte Schwachpunkt.
+
+Ich werde das Review in den geforderten Kategorien strukturieren.
+
+
+</details>
+
+---
+
+
+
+# Architektur-Review: hallenfussball-pwa
+
+## Zusammenfassung
+Die Architektur folgt einem **Clean Architecture**-Ansatz mit klarer Trennung zwischen **Core (Business Logic)** und **UI (React)**. Das Repository-Pattern wird konsequent für Datenzugriff und Offline-First-Funktionalität eingesetzt. Die Turnierlogik (Generatoren) ist modular und rein funktional aufgebaut, was die Testbarkeit stark erhöht.
+
+## Stärken
+
+1.  **Saubere Schichtenarchitektur:**
+    - `src/core` enthält reine Business-Logik ohne React-Abhängigkeiten (außer Context).
+    - Generatoren (`playoffGenerator`, `fairScheduler`) sind rein funktional und leicht testbar.
+    - Models und Schemas sind zentralisiert und konsistent.
+
+2.  **Robustes Repository Pattern:**
+    - Abstraktion über `ITournamentRepository` ermöglicht einfachen Wechsel zwischen `LocalStorage` und `Supabase`.
+    - `OfflineRepository` Wrapper implementiert Offline-First-Strategie mit Mutation-Queue.
+    - `RepositoryContext` orchestriert die Repository-Auswahl basierend auf Auth-Status.
+
+3.  **Umfassende Validierung:**
+    - Zod-Schemas für alle Domain-Objekte (`Tournament`, `Match`, `Team`).
+    - `passthrough()` verhindert Datenverlust bei unbekannten Feldern (Forward Compatibility).
+    - Umfangreiche Tests für Schemas und Generatoren.
+
+4.  **Fehlerbehandlung:**
+    - Eigene Error-Hierarchie (`AppError`, `RepositoryError`, etc.) mit Feature-Tagging.
+    - Konsistente Behandlung von `AbortError` in `isAbortError`.
+
+5.  **Komplexe Logik-Modularisierung:**
+    - Playoff-Generierung, Spielplan-Erstellung und Schiedsrichter-Zuweisung sind in separaten Modulen gekapselt.
+    - Preset-basierte Playoff-Logik (`top-4`, `top-8`, etc.) ist flexibel konfigurierbar.
+
+## Architektur-Probleme
+
+### 1. Dependency Inversion Verletzung (Critical)
+**Datei:** `src/core/contexts/RepositoryContext.tsx`
+**Problem:** Der Core-Context importiert `useAuth` aus `features/auth`. Das bricht die Abhängigkeitsrichtung (Core sollte nicht von Features abhängen).
+```typescript
+// src/core/contexts/RepositoryContext.tsx
+import { useAuth } from '../../features/auth/hooks/useAuth'; // ❌ Core hängt von Feature ab
+```
+**Auswirkung:** Zirkuläre Abhängigkeiten werden möglich, Core ist nicht mehr unabhängig testbar.
+
+### 2. Date-Handling Inkonsistenz (High)
+**Datei:** `src/core/models/schemas/TournamentSchema.ts`
+**Problem:** `scheduledTime` ist als `z.union([z.string(), z.date()])` definiert, aber im Code oft als `Date`-Objekt behandelt. JSON-Serialisierung wandelt `Date` in String um, was zu Laufzeitfehlern führen kann.
+```typescript
+// Schema
+scheduledTime: z.union([z.string(), z.date()]).optional(),
+
+// Code (scheduleHelpers.ts)
+const matchStart = m.scheduledTime ? new Date(m.scheduledTime) : ... // ⚠️ Risiko bei falschem Typ
+```
+**Auswirkung:** Potenzielle Bugs bei der Zeitberechnung, besonders nach Reload aus LocalStorage.
+
+### 3. Komplexe Generator-Logik (Medium)
+**Datei:** `src/core/generators/scheduleGenerator.ts`
+**Problem:** Die `generateFullSchedule`-Funktion enthält zu viel Logik ("Hybrid Mode", Persistenz-Checks, Fallbacks). Die Funktion ist zu groß und schwer zu warten.
+```typescript
+// scheduleGenerator.ts
+if (hasMatches) {
+  // ... 100+ Zeilen Logik für Persistenz-Mode
+} else {
+  // ... Generierungs-Logik
+}
+```
+**Auswirkung:** Hohe kognitive Last, schwer zu testen, fehleranfällig bei Änderungen.
+
+### 4. Mutation-Queue Type Safety (Medium)
+**Datei:** `src/core/models/schemas/MutationItemSchema.ts`
+**Problem:** `payload: z.unknown()` reduziert Type Safety für Mutationen.
+```typescript
+export const MutationItemSchema = z.object({
+  // ...
+  payload: z.unknown(), // ⚠️ Keine Typprüfung
+  // ...
+});
+```
+**Auswirkung:** Fehlerhafte Payloads werden erst zur Laufzeit erkannt.
+
+### 5. Global State im Context (Low)
+**Datei:** `src/core/contexts/RepositoryContext.tsx`
+**Problem:** `supabaseLiveMatchRepoRef` wird im Context gehalten. Bei mehrfacher Instanziierung (z.B. Strict Mode) kann dies zu Problemen führen.
+```typescript
+const supabaseLiveMatchRepoRef = useRef<SupabaseLiveMatchRepository | null>(null);
+```
+**Auswirkung:** Potenzielle Memory Leaks oder doppelte Subscriptions.
+
+## Konkrete Verbesserungsvorschläge
+
+### 1. Dependency Inversion für Auth
+Erstelle ein Interface für Auth-Status im Core und injiziere es.
+
+```typescript
+// src/core/contexts/AuthContext.ts (neu)
+export interface IAuthProvider {
+  user: { id: string; globalRole?: string } | null;
+  isLoading: boolean;
+}
+
+// src/core/contexts/RepositoryContext.tsx
+export const RepositoryProvider: React.FC<{ 
+  children: React.ReactNode;
+  authProvider: IAuthProvider; // ⚡ Injizieren statt importieren
+}> = ({ children, authProvider }) => {
+  const { user } = authProvider;
+  // ...
+};
+```
+
+### 2. Einheitliches Date-Handling mit Zod Transform
+Nutze `z.preprocess` für konsistente Date-Transformation.
+
+```typescript
+// src/core/models/schemas/TournamentSchema.ts
+const DateSchema = z.preprocess(
+  (arg) => {
+    if (arg instanceof Date) return arg;
+    if (typeof arg === 'string') return new Date(arg);
+    return arg;
+  },
+  z.date()
+);
+
+export const MatchSchema = z.object({
+  // ...
+  scheduledTime: DateSchema.optional(), // ⚡ Immer Date-Objekt im Memory
+});
+```
+
+### 3. Refactoring des Schedule Generators
+Trenne Persistenz-Logik von Generierungs-Logik.
+
+```typescript
+// src/core/generators/scheduleGenerator.ts
+export function generateFullSchedule(tournament: Tournament, locale: 'de' | 'en'): GeneratedSchedule {
+  const matches = hasExistingMatches(tournament) 
+    ? hydrateExistingMatches(tournament) // ⚡ Separate Funktion
+    : generateMatchesFromScratch(tournament); // ⚡ Separate Funktion
+  
+  return buildSchedule(matches, tournament, locale);
+}
+```
+
+### 4. Typed Mutation Payloads
+Verwende Union Types für Payloads statt `z.unknown()`.
+
+```typescript
+// src/core/models/schemas/MutationItemSchema.ts
+const SaveTournamentPayload = z.object({ /* ... */ });
+const UpdateMatchPayload = z.object({ /* ... */ });
+
+const MutationPayload = z.discriminatedUnion('type', [
+  SaveTournamentPayload,
+  UpdateMatchPayload,
+  // ...
+]);
+
+export const MutationItemSchema = z.object({
+  type: z.enum(['SAVE_TOURNAMENT', 'UPDATE_MATCH', ...]),
+  payload: MutationPayload, // ⚡ Typsicher
+  // ...
+});
+```
+
+### 5. Cleanup im RepositoryContext
+Verwende `useRef` für Cleanup-Logik, um doppelte Subscriptions zu vermeiden.
+
+```typescript
+// src/core/contexts/RepositoryContext.tsx
+const cleanupRef = useRef<() => void>();
+
+useEffect(() => {
+  return () => {
+    cleanupRef.current?.();
+  };
+}, []);
+
+// Bei Repository-Wechsel
+if (cleanupRef.current) {
+  cleanupRef.current();
+}
+cleanupRef.current = () => supabaseLiveMatchRepoRef.current?.unsubscribeAll();
+```
+
+## Bewertung
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Trennung der Belange** | 8/10 | Core/Feature-Trennung gut, aber Auth-Coupling im Context |
+| **Testbarkeit** | 9/10 | Funktionale Generatoren und Schemas sind hervorragend testbar |
+| **Skalierbarkeit** | 7/10 | Repository-Pattern skaliert gut, aber Generator-Logik wird komplex |
+| **Type Safety** | 8/10 | Zod + TypeScript gut integriert, aber `z.unknown()` und Date-Probleme |
+| **Wartbarkeit** | 7/10 | Gute Struktur, aber einige Funktionen sind zu komplex (scheduleGenerator) |
+
+**Gesamtbewertung: 7.8/10**
+
+Die Architektur ist für eine PWA mit Offline-First-Anforderungen sehr gut durchdacht. Die größten Schwachstellen liegen im Coupling zwischen Core und Features sowie in der Komplexität einiger Generator-Funktionen. Mit den vorgeschlagenen Verbesserungen kann die Architektur auf 9/10 gehoben werden.

--- a/reviews/2026-03-16_1935_code_quality.md
+++ b/reviews/2026-03-16_1935_code_quality.md
@@ -1,0 +1,357 @@
+# Code Review: Code-Qualitaet & TypeScript-Patterns
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 30.5s  
+**Status:** success  
+**Code-Kontext:** 146,980 Zeichen  
+
+<details><summary>Thinking Process (483 Zeichen)</summary>
+
+Der Code ist sehr umfangreich und enthält viele verschiedene Module. Ich muss eine strukturierte Analyse durchführen, um Code-Qualität, Patterns und Wartbarkeit zu bewerten.
+
+Lass mich die wichtigsten Aspekte analysieren:
+
+1. **TypeScript Strict Mode & Type Safety**
+2. **Code Smells & Patterns**
+3. **Test Coverage & Qualität**
+4. **Naming Conventions**
+5. **Wartbarkeit & Architektur**
+
+Ich werde basierend auf dem bereitgestellten Code ein detailliertes Quality-Report erstellen.
+
+
+</details>
+
+---
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metric | Score | Status |
+|--------|-------|--------|
+| **Overall Quality** | **7.8/10** | ✅ Good |
+| **Type Safety** | 8.2/10 | ✅ Strong |
+| **Test Coverage** | 8.5/10 | ✅ Excellent |
+| **Maintainability** | 7.5/10 | ⚠️ Moderate |
+| **Performance** | 7.0/10 | ⚠️ Needs Attention |
+
+---
+
+## 🔴 Code Smells (Critical & High Priority)
+
+### 1. **BUG-001: Team Matching Inconsistency**
+**File:** `src/utils/calculations.ts` (Line 35-42)
+**Severity:** 🔴 Critical
+
+```typescript
+// Problem: Mixing team ID and name matching creates ambiguity
+const teamAStanding = standings.find(
+  (s) => s.team.name === match.teamA || s.team.id === match.teamA
+);
+```
+
+**Issue:** `match.teamA` can be either team ID or team name depending on context. This creates fragile code that's hard to debug.
+
+**Recommendation:**
+```typescript
+// Normalize team references to IDs only
+const teamAStanding = standings.find(s => s.team.id === normalizeTeamId(match.teamA));
+```
+
+---
+
+### 2. **Performance: O(n²) Fairness Calculator**
+**File:** `src/utils/FairnessCalculator.ts` (Line 15-25)
+**Severity:** 🟡 Medium
+
+```typescript
+// Current: O(n²) for 64 teams, ~5-10s
+// Test shows: "NOTE: Current baseline after Session 2 is ~5-10s (O(n²))"
+// Before: ~30-35s (O(n³))
+```
+
+**Issue:** While improved from O(n³), still problematic for 128+ teams (skipped test).
+
+**Recommendation:**
+```typescript
+// Consider using a priority queue or heap-based approach
+// Target: O(n log n) for large tournaments
+```
+
+---
+
+### 3. **Dead Code: updateKnockoutMatchesAfterResult**
+**File:** `src/utils/knockoutMatchGenerator.ts` (Line 100+)
+**Severity:** 🟡 Medium
+
+```typescript
+// NOTE: updateKnockoutMatchesAfterResult was removed (dead code - never called)
+```
+
+**Issue:** Commented-out code that should be removed entirely.
+
+**Recommendation:** Remove dead code comments and unused functions.
+
+---
+
+### 4. **Magic Numbers in Tests**
+**File:** `src/utils/__tests__/fairScheduler.minimal.test.ts` (Line 55)
+**Severity:** 🟢 Low
+
+```typescript
+expect(duration).toBeLessThan(45000); // 45s generous timeout
+```
+
+**Issue:** Hard-coded timeout values should be constants.
+
+**Recommendation:**
+```typescript
+const SCHEDULER_TIMEOUT_MS = 45000;
+expect(duration).toBeLessThan(SCHEDULER_TIMEOUT_MS);
+```
+
+---
+
+## 🟡 TypeScript Violations
+
+### 1. **Non-Null Assertions (!)**
+**Files:** Multiple test files
+**Severity:** 🟡 Medium
+
+```typescript
+// src/utils/__tests__/calculations.test.ts (Line 108)
+const team1 = standings.find(s => s.team.name === 'Team 1')!;
+```
+
+**Issue:** Non-null assertions in production code are dangerous. Acceptable in tests but should be minimized.
+
+**Recommendation:** Use proper type guards or optional chaining in production code.
+
+---
+
+### 2. **Type Assertions with `as`**
+**File:** `src/utils/__tests__/ScenarioHMK.test.ts` (Line 20)
+**Severity:** 🟢 Low
+
+```typescript
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+```
+
+**Issue:** Runtime JSON parsing without validation.
+
+**Recommendation:** Use Zod schema validation:
+```typescript
+import { tournamentSchema } from '../types/tournament';
+const importedTournament = tournamentSchema.parse(JSON.parse(fileContent));
+```
+
+---
+
+### 3. **Unused ESLint Disable Comments**
+**File:** `src/utils/calculations.ts` (Line 35)
+**Severity:** 🟢 Low
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Boolean OR: true if either team matches
+```
+
+**Issue:** Some `eslint-disable` comments are overly permissive.
+
+**Recommendation:** Review and remove unnecessary disables.
+
+---
+
+## 📝 Naming Inconsistencies
+
+### 1. **Mixed German/English Naming**
+**Files:** Multiple utility files
+**Severity:** 🟢 Low
+
+```typescript
+// German: getGroupLabel, getGroupShortCode
+// English: generateDisplayNames, resolvePlayoffPlaceholder
+```
+
+**Issue:** Inconsistent naming convention across the codebase.
+
+**Recommendation:** Choose one convention (preferably English for consistency with React/TS ecosystem).
+
+---
+
+### 2. **Inconsistent Variable Naming**
+**File:** `src/utils/calculations.ts` (Line 115)
+**Severity:** 🟢 Low
+
+```typescript
+let _aWins = 0;  // Underscore prefix for unused variable
+```
+
+**Issue:** Inconsistent use of underscore prefix.
+
+**Recommendation:** Use `aWins` and handle properly, or use `_` prefix consistently for intentionally unused variables.
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Excellent Test Coverage**
+**Files:** Multiple test files
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+// Comprehensive test scenarios including edge cases
+it('handles odd teams (13) with BYE rounds', () => { ... });
+it('handles mixed ID and name references', () => { ... });
+it('completes 64 teams (performance baseline)', () => { ... });
+```
+
+**Why it's good:** Tests cover edge cases, performance scenarios, and bug fixes (BUG-001, DEF-003).
+
+---
+
+### 2. **Type-Safe Utility Functions**
+**File:** `src/utils/debug.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+export function debugTap<T>(context: string, label: string): (value: T) => T {
+  return (value: T) => {
+    if (isDev) {
+      console.log(`${context} ${label}:`, value);
+    }
+    return value;
+  };
+}
+```
+
+**Why it's good:** Generic type preservation, production-safe (stripped in production).
+
+---
+
+### 3. **Graceful Fallbacks**
+**File:** `src/utils/idGenerator.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+if (crypto?.randomUUID) {
+  return crypto.randomUUID();
+}
+// Fallback: timestamp + random (simulated UUID-ish)
+```
+
+**Why it's good:** Progressive enhancement with fallback for older browsers.
+
+---
+
+### 4. **Comprehensive Error Handling**
+**File:** `src/utils/soundStorage.ts`
+**Score:** ⭐⭐⭐⭐⭐
+
+```typescript
+export async function storeCustomSound(
+  tournamentId: string,
+  file: File
+): Promise<{ success: boolean; error?: string }> {
+  const validation = validateAudioFile(file);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+  // ... with try-catch and proper error messages
+}
+```
+
+**Why it's good:** Structured error responses, validation before processing.
+
+---
+
+## 🛠 Refactoring Recommendations (Prioritized)
+
+### **Priority 1: Critical (Fix Immediately)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 1 | Team ID/Name matching ambiguity | 2h | 🔴 High |
+| 2 | Add Zod validation for JSON imports | 3h | 🔴 High |
+| 3 | Remove dead code & comments | 1h | 🟡 Medium |
+
+### **Priority 2: High (Next Sprint)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 4 | Optimize FairnessCalculator for 128+ teams | 8h | 🟡 Medium |
+| 5 | Standardize naming convention (German/English) | 4h | 🟢 Low |
+| 6 | Replace magic numbers with constants | 2h | 🟢 Low |
+
+### **Priority 3: Medium (Backlog)**
+
+| # | Issue | Effort | Impact |
+|---|-------|--------|--------|
+| 7 | Add TypeScript strict mode flags | 4h | 🟡 Medium |
+| 8 | Improve ESLint rule configuration | 2h | 🟢 Low |
+| 9 | Add integration tests for scheduler | 6h | 🟡 Medium |
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Category | Score | Notes |
+|----------|-------|-------|
+| **Type Safety** | 8.2/10 | Strong typing, some `as` casts |
+| **Test Coverage** | 8.5/10 | Excellent edge case coverage |
+| **Performance** | 7.0/10 | O(n²) scheduler needs optimization |
+| **Maintainability** | 7.5/10 | Good structure, some naming issues |
+| **Error Handling** | 8.0/10 | Comprehensive, structured errors |
+| **Documentation** | 8.0/10 | Good JSDoc, some TODOs |
+| **Security** | 7.5/10 | Input validation present, could be stricter |
+
+---
+
+## 🎯 Action Items
+
+### Immediate (This Week)
+```bash
+# 1. Fix team matching ambiguity
+# 2. Add Zod validation for imports
+# 3. Clean up dead code
+```
+
+### Short-term (Next Sprint)
+```bash
+# 4. Optimize scheduler performance
+# 5. Standardize naming conventions
+# 6. Add performance benchmarks
+```
+
+### Long-term (Next Quarter)
+```bash
+# 7. Implement TypeScript strict mode
+# 8. Add integration test suite
+# 9. Performance monitoring setup
+```
+
+---
+
+## 📋 Summary
+
+**Strengths:**
+- ✅ Excellent test coverage with edge cases
+- ✅ Strong type safety overall
+- ✅ Good error handling patterns
+- ✅ Comprehensive documentation
+
+**Weaknesses:**
+- ⚠️ Team ID/name matching ambiguity
+- ⚠️ Performance issues with large tournaments
+- ⚠️ Some dead code and magic numbers
+- ⚠️ Naming convention inconsistencies
+
+**Overall Assessment:** The codebase is **production-ready** with solid foundations. The identified issues are mostly optimizations rather than blockers. Focus on Priority 1 items before scaling to larger tournaments.
+
+---
+
+*Report generated by Senior TypeScript/React Developer Review*
+*Date: 2024-01-XX*
+*Project: hallenfussball-pwa (626 files, ~24,000 LOC)*

--- a/reviews/2026-03-16_1935_components_ui.md
+++ b/reviews/2026-03-16_1935_components_ui.md
@@ -1,0 +1,294 @@
+# Code Review: UI-Komponenten & Design System
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 50.0s  
+**Status:** success  
+**Code-Kontext:** 147,788 Zeichen  
+
+<details><summary>Thinking Process (8,541 Zeichen)</summary>
+
+Der Nutzer möchte ein strukturiertes UI-Komponenten-Review für das Projekt "hallenfussball-pwa". Ich habe den Code analysiert und muss nun die Ergebnisse in der geforderten Struktur präsentieren.
+
+**Analyse der Komponenten:**
+
+1.  **ActionMenu:**
+    *   **Inkonsistenzen:** `visible`-Prop führt zu `return null` nach Hooks (React Rules of Hooks Verletzung). Inline-Styles für Hover-Zustände (`onMouseEnter`/`onMouseLeave`) sind fehleranfällig und schwer zu warten.
+    *   **Accessibility:** `aria-label` ist statisch ("Aktionen"), sollte dynamisch sein. `role="menu"` und `role="menuitem"` sind gesetzt, aber Keyboard-Navigation (Pfeiltasten im Menü) fehlt komplett.
+    *   **Design Tokens:** `cssVars` wird genutzt, aber `zIndex` ist hardcodiert (1100).
+    *   **Verbesserung:** Hooks vor `visible`-Check verschieben. Keyboard-Navigation implementieren.
+
+2.  **BottomActionBar:**
+    *   **Inkonsistenzen:** `zIndex` (100) ist niedriger als `BottomNavigation` (1000), aber der Kommentar sagt "Below modals but above content". Das ist verwirrend.
+    *   **Accessibility:** Buttons haben keine `aria-label` oder `aria-disabled` (obwohl `disabled`-Prop existiert).
+    *   **Design Tokens:** `layoutHeights.bottomActionBar` wird genutzt (gut).
+    *   **Verbesserung:** `aria-disabled` auf Buttons setzen.
+
+3.  **BottomNavigation:**
+    *   **Inkonsistenzen:** `activeTab` Typ ist `string`, aber Props erwarten `BottomNavTab`.
+    *   **Accessibility:** `aria-current="page"` ist gut gesetzt. Touch-Targets sind 44px (gut).
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Typisierung von `activeTab` verschärfen.
+
+4.  **BottomSheet:**
+    *   **Inkonsistenzen:** `useFocusTrap` Hook wird genutzt, aber `containerRef` wird nicht an das Sheet-Element gebunden (es wird `ref={focusTrap.containerRef}` verwendet, aber das Element ist ein `div`, kein `dialog`).
+    *   **Accessibility:** `role="dialog"` und `aria-modal="true"` sind gesetzt. `aria-labelledby` wird dynamisch generiert (gut).
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `ref`-Handling prüfen.
+
+5.  **Button:**
+    *   **Inkonsistenzen:** `pressEffect` ist standardmäßig `true`, aber `prefersReducedMotion` wird geprüft. Das ist gut.
+    *   **Accessibility:** `aria-label` ist optional, aber für Icon-only Buttons erforderlich. `aria-busy` für Loading ist gut.
+    *   **Design Tokens:** `cssVars` und `transitions` werden genutzt.
+    *   **Verbesserung:** `aria-label` als required markieren, wenn `icon` vorhanden und `children` fehlt.
+
+6.  **Card:**
+    *   **Inkonsistenzen:** `onClick` ist vorhanden, aber `role="button"` und `tabIndex` fehlen.
+    *   **Accessibility:** Wenn klickbar, muss es ein Button sein oder `role="button"` + `tabIndex="0"` + `onKeyDown` haben.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Klickbare Cards sollten semantisch korrekte Buttons sein oder ARIA-Attribute erhalten.
+
+7.  **CollapsibleInfoPanel / CollapsibleSection:**
+    *   **Inkonsistenzen:** `role="button"` auf einem `div` mit `onClick`.
+    *   **Accessibility:** `aria-expanded` und `aria-controls` sind gut gesetzt. `onKeyDown` für Enter/Space ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Semantisch korrekter wäre ein `<button>` für den Header.
+
+8.  **ColorPicker:**
+    *   **Inkonsistenzen:** `HexColorPicker` von `react-colorful` wird genutzt.
+    *   **Accessibility:** `role="dialog"` auf dem Dropdown. `aria-label` ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keyboard-Navigation für Presets fehlt.
+
+9.  **Combobox:**
+    *   **Inkonsistenzen:** `role="combobox"` und `role="listbox"` sind gesetzt.
+    *   **Accessibility:** `aria-expanded`, `aria-haspopup`, `aria-invalid` sind vorhanden. `highlightedIndex` für Keyboard-Navigation ist implementiert.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `aria-activedescendant` fehlt für die Highlighted Option.
+
+10. **ConfirmDialog:**
+    *   **Inkonsistenzen:** `isOpen` default ist `true`, was zu einem sofortigen Render führt.
+    *   **Accessibility:** `role="dialog"`, `aria-modal="true"`, `aria-labelledby` sind gesetzt. Focus-Trap ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `isOpen` default auf `false` setzen.
+
+11. **ConnectionStatusBar:**
+    *   **Inkonsistenzen:** `RefreshIcon` ist inline definiert.
+    *   **Accessibility:** `title` auf Button ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `aria-label` auf Button statt `title`.
+
+12. **FieldDisplay / GroupDisplay:**
+    *   **Inkonsistenzen:** `variant` Props sind gut.
+    *   **Accessibility:** Keine speziellen Anforderungen, da reine Text-Anzeige.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+13. **Icons:**
+    *   **Inkonsistenzen:** SVGs sind inline.
+    *   **Accessibility:** `aria-hidden="true"` fehlt oft, wenn `color` und `size` Props genutzt werden.
+    *   **Design Tokens:** `currentColor` wird genutzt (gut).
+    *   **Verbesserung:** `aria-hidden` standardmäßig setzen.
+
+14. **Input:**
+    *   **Inkonsistenzen:** `useId` wird für `aria-describedby` genutzt (gut).
+    *   **Accessibility:** `aria-invalid`, `aria-describedby` sind vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `minHeight` für Touch-Targets prüfen.
+
+15. **LogoUploadDialog:**
+    *   **Inkonsistenzen:** `dropZone` hat `onClick`, aber kein `role="button"`.
+    *   **Accessibility:** `aria-label` auf Close-Button ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** DropZone sollte `role="button"` und `tabIndex` haben.
+
+16. **NumberStepper:**
+    *   **Inkonsistenzen:** `mode` Props sind gut.
+    *   **Accessibility:** `aria-label` auf Buttons ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `aria-valuenow` auf dem Display-Element.
+
+17. **PasswordInput:**
+    *   **Inkonsistenzen:** `tabIndex={-1}` auf Toggle-Button (falsch, sollte fokussierbar sein).
+    *   **Accessibility:** `aria-label` ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `tabIndex` entfernen.
+
+18. **ProgressRing:**
+    *   **Inkonsistenzen:** `aria-valuenow` ist vorhanden.
+    *   **Accessibility:** `role="button"` wenn klickbar.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+19. **PublicBottomNav:**
+    *   **Inkonsistenzen:** Ähnlich wie `BottomNavigation`.
+    *   **Accessibility:** `aria-current` ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+20. **ScoreStepper:**
+    *   **Inkonsistenzen:** `aria-label` auf Buttons ist vorhanden.
+    *   **Accessibility:** `aria-live="polite"` auf Wert-Display (gut).
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+21. **Select:**
+    *   **Inkonsistenzen:** Native `<select>` wird genutzt.
+    *   **Accessibility:** `aria-invalid` ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+22. **Skeleton:**
+    *   **Inkonsistenzen:** `role="status"`, `aria-busy="true"` sind vorhanden (gut).
+    *   **Accessibility:** `aria-label` ist vorhanden.
+    *   **Design Tokens:** CSS-Variablen werden genutzt.
+    *   **Verbesserung:** Keine.
+
+23. **SyncIndicator:**
+    *   **Inkonsistenzen:** `variant` Props sind gut.
+    *   **Accessibility:** `title` auf Compact-Indicator (sollte `aria-label` sein).
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** `aria-label` statt `title`.
+
+24. **TeamAvatar:**
+    *   **Inkonsistenzen:** `alt`-Text ist dynamisch (gut).
+    *   **Accessibility:** `alt`-Text ist vorhanden.
+    *   **Design Tokens:** `cssVars` wird genutzt.
+    *   **Verbesserung:** Keine.
+
+25. **Toast:**
+    *   **Inkonsistenzen:** `role="alert"`, `aria-live="polite"` sind vorhanden.
+    *   **Accessibility:** `aria-label` auf Dismiss-Button ist vorhanden.
+    *   **Design Tokens:** CSS-Variablen werden genutzt.
+    *   **Verbesserung:** Keine.
+
+**Zusammenfassung:**
+Das Design-System ist gut durchdacht (`cssVars`), aber es gibt einige Accessibility-Lücken (Keyboard-Navigation, semantische HTML-Elemente) und Konsistenzprobleme (Inline-Styles vs. CSS-Classes, `zIndex` Hardcoding).
+
+**UI Component Score:** 7/10
+
+
+</details>
+
+---
+
+
+
+# UI-Komponenten-Review: hallenfussball-pwa
+
+## Executive Summary
+Das Design-System ist **konsistent aufgebaut** und nutzt Design Tokens (`cssVars`) effektiv. Die Komponenten sind **mobile-first** konzipiert (Touch-Targets, Bottom Navigation). Allerdings gibt es signifikante **Accessibility-Lücken** (fehlende Keyboard-Navigation, semantische Fehler) und **Inkonsistenzen** in der Implementierung (Inline-Styles vs. CSS-Classes, Hooks-Regeln).
+
+---
+
+## 1. Design-Token-Verstöße & Konsistenz
+
+### 🔴 Hardcodierte Werte
+- **`ActionMenu`**: `zIndex: 1100` ist hardcodiert. Sollte ein Token sein (z.B. `zIndex.dropdown`).
+- **`BottomNavigation`**: `zIndex: 1000` ist hardcodiert.
+- **`ConfirmDialog`**: `zIndex: 10000` ist hardcodiert.
+- **`ToastContainer`**: `bottom: 24, right: 24` sind hardcodierte Pixel-Werte.
+
+### 🟡 Inline-Styles vs. CSS-Classes
+- **`ActionMenu`**: `onMouseEnter`/`onMouseLeave` manipulieren direkt `e.currentTarget.style`. Das ist **anti-pattern** für React (Performance, State-Management).
+- **`Button`**: Nutzt `transitions` aus `styles/motion`, aber andere Komponenten nutzen Inline-Transition-Strings.
+- **`Skeleton`**: Nutzt CSS-Module (`Skeleton.module.css`), was **besser** ist als Inline-Styles.
+
+### 🟢 Positive Beispiele
+- **`Input`**, **`Select`**, **`Combobox`**: Nutzen konsistent `cssVars` für Farben, Abstände und Typografie.
+- **`TeamAvatar`**: Nutzt `AVATAR_SIZES` Objekt für konsistente Größen.
+
+---
+
+## 2. Accessibility-Verstöße (WCAG 2.1 AA)
+
+### 🔴 Kritische Verstöße
+| Komponente | Problem | WCAG Kriterium |
+|------------|---------|----------------|
+| **ActionMenu** | Keine Pfeiltasten-Navigation im Menü (nur Escape zum Schließen). | 2.1.1 Keyboard |
+| **Card** | `onClick` auf `div` ohne `role="button"` und `tabIndex="0"`. | 4.1.2 Name, Role, Value |
+| **CollapsibleInfoPanel** | `role="button"` auf `div` statt semantischem `<button>`. | 4.1.2 Name, Role, Value |
+| **PasswordInput** | `tabIndex={-1}` auf Toggle-Button (nicht fokussierbar). | 2.1.1 Keyboard |
+| **LogoUploadDialog** | DropZone hat `onClick` aber keine Keyboard-Interaktion. | 2.1.1 Keyboard |
+
+### 🟡 Mäßige Verstöße
+| Komponente | Problem | WCAG Kriterium |
+|------------|---------|----------------|
+| **ActionMenu** | `aria-label="Aktionen"` ist statisch, sollte kontextabhängig sein. | 1.3.1 Info and Relationships |
+| **Combobox** | `aria-activedescendant` fehlt für die hervorgehobene Option. | 1.3.1 Info and Relationships |
+| **SyncIndicator** | `title` statt `aria-label` auf Compact-Indicator. | 1.1.1 Non-text Content |
+| **ConfirmDialog** | `isOpen` default ist `true` (Dialog erscheint sofort beim Import). | 2.4.3 Focus Order |
+| **ConnectionStatusBar** | `title` statt `aria-label` auf Refresh-Button. | 1.1.1 Non-text Content |
+
+### 🟢 Positive Beispiele
+- **Skeleton**: `role="status"`, `aria-busy="true"` korrekt gesetzt.
+- **Toast**: `role="alert"`, `aria-live="polite"` korrekt gesetzt.
+- **Input**: `aria-invalid`, `aria-describedby` korrekt gesetzt.
+- **BottomNavigation**: `aria-current="page"` korrekt gesetzt.
+
+---
+
+## 3. Inkonsistenzen & Code-Qualität
+
+### 🔴 React Hooks Rules
+- **`ActionMenu`**: `if (!visible) return null;` **nach** `useEffect` und `useCallback`. Das verletzt die **Rules of Hooks**. Hooks müssen immer in der gleichen Reihenfolge aufgerufen werden.
+
+### 🟡 Typisierung
+- **`BottomNavigation`**: `activeTab` Prop ist `string`, aber `onTabChange` erwartet `BottomNavTab`.
+- **`ConfirmDialog`**: `isOpen` default ist `true`, was zu unerwartetem Verhalten führt.
+- **`Icons`**: `Icons` Objekt ist nicht typisiert (keine TypeScript-Interface für `Icons` Keys).
+
+### 🟡 State-Management
+- **`ActionMenu`**: `isHovered` State in `ActionMenuItemButton` ist unnötig, da `:hover` CSS ausreicht.
+- **`Button`**: `isPressed` State für Press-Effekt ist gut, aber `prefersReducedMotion` wird in `useEffect` geprüft (sollte `matchMedia` direkt sein).
+
+### 🟢 Positive Beispiele
+- **`useId`**: Wird in `Input`, `BottomSheet`, `CollapsibleInfoPanel` korrekt für `aria-describedby`/`aria-labelledby` genutzt.
+- **`Skeleton`**: `SkeletonPresets` Objekt für wiederverwendbare Konfigurationen.
+
+---
+
+## 4. Verbesserungsvorschläge
+
+### 🔴 Priorität 1 (Accessibility & Bugs)
+1. **`ActionMenu`**:
+   - Hooks vor `visible`-Check verschieben.
+   - Keyboard-Navigation (Pfeiltasten) implementieren.
+   - `aria-label` dynamisch machen.
+2. **`Card`**:
+   - Wenn klickbar: `<button>` statt `<div>` oder `role="button"` + `tabIndex="0"` + `onKeyDown`.
+3. **`PasswordInput`**:
+   - `tabIndex={-1}` entfernen.
+4. **`CollapsibleInfoPanel`**:
+   - Header als `<button>` statt `<div>` mit `role="button"`.
+
+### 🟡 Priorität 2 (Konsistenz)
+1. **Design Tokens**:
+   - `zIndex` Werte in `design-tokens` auslagern (z.B. `zIndex.dropdown = 1100`).
+   - `ToastContainer` Positionierung in Tokens auslagern.
+2. **Inline-Styles**:
+   - `ActionMenu` Hover-Effekte in CSS-Classes auslagern.
+   - `Button` Press-Effekt in CSS-Classes auslagern.
+3. **Typisierung**:
+   - `BottomNavigation` `activeTab` Typisierung verschärfen.
+   - `Icons` Objekt typisieren.
+
+### 🟢 Priorität 3 (Optimierung)
+1. **`ActionMenu`**: `isHovered` State entfernen, CSS `:hover` nutzen.
+2. **`Button`**: `prefersReducedMotion` direkt in `useEffect` initialisieren.
+3. **`ConfirmDialog`**: `isOpen` default auf `false` setzen.
+
+---
+
+## 5. UI Component Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Design System** | 8/10 | Konsistente Nutzung von `cssVars`, aber einige Hardcodierungen. |
+| **Accessibility** | 5/10 | Viele kritische Verstöße (Keyboard, semantische HTML). |
+| **Code Quality** | 7/10 | Gute Typisierung, aber Hooks-Regeln werden verletzt. |
+| **Mobile UX** | 9/10 | Touch-Targets, Bottom Navigation, Safe Areas sind gut umgesetzt. |
+| **Performance** | 7/10 | Inline-Styles und State-Management könnten optimiert werden. |
+
+### **Gesamtscore: 7/10**
+
+**Fazit**: Das UI-System ist **funktional und mobile-optimiert**, aber **Accessibility muss dringend verbessert werden**. Die Hooks-Verletzung in `ActionMenu` ist ein kritischer Bug, der zu unerwartetem Verhalten führen kann. Die Konsistenz zwischen Inline-Styles und CSS-Classes sollte vereinheitlicht werden.

--- a/reviews/2026-03-16_1935_export_output.md
+++ b/reviews/2026-03-16_1935_export_output.md
@@ -1,0 +1,322 @@
+# Code Review: PDF-Export, Sharing & Datenausgabe
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 29.7s  
+**Status:** success  
+**Code-Kontext:** 150,414 Zeichen  
+
+<details><summary>Thinking Process (2,091 Zeichen)</summary>
+
+Der Benutzer bittet um ein strukturiertes Code-Review mit Fokus auf PDF-Export, Sharing und Datenausgabe. Ich muss die bereitgestellten Code-Snippets analysieren und ein Review mit den geforderten Kategorien erstellen.
+
+Lass mich die relevanten Teile identifizieren:
+
+1. **PDF-Export**: `PDFExportDialog.tsx` - zeigt Export-Optionen, ruft `exportScheduleToPDF` auf
+2. **Sharing**: `ScheduleActionButtons.tsx` - zeigt Share-Dialog, `ShareDialog` wird importiert
+3. **Import/Export Daten**: `ImportDialog.tsx`, `ImportSteps.tsx`, `ImportTemplates.ts` - JSON/CSV Import
+4. **Schedule Display**: `ScheduleDisplay.tsx` - zeigt Spielplan, aber kein direkter Export-Code
+5. **Kein direkter PDF-Export-Code** in den Snippets - `exportScheduleToPDF` wird nur aufgerufen, Implementation nicht gezeigt
+
+Probleme die ich sehe:
+
+1. **PDF-Export Bugs**:
+   - Keine Fehlerbehandlung für jsPDF-Generierung (nur try/catch im Dialog)
+   - Keine Fallback-Logik wenn PDF-Generierung fehlschlägt
+   - Umlaute/Zeichensatz-Probleme nicht sichtbar (jsPDF benötigt spezielle Font-Handling)
+   - Layout-Probleme bei langen Team-Namen nicht behandelt
+   - Keine Druckvorschau vor Export
+
+2. **Fehlende Export-Formate**:
+   - Nur PDF (kein CSV, Excel, JSON Export)
+   - Kein Print-Layout (@media print)
+   - Kein QR-Code für direkten Zugriff auf Live-Ergebnisse
+   - Keine API-Endpunkte für automatisierten Export
+
+3. **Sharing-UX-Probleme**:
+   - ShareDialog Implementation nicht sichtbar (nur Import)
+   - Keine Deep-Links für spezifische Turniere
+   - Keine QR-Code Generierung für Monitor-Ansicht
+   - Keine Copy-to-Clipboard Funktion für Links
+   - Keine Web Share API Nutzung (native Sharing auf Mobile)
+
+4. **Positive Patterns**:
+   - Dialog-basierter Export mit Optionen (Scores, Standings)
+   - Import/Export Templates (JSON, CSV)
+   - Error Handling im Dialog
+   - Loading States (isGenerating)
+   - i18n Integration
+
+5. **Export Score**: 6/10 - Grundfunktionen da, aber viele Lücken bei Sharing, Print, und Fehlerbehandlung
+
+Ich sollte das Review strukturiert aufbauen mit konkreten Beispielen aus dem Code.
+
+
+</details>
+
+---
+
+
+
+# Code Review: PDF-Export, Sharing & Datenausgabe
+
+## 📊 Export Score: **6/10**
+
+---
+
+## 🔴 Export-Bugs
+
+### 1. **PDF-Generierung ohne Font-Handling**
+```tsx
+// src/components/dialogs/PDFExportDialog.tsx
+await exportScheduleToPDF(updatedSchedule, includeStandings ? standings : undefined, {
+  locale: 'de',
+  includeScores,
+  includeStandings,
+  ...(tournament.organizer?.trim() ? { organizerName: tournament.organizer } : {}),
+  hallName: getLocationName(tournament),
+});
+```
+
+**Problem**: `exportScheduleToPDF` Implementation nicht im Code sichtbar. Bei jsPDF sind Umlaute (ä, ö, ü, ß) und Sonderzeichen ohne Font-Embedding **nicht darstellbar**.
+
+**Risiko**: PDF-Export bricht bei deutschen Team-Namen oder Orten mit Umlauten.
+
+**Empfehlung**:
+```ts
+// In pdfExporter.ts
+import { FontLoader } from 'jspdf';
+const pdf = new jsPDF();
+pdf.addFont('DejaVuSans.ttf', 'DejaVuSans', 'normal');
+pdf.setFont('DejaVuSans');
+```
+
+### 2. **Keine Fehlerbehandlung bei PDF-Generierung**
+```tsx
+try {
+  await exportScheduleToPDF(...);
+  setTimeout(() => { onClose(); setIsGenerating(false); }, 500);
+} catch (err) {
+  console.error('PDF generation failed:', err);
+  setError(t('pdfExport.error'));
+  setIsGenerating(false);
+}
+```
+
+**Problem**: Fehler wird nur im Dialog angezeigt, kein Fallback (z.B. Browser-Print).
+
+**Empfehlung**:
+```tsx
+catch (err) {
+  console.error('PDF generation failed:', err);
+  setError(t('pdfExport.error'));
+  setIsGenerating(false);
+  // Fallback: Browser-Print
+  if (confirm('PDF-Generierung fehlgeschlagen. Browser-Druck verwenden?')) {
+    window.print();
+  }
+}
+```
+
+### 3. **Keine Layout-Validierung vor Export**
+- Lange Team-Namen werden nicht abgeschnitten
+- Keine Prüfung ob alle Daten für PDF verfügbar sind
+- Keine Seitenbreiten-Validierung
+
+---
+
+## 🟡 Fehlende Export-Formate
+
+| Format | Status | Priorität |
+|--------|--------|-----------|
+| PDF | ✅ Implementiert | - |
+| CSV | ❌ Nur Import | Hoch |
+| Excel (.xlsx) | ❌ Nicht vorhanden | Mittel |
+| JSON Export | ❌ Nur Import | Mittel |
+| Print-Layout | ❌ Kein @media print | Hoch |
+| QR-Code Export | ❌ Nicht vorhanden | Mittel |
+
+**Empfehlung**:
+```tsx
+// Export-Dialog erweitern
+const exportFormats = [
+  { id: 'pdf', label: 'PDF', icon: <Icons.Download /> },
+  { id: 'csv', label: 'CSV', icon: <Icons.Table /> },
+  { id: 'json', label: 'JSON', icon: <Icons.Code /> },
+  { id: 'print', label: 'Drucken', icon: <Icons.Printer /> },
+];
+```
+
+---
+
+## 🟠 Sharing-UX-Probleme
+
+### 1. **ShareDialog Implementation nicht sichtbar**
+```tsx
+// src/components/ScheduleActionButtons.tsx
+<ShareDialog
+  isOpen={showShareDialog}
+  onClose={() => setShowShareDialog(false)}
+  tournamentId={tournament.id}
+  tournamentTitle={tournament.title}
+  shareCode={tournament.shareCode}
+  isPublic={tournament.isPublic}
+/>
+```
+
+**Problem**: `ShareDialog` nicht im Code. Unklar ob:
+- Web Share API genutzt wird (native Mobile Sharing)
+- QR-Code generiert wird
+- Deep-Links funktionieren
+
+**Empfehlung**:
+```tsx
+// Web Share API mit Fallback
+const handleShare = async () => {
+  const shareData = {
+    title: tournament.title,
+    text: `Schau dir das Turnier an: ${tournament.title}`,
+    url: `${window.location.origin}/t/${tournament.shareCode}`,
+  };
+
+  if (navigator.share) {
+    await navigator.share(shareData);
+  } else {
+    // Fallback: Copy to Clipboard
+    await navigator.clipboard.writeText(shareData.url);
+    showSuccess(t('share.copied'));
+  }
+};
+```
+
+### 2. **Keine Monitor-URL für öffentliche Anzeigetafel**
+- Keine separate `monitor`-Route sichtbar
+- Keine QR-Code Generierung für Live-Tracking
+- Keine Deep-Links zu spezifischen Spielen
+
+**Empfehlung**:
+```tsx
+// Monitor-URL generieren
+const monitorUrl = `${window.location.origin}/monitor/${tournament.shareCode}`;
+const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(monitorUrl)}`;
+```
+
+### 3. **Keine Copy-to-Clipboard für Links**
+- Turnier-Link kann nicht kopiert werden
+- Keine "Link teilen"-Funktion
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Dialog-basierter Export mit Optionen**
+```tsx
+// PDFExportDialog.tsx
+const [includeScores, setIncludeScores] = useState(hasScores);
+const [includeStandings, setIncludeStandings] = useState(true);
+```
+- Nutzer kann wählen ob Ergebnisse/Tabellen enthalten sein sollen
+- Loading State (`isGenerating`) verhindert Mehrfachklicks
+- Error Handling mit Benutzer-Feedback
+
+### 2. **Import/Export Templates**
+```tsx
+// ImportTemplates.ts
+export const JSON_TEMPLATE = { ... };
+export const CSV_TEMPLATE = `Team,Gruppe\n...`;
+export const downloadTemplate = (type: 'json' | 'csv') => { ... };
+```
+- Vorlagen für Import
+- CSV und JSON unterstützt
+- Template-Download als Button
+
+### 3. **i18n Integration**
+```tsx
+const { t } = useTranslation('tournament');
+title={t('pdfExport.title')}
+```
+- Alle Export-Labels übersetzbar
+- Konsistente UX über Sprachen
+
+### 4. **Responsive Action Buttons**
+```tsx
+// ScheduleActionButtons.tsx
+const fabContainerStyle: CSSProperties = {
+  position: 'fixed',
+  bottom: `calc(${layoutHeights.bottomNav} + ${cssVars.spacing.lg} + env(safe-area-inset-bottom, 0px))`,
+  right: cssVars.spacing.lg,
+  zIndex: 100,
+};
+```
+- Mobile FAB-Buttons
+- Desktop normale Buttons
+- Safe-Area-Handling für iOS
+
+---
+
+## 📋 Empfehlungen (Priorisiert)
+
+### **High Priority**
+1. **PDF Font-Embedding für Umlaute**
+   - DejaVu Sans oder Roboto Font in jsPDF integrieren
+   - Test mit Team-Namen wie "TSV München 1860"
+
+2. **Print-Layout (@media print)**
+   ```css
+   @media print {
+     .schedule-display {
+       page-break-after: always;
+     }
+     .no-print {
+       display: none;
+     }
+   }
+   ```
+
+3. **Web Share API mit Fallback**
+   - Native Sharing auf Mobile
+   - Clipboard-Fallback auf Desktop
+
+### **Medium Priority**
+4. **CSV Export (nicht nur Import)**
+   - Export von Spielplan und Tabellen
+   - Download als Blob
+
+5. **QR-Code für Monitor-URL**
+   - Generiere QR-Code für öffentliche Anzeigetafel
+   - In PDF und Share-Dialog integrieren
+
+6. **Deep-Links zu Spielen**
+   - `/tournament/:shareCode/match/:matchId`
+   - Für Live-Tracking und Korrektur
+
+### **Low Priority**
+7. **Excel Export (.xlsx)**
+   - Für Organiser mit komplexen Daten
+   - Bibliothek: `xlsx` oder `exceljs`
+
+8. **Export History**
+   - Letzten Export speichern
+   - "Neu generieren" vs. "Letzte Version herunterladen"
+
+---
+
+## 🎯 Fazit
+
+**Stärken**:
+- Dialog-basierter Export mit Optionen
+- Import/Export Templates vorhanden
+- Responsive UI für Mobile/Desktop
+
+**Schwächen**:
+- PDF-Generierung ohne Font-Handling (kritisch!)
+- Keine Print-Layouts
+- Sharing-Funktionen unklar (Dialog nicht sichtbar)
+- Keine CSV/JSON Exporte
+
+**Nächste Schritte**:
+1. `exportScheduleToPDF` Implementation prüfen (Font-Handling)
+2. Print-Stylesheets hinzufügen
+3. ShareDialog mit Web Share API implementieren
+4. CSV Export hinzufügen
+
+**Export Score: 6/10** - Grundfunktionen vorhanden, aber kritische Lücken bei Umlauten und Sharing.

--- a/reviews/2026-03-16_1935_hooks_state.md
+++ b/reviews/2026-03-16_1935_hooks_state.md
@@ -1,0 +1,371 @@
+# Code Review: Hooks, State & Context
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 102.7s  
+**Status:** success  
+**Code-Kontext:** 147,996 Zeichen  
+
+<details><summary>Thinking Process (12,184 Zeichen)</summary>
+
+The user wants a code review focused on React Hooks and State Management for a large-scale PWA project (Hallenfussball-PWA).
+
+I need to analyze the provided code snippets (Hooks and Contexts) and evaluate them based on specific criteria:
+1.  **Re-Render Problems**: Unnecessary renders due to bad dependency arrays or object creation.
+2.  **Memory Leaks**: Missing cleanup in `useEffect` (timers, listeners, subscriptions).
+3.  **Anti-Patterns**: Violations of Rules of Hooks, "God Hooks", excessive nesting.
+4.  **Positive Patterns**: Good practices observed.
+5.  **State Management Score**: A rating from 1-10.
+
+**Code Analysis:**
+
+1.  **`useMatchTimer` / `useMatchTimerExtended`**:
+    *   Uses `requestAnimationFrame` inside `useEffect`.
+    *   Cleanup: `cancelAnimationFrame` is called in the return function.
+    *   Dependencies: `timerStartTime`, `baseElapsedSeconds`, `status`.
+    *   Issue: `useMatchTimerExtended` calculates `result` via `useMemo` inside the component body but the `useEffect` updates state (`setElapsedSeconds`). This is standard.
+    *   Potential Issue: `useMatchTimerExtended` creates a new `MatchTimerResult` object every time `elapsedSeconds` changes (inside `useMemo`). This is fine for the consumer, but if this hook is used in a list, it might cause re-renders if the reference changes. However, since it returns a new object anyway, it's expected.
+    *   `useMatchTimer` (deprecated) uses `setInterval` logic via `requestAnimationFrame` loop.
+    *   **Memory Leak Risk**: In `useMatchTimerExtended`, the `updateTimer` function captures `startTime` and `lastUpdateRef`. The cleanup cancels the frame. This looks safe.
+    *   **Re-renders**: The hook returns a new object every second. If used in a component that doesn't memoize its children, it will trigger re-renders. This is expected for a timer.
+
+2.  **`useMonitorTheme`**:
+    *   Uses `window.matchMedia`.
+    *   Cleanup: `removeEventListener` is present.
+    *   State: `systemPrefersDark`.
+    *   **Issue**: `monitorThemes[resolvedTheme]` is accessed directly. If `monitorThemes` is a constant object, this is fine. If it's dynamic, it might be recreated. Assuming it's a constant import.
+    *   **Re-renders**: Returns a new object `{ resolvedTheme, themeColors }` on every render where `theme` or `systemPrefersDark` changes. This is standard.
+
+3.  **`useAuthTimeoutToast`**:
+    *   Uses `useEffect` to check `sessionStorage`.
+    *   **Issue**: `showWarning` from `useToast` is in the dependency array. If `showWarning` is not stable (memoized in ToastContext), this effect runs on every render.
+    *   **Memory Leak**: None obvious.
+
+4.  **`useAutoSave`**:
+    *   Uses `setInterval` for periodic save.
+    *   Cleanup: `clearInterval` is present.
+    *   Dependencies: `hasUnsavedChanges`, `saveAsDraft`, `autoSaveInterval`.
+    *   **Issue**: `hasUnsavedChanges` is a `useCallback` but depends on `formData` and `lastSavedDataRef`. `lastSavedDataRef` is a ref object. If the ref object identity changes (it shouldn't if passed from parent), it's fine. However, `JSON.stringify(formData)` inside `hasUnsavedChanges` can be expensive if `formData` is large.
+    *   **Re-renders**: `saveAsDraft` depends on `hasUnsavedChanges`, `formData`, etc. If `formData` changes often, `saveAsDraft` changes, causing the `useEffect` interval to reset. This is actually good for correctness but might cause flickering if the interval resets constantly.
+    *   **Memory Leak**: `beforeunload` listener is cleaned up.
+
+5.  **`useBreakpoint`**:
+    *   Uses `window.addEventListener('resize')`.
+    *   Cleanup: `removeEventListener`.
+    *   **Issue**: `useState` initialized with `window.innerWidth`. SSR safety check `typeof window !== 'undefined'`.
+    *   **Re-renders**: Updates on every resize. This is expected.
+    *   **Optimization**: Could use `ResizeObserver` for specific elements, but `window` resize is fine for global breakpoints.
+
+6.  **`useClickOutside`**:
+    *   Standard implementation.
+    *   Cleanup: `removeEventListener`.
+    *   **Issue**: `handler` in dependency array. If `handler` is not memoized in the parent, the listener is removed and re-added constantly. This is a common anti-pattern.
+    *   **Fix**: Use `useCallback` in parent or `useRef` for handler inside hook (like `useDialogTimer` does).
+
+7.  **`useCorporateColors`**:
+    *   Complex hook with async `loadTheme`.
+    *   **Issue**: `applyPreset` and `applyCustomColors` update `currentConfig` state and call `updateProfile`.
+    *   **Re-renders**: `colors` is memoized. `applyPreset` is memoized.
+    *   **Memory Leak**: None obvious.
+    *   **State**: Uses `useState` for `currentConfig`.
+
+8.  **`useDebounce`**:
+    *   Standard `setTimeout` cleanup.
+    *   **Issue**: `delay` in dependency array. If `delay` changes, timer resets. This is correct behavior.
+
+9.  **`useDialogTimer`**:
+    *   Uses `setInterval`.
+    *   Cleanup: `clearInterval`.
+    *   **Issue**: `onExpire` is stored in a ref to avoid stale closures. This is a **Positive Pattern**.
+    *   **Re-renders**: `isActive` and `paused` in dependency array for the main effect.
+
+10. **`useFields`**:
+    *   Purely derived state from `tournament` prop.
+    *   **Issue**: `updateField` creates a new `Tournament` object.
+    *   **Re-renders**: `fields` is memoized based on `tournament?.fields`.
+
+11. **`useFocusTrap`**:
+    *   Uses `useEffect` for `keydown` listener.
+    *   Cleanup: `removeEventListener`.
+    *   **Issue**: `containerRef` is returned.
+    *   **Memory Leak**: `inertElements` array is tracked and removed in cleanup. Good.
+
+12. **`useFontScale`**:
+    *   Uses `localStorage`.
+    *   **Issue**: `applyScale` modifies `document.documentElement`.
+    *   **Re-renders**: `fontScale` state.
+
+13. **`useFormPersistence`**:
+    *   Uses `localStorage` with debounce.
+    *   **Issue**: `debounceRef` cleanup.
+    *   **Re-renders**: `setData` triggers save.
+
+14. **`useHaptic` / `useHapticFeedback`**:
+    *   Simple wrappers around `navigator.vibrate`.
+    *   **Issue**: `useHapticFeedback` has `enabled` prop.
+    *   **Re-renders**: `trigger` is memoized.
+
+15. **`useHighContrast`**:
+    *   Similar to `useFontScale`.
+    *   **Issue**: `useEffect` for system preference listener.
+    *   **Cleanup**: `removeEventListener`.
+
+16. **`useInitialSync`**:
+    *   Uses `useRef` for `hasSynced`.
+    *   **Issue**: `useEffect` depends on `isAuthenticated`, `isGuest`, `user`.
+    *   **Logic**: Syncs local to cloud.
+    *   **Memory Leak**: None.
+
+17. **`useIsMobile`**:
+    *   Uses `matchMedia`.
+    *   Cleanup: `removeEventListener`.
+    *   **Positive**: Uses `matchMedia` instead of `window.innerWidth` for better performance.
+
+18. **`useListAnimation`**:
+    *   Uses `useMemo` for animation styles.
+    *   **Issue**: `items` in dependency array. If `items` array reference changes (even if content same), styles recalculate.
+    *   **Re-renders**: Returns new array of objects every time `items` changes.
+
+19. **`useLiveMatches`**:
+    *   Complex hook with `useEffect` for polling/storage events.
+    *   **Issue**: `useEffect` for `storage` events.
+    *   **Cleanup**: `removeEventListener`.
+    *   **Memory Leak**: `seenGoalIds` ref.
+    *   **Re-renders**: `liveMatches` Map is updated.
+    *   **Performance**: `calculateElapsedSeconds` is called frequently.
+    *   **Issue**: `useEffect` for `storage` events might fire multiple times. `lastUpdateTime` ref is used to debounce. Good.
+
+20. **`useLiveProgress`**:
+    *   Uses `setInterval` for running matches.
+    *   Cleanup: `clearInterval`.
+    *   **Re-renders**: `elapsedSeconds` updates every second.
+
+21. **`useLocalStorage`**:
+    *   Standard implementation.
+    *   **Issue**: `setValue` sets state and writes to storage.
+    *   **Re-renders**: Standard `useState`.
+
+22. **`useLongPress`**:
+    *   Uses `setTimeout`.
+    *   Cleanup: `clearTimeout`.
+    *   **Issue**: `isPressed` is returned but relies on `isPressedRef`. This is a **Bug**. `isPressed` state is not updated in the hook, only the ref is. The return value `isPressed: isPressedRef.current` will be stale in the render cycle unless wrapped in a state or the component re-renders due to other reasons.
+    *   **Correction**: It should probably use `useState` for `isPressed` to trigger re-renders, or the consumer shouldn't rely on it for UI updates. Looking at the code: `const [isPressed, setIsPressed] = useState(false)` is missing. It returns `isPressedRef.current` which is the initial value `false` mostly. This is a **Critical Bug**.
+
+23. **`useMatchCockpitPro`**:
+    *   Composes multiple hooks (`useMatchTimerExtended`, `useNettoWarning`, `useMatchSound`, `useHapticFeedback`, `useWakeLock`).
+    *   **Issue**: `useEffect` for timer zero. Dependencies include `triggerHapticFn`, `playSound`, etc.
+    *   **Re-renders**: Returns many values.
+    *   **Logic**: `hasFireTimerZero` ref prevents multiple triggers. Good.
+
+24. **`useMatchExecution`**:
+    *   Complex logic for match state.
+    *   **Issue**: `useEffect` for loading initial state.
+    *   **Re-renders**: `liveMatches` Map.
+    *   **Memory Leak**: `timer` interval for display updates. Cleanup present.
+
+25. **`useMatchSound`**:
+    *   Uses `Audio` element ref.
+    *   Cleanup: `removeEventListener` for `ended`.
+    *   **Issue**: `useEffect` for loading sound. `isMounted` check prevents state updates on unmount. Good.
+    *   **Memory Leak**: `URL.revokeObjectURL` for custom sounds. Good.
+
+26. **`useMonitorHeartbeats`**:
+    *   Uses Supabase Realtime.
+    *   Cleanup: `removeChannel`.
+    *   **Issue**: `refreshStatuses` is memoized but called in `useEffect` interval.
+    *   **Re-renders**: `heartbeats` Map.
+
+27. **`RepositoryContext`**:
+    *   Context Provider.
+    *   **Issue**: `useMemo` for `value`. Dependencies: `user`.
+    *   **Re-renders**: If `user` changes, providers re-render.
+    *   **Cleanup**: `useEffect` for `unsubscribeAll`.
+
+**Summary of Findings:**
+
+*   **Re-Render Problems**:
+    *   `useClickOutside`: `handler` dependency in `useEffect` causes listener re-attachment if parent doesn't memoize `handler`.
+    *   `useMatchTimerExtended`: Returns new object every second. If used in a list without `React.memo`, causes re-renders.
+    *   `useLiveMatches`: `liveMatches` Map is recreated on every update.
+    *   `useLongPress`: `isPressed` return value is stale (ref vs state).
+
+*   **Memory Leaks**:
+    *   `useMatchSound`: `URL.revokeObjectURL` is handled, but `audioRef` is not explicitly nullified on unmount (though GC handles it).
+    *   `useMonitorHeartbeats`: `refreshStatuses` interval is cleared.
+    *   Most hooks have cleanup, but `useClickOutside` is the main risk for listener accumulation if `handler` changes often.
+
+*   **Anti-Patterns**:
+    *   `useLongPress`: `isPressed` is a ref value returned directly, not state. It won't trigger re-renders.
+    *   `useClickOutside`: `handler` in dependency array without `useCallback` in parent.
+    *   `useMatchTimer`: Deprecated but still exported.
+    *   `useMatchExecution`: Very large hook ("God Hook" tendency), though split into service layer.
+    *   `useLiveMatches`: Complex logic inside hook (parsing, event detection) that could be moved to a service.
+
+*   **Positive Patterns**:
+    *   `useDialogTimer`: `onExpire` stored in `useRef` to avoid stale closures.
+    *   `useMatchSound`: `isMounted` check in async effect.
+    *   `useMonitorHeartbeats`: `rawRef` for raw data, derived state in `refreshStatuses`.
+    *   `useFocusTrap`: `inertElements` tracking for cleanup.
+    *   `useIsMobile`: Uses `matchMedia` instead of `resize` listener.
+    *   `RepositoryContext`: `useRef` for singleton-like repo instances to prevent recreation.
+
+*   **State Management Score**: 8/10.
+    *   Strong use of Context for Repositories.
+    *   Good separation of concerns (Hooks for UI logic, Services for business logic).
+    *   Some performance issues with object creation in timers.
+    *   `useLongPress` bug is significant.
+
+**Plan:**
+1.  Structure the review as requested.
+2.  Highlight specific code locations.
+3.  Provide actionable fixes.
+4.  Assign the score.
+
+
+</details>
+
+---
+
+
+
+Hier ist das strukturierte Review der Hooks und Contexts für das **hallenfussball-pwa** Projekt.
+
+## 📊 State Management Score: 8/10
+
+**Begründung:** Die Architektur ist insgesamt sehr solide. Die Trennung von UI-Logik (Hooks) und Geschäftslogik (Services/Repositories) ist gut umgesetzt. Der `RepositoryContext` ist ein starkes Muster für die Datenbeschaffung. Es gibt jedoch einige kritische Performance-Probleme bei Timer-Hooks und einen funktionellen Bug in `useLongPress`, der behoben werden muss.
+
+---
+
+## 🚨 Re-Render-Probleme
+
+### 1. `useClickOutside` & `useClickOutsideMultiple`
+**Problem:** Der `handler` ist in der Dependency-Array des `useEffect`. Wenn der übergebene Handler im Eltern-Component nicht mit `useCallback` stabilisiert ist, wird der Event-Listener bei jedem Render entfernt und neu angehängt.
+**Folge:** Performance-Overhead, potenzielle Race Conditions.
+**Fix:**
+```ts
+// In useClickOutside.ts
+useEffect(() => {
+  if (!enabled) return;
+  const listener = (event: MouseEvent | TouchEvent) => {
+    // ... logic
+  };
+  document.addEventListener('mousedown', listener);
+  // ...
+  return () => {
+    document.removeEventListener('mousedown', listener);
+    // ...
+  };
+}, [ref, enabled]); // handler entfernen!
+// Oder handler in Ref speichern, wie in useDialogTimer
+```
+
+### 2. `useMatchTimerExtended` & `useLiveProgress`
+**Problem:** Diese Hooks geben bei jedem Tick (jede Sekunde) ein **neues Objekt** zurück (`MatchTimerResult` bzw. `UseLiveProgressReturn`).
+**Folge:** Wenn diese Hooks in einer Liste von Matches verwendet werden, re-rendern alle Eltern-Components bei jeder Sekunde, selbst wenn sich nur die Zeit ändert.
+**Fix:**
+*   Nutze `React.memo` für die Komponenten, die den Timer anzeigen.
+*   Oder zerlege den Hook: Gib nur `elapsedSeconds` zurück und berechne die Formate im Component (weniger Objekte).
+
+### 3. `useLiveMatches`
+**Problem:** `liveMatches` ist eine `Map`. Bei jedem Update wird eine **neue Map-Instanz** erstellt (`new Map(...)`).
+**Folge:** Alle Consumer, die `liveMatches` direkt verwenden, re-rendern, auch wenn sich nur ein Match geändert hat.
+**Fix:**
+*   Nutze `useMemo` im Consumer, um spezifische Matches zu selektieren.
+*   Besser: Gib `getMatchById` zurück und lass den Consumer `useMemo` nutzen.
+
+---
+
+## ⚠️ Memory Leaks & Cleanup
+
+### 1. `useLongPress` (Kritisch)
+**Problem:** `isPressed` wird als `isPressedRef.current` zurückgegeben. Refs lösen **keine Re-Renders** aus.
+**Folge:** Die UI wird nicht aktualisiert, wenn der Press-Status sich ändert (z.B. Button-Feedback).
+**Fix:**
+```ts
+const [isPressed, setIsPressed] = useState(false);
+// ...
+setIsPressed(true); // in handlePressStart
+setIsPressed(false); // in handlePressEnd
+return { ..., isPressed };
+```
+
+### 2. `useMatchSound`
+**Problem:** `audioRef.current` wird nicht explizit auf `null` gesetzt beim Unmount.
+**Folge:** Das Audio-Element bleibt im Speicher, bis GC greift.
+**Fix:**
+```ts
+useEffect(() => {
+  return () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null; // Explicit cleanup
+    }
+    if (customUrlRef.current) {
+      URL.revokeObjectURL(customUrlRef.current);
+    }
+  };
+}, []);
+```
+
+### 3. `useMonitorHeartbeats`
+**Problem:** `refreshStatuses` wird in einem `setInterval` verwendet. Die Funktion selbst ist `useCallback`-gememoized, aber das `setInterval` hängt von `tournamentId` ab.
+**Folge:** Wenn `tournamentId` sich ändert, wird das alte Interval nicht sofort gestoppt, bevor das neue startet (kurzes Overlap).
+**Fix:**
+*   `useRef` für das Interval-ID speichern und im Cleanup explizit `clearInterval` aufrufen.
+
+---
+
+## 🛑 Anti-Patterns
+
+### 1. `useMatchExecution` ("God Hook" Tendenz)
+**Problem:** Der Hook enthält extrem viel Logik (Initialisierung, Status-Handling, Scoring, Tiebreaker, Skip, Undo, Sync). Er ist über 200 Zeilen lang und hat viele Abhängigkeiten.
+**Folge:** Schwer testbar, schwer zu warten, führt zu großen Re-Render-Bereichen.
+**Empfehlung:**
+*   Spalte die Handler-Logik in separate Hooks auf (z.B. `useMatchScoring`, `useMatchStatus`).
+*   Oder delegiere mehr Logik an `MatchExecutionService` und reduziere den Hook auf State-Management.
+
+### 2. `useLocalStorage`
+**Problem:** `setValue` führt `JSON.stringify` bei jedem Set aus.
+**Folge:** Bei großen Objekten (z.B. ganze Turniere) Performance-Overhead.
+**Empfehlung:**
+*   Prüfe vorher, ob sich der Wert wirklich geändert hat (`JSON.stringify(old) !== JSON.stringify(new)`).
+
+### 3. `useAuthTimeoutToast`
+**Problem:** `showWarning` ist in den Dependencies. Wenn `ToastContext` nicht `useCallback` für `showWarning` nutzt, läuft der Effekt bei jedem Render.
+**Empfehlung:**
+*   `showWarning` im ToastContext mit `useCallback` stabilisieren.
+
+---
+
+## ✅ Positive Patterns
+
+1.  **`useDialogTimer` (Stale Closure Fix):**
+    *   Nutzt `onExpireRef` um den Callback aktuell zu halten, ohne den Effekt neu zu starten. Das ist der korrekte Weg für Timer-Callbacks.
+    ```ts
+    const onExpireRef = useRef(onExpire);
+    useEffect(() => { onExpireRef.current = onExpire; }, [onExpire]);
+    // Nutzung: onExpireRef.current?.();
+    ```
+
+2.  **`useIsMobile` (Performance):**
+    *   Nutzt `matchMedia` statt `window.addEventListener('resize')`. Das ist performanter, da es nur bei Breakpoint-Überschreitung feuert.
+
+3.  **`RepositoryContext` (Singleton Pattern):**
+    *   Nutzt `useRef` (`supabaseLiveMatchRepoRef`), um Repository-Instanzen über den Lebenszyklus des Providers hinweg stabil zu halten, auch wenn `user` sich ändert (wichtig für Realtime-Subscriptions).
+
+4.  **`useFocusTrap` (Accessibility):**
+    *   Korrekte Implementierung von `inert` Attributen und Fokus-Restoration. Sehr gut für WCAG-Konformität.
+
+5.  **`useMatchSound` (Async Safety):**
+    *   Nutzt `isMounted` Flag in `useEffect` um State-Updates nach Unmount zu verhindern.
+
+---
+
+## 🛠️ Konkrete Handlungsempfehlungen
+
+1.  **Priorität 1 (Bugfix):** `useLongPress` korrigieren (`isPressed` muss State sein).
+2.  **Priorität 2 (Performance):** `useClickOutside` Dependency-Array bereinigen (`handler` entfernen).
+3.  **Priorität 3 (Optimierung):** Timer-Hooks (`useMatchTimerExtended`) so umbauen, dass sie nicht bei jedem Tick ein neues Objekt zurückgeben, oder Consumer mit `React.memo` schützen.
+4.  **Priorität 4 (Refactoring):** `useMatchExecution` in kleinere Hooks aufteilen, um die Komplexität zu reduzieren.
+
+**Gesamturteil:** Das Team hat ein sehr hohes Verständnis für React Hooks (Refs, Cleanup, Dependencies). Die Architektur ist skalierbar. Mit den oben genannten Fixes (insbesondere `useLongPress` und `useClickOutside`) wäre das State-Management auf Production-Level 10/10.

--- a/reviews/2026-03-16_1935_i18n_a11y.md
+++ b/reviews/2026-03-16_1935_i18n_a11y.md
@@ -1,0 +1,232 @@
+# Code Review: Internationalisierung & Barrierefreiheit
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 45.3s  
+**Status:** success  
+**Code-Kontext:** 150,570 Zeichen  
+
+<details><summary>Thinking Process (6,577 Zeichen)</summary>
+
+Der Benutzer möchte eine Analyse der Internationalisierung (i18n) und Barrierefreiheit (Accessibility) für das Projekt "hallenfussball-pwa".
+
+Ich habe den Code-Review erhalten, der eine große Anzahl von Dateien enthält, die sich auf i18n (Übersetzungsdateien, Konfiguration, Typen) und einige Komponenten (ContactForm, ErrorBoundary) konzentrieren.
+
+**Analyse der i18n-Struktur:**
+1.  **Konfiguration (`src/i18n/index.ts`):**
+    *   Nutzt `i18next` und `react-i18next`.
+    *   Spracherkennung: `localStorage` > `navigator.language` > Fallback `de`.
+    *   Ressourcen: Statische Imports für DE und EN.
+    *   Namespaces: Gut strukturiert (`common`, `auth`, `dashboard`, etc.).
+    *   Typisierung: `src/i18n/types.ts` nutzt Module-Augmentation für TypeScript-Sicherheit.
+    *   Fallback: `returnNull: false` (gute Praxis, zeigt Keys statt null).
+    *   HTML Lang: Wird dynamisch gesetzt.
+
+2.  **Übersetzungsdateien (JSON):**
+    *   **DE & EN:** Beide Sprachen sind weitgehend abgedeckt.
+    *   **Struktur:** Klare Trennung nach Features (Wizard, Cockpit, Admin, etc.).
+    *   **Pluralisierung:** Es gibt `one` und `other` Keys (z.B. `gamesRunning_one`, `gamesRunning_other`). Das ist gut.
+    *   **Interpolation:** `{{variable}}` wird konsequent genutzt.
+    *   **Lücken:** Ich muss prüfen, ob alle Keys in EN vorhanden sind, die in DE existieren. Ein schneller Blick zeigt, dass die Struktur sehr ähnlich ist. Es könnte jedoch sein, dass spezifische Fehlermeldungen oder dynamische Inhalte fehlen.
+    *   **Hardcodierte Strings:** Ich muss in den Komponenten-Beispielen prüfen, ob Text direkt im JSX steht.
+        *   `ContactForm.tsx`: Nutzt `t('contact.toggle')`, `t('contact.name')` etc. -> Gut.
+        *   `ErrorBoundary.tsx`: Nutzt `t('errorBoundary.title')`, `t('actions.retry')`. -> Gut.
+        *   Es gibt jedoch Inline-Styles und Icons (z.B. `⚠️`, `✓`, `▶`, `▼`). Icons sind okay, aber Text-Icons sollten über i18n gehen, wenn sie kontextabhängig sind. Hier sind es UI-Elemente, also okay.
+        *   `ErrorBoundary.tsx`: `process.env.NODE_ENV === 'development'` ist okay, aber der Text darin ist fest.
+        *   `ContactForm.tsx`: `showExtended ? '▼' : '▶'` sind Icons, keine Texte.
+
+3.  **Barrierefreiheit (Accessibility):**
+    *   **ARIA-Labels:** Viele Keys enden auf `AriaLabel` oder `Aria` (z.B. `warningClickAria`, `searchAriaLabel`, `backAriaLabel`). Das zeigt ein Bewusstsein.
+    *   **Live Regions:** `cockpit.json` hat `ariaLive` Keys (`running`, `paused`, `ended`). Das ist kritisch für Screenreader bei Live-Daten.
+    *   **Semantik:** `ErrorBoundary.tsx` nutzt `role="alert"` für Fehlermeldungen. Das ist korrekt.
+    *   **Fokus:** Nicht direkt im Code sichtbar, aber `ErrorBoundary` hat Buttons.
+    *   **Kontraste:** `cssVars` werden genutzt, aber ich kann die Kontrastwerte nicht prüfen. Ich muss annehmen, dass sie gut sind, aber darauf hinweisen.
+    *   **Touch Targets:** Nicht im Code sichtbar, aber `ContactForm` nutzt `Input` Komponenten.
+    *   **Sprach-Attribute:** `document.documentElement.lang` wird gesetzt. Gut.
+
+**Potenzielle Probleme:**
+1.  **i18n:**
+    *   **Pluralisierung:** `gamesRunning_one` vs `gamesRunning_other`. In `admin.json` (DE) gibt es `gamesRunning_one` und `gamesRunning_other`. In `admin.json` (EN) gibt es auch `gamesRunning_one` und `gamesRunning_other`. Das ist konsistent.
+    *   **Fehlende Keys:** Ich muss prüfen, ob alle DE-Keys in EN vorhanden sind.
+        *   Beispiel `admin.json`: DE hat `center.loading`, EN hat `center.loading`.
+        *   Beispiel `wizard.json`: DE hat `step1.title`, EN hat `step1.title`.
+        *   Es sieht sehr vollständig aus.
+    *   **Hardcodierte Strings:** In `ContactForm.tsx` gibt es `showExtended ? '▼' : '▶'`. Das sind Icons, aber wenn sie als Text gerendert werden, sollten sie vielleicht über `aria-label` oder `aria-hidden` gesteuert werden.
+    *   **Dateiformate:** `src/i18n/utils/dateFormatting.ts` nutzt `Intl.DateTimeFormat`. Das ist gut für i18n.
+    *   **Fallback:** `returnNull: false` ist gut.
+
+2.  **Accessibility:**
+    *   **Live Updates:** Der Cockpit-Bereich hat `ariaLive` Keys. Aber wie werden sie genutzt? Im Code-Review sehe ich nur die JSON-Dateien. Ich muss annehmen, dass sie in der Cockpit-Komponente genutzt werden. Wenn nicht, ist das ein Problem.
+    *   **Fokus-Management:** Bei Modals (z.B. `cardDialog`, `timeAdjust`) muss der Fokus verwaltet werden. Das ist im Code nicht sichtbar, aber wichtig.
+    *   **Kontraste:** `cssVars.colors.primary` etc. sind nicht definiert. Ich kann Kontraste nicht prüfen.
+    *   **Screenreader:** `ErrorBoundary` nutzt `role="alert"`. Das ist gut.
+    *   **Navigation:** `skip links` sind nicht im Code sichtbar.
+    *   **Formulare:** `ContactForm` nutzt `Input` mit `label`. Das ist gut. Aber `placeholder` ist nicht immer ein Ersatz für `label`. Hier gibt es `label={t('contact.name')}`. Das ist korrekt.
+    *   **Icons:** `⚠️` in `ErrorBoundary` hat `aria-hidden="true"`. Das ist korrekt.
+
+**Zusammenfassung:**
+Das Projekt hat eine sehr solide i18n- und Accessibility-Grundlage.
+*   **i18n:** Sehr gut strukturiert, Typisierung vorhanden, Pluralisierung implementiert, Datumsformate lokalisiert.
+*   **Accessibility:** ARIA-Labels sind vorhanden, Live-Regionen sind vorbereitet, semantisches HTML wird genutzt (`role="alert"`).
+
+**Mögliche Schwachstellen:**
+*   **Live-Daten:** Die `ariaLive` Keys sind definiert, aber ich sehe nicht, wie sie im Cockpit genutzt werden. Wenn sie nicht dynamisch aktualisiert werden, nützen sie nichts.
+*   **Fokus-Management:** Bei Dialogen (z.B. `cardDialog`) muss der Fokus innerhalb des Dialogs bleiben.
+*   **Touch Targets:** Nicht prüfbar, aber wichtig für PWA.
+*   **Kontraste:** Nicht prüfbar.
+*   **Hardcodierte Strings:** In `ContactForm` gibt es Icons (`▼`, `▶`). Diese sollten `aria-hidden` haben, wenn sie dekorativ sind.
+*   **Fehlermeldungen:** In `ErrorBoundary` wird `error.message` angezeigt. Das kann für Screenreader verwirrend sein, wenn es nicht kontextualisiert ist.
+
+**Scores:**
+*   **i18n:** 9/10 (Sehr gut, nur kleine Lücken möglich).
+*   **Accessibility:** 8/10 (Gute Basis, aber Fokus-Management und Live-Updates müssen implementiert sein).
+
+**Empfehlungen:**
+1.  **i18n:** Prüfen, ob alle DE-Keys in EN vorhanden sind.
+2.  **Accessibility:** Sicherstellen, dass `ariaLive` im Cockpit genutzt wird. Fokus-Management bei Modals implementieren.
+3.  **Icons:** `aria-hidden` für dekorative Icons.
+4.  **Kontraste:** Prüfen.
+5.  **Touch Targets:** Mindestens 48x48px.
+
+Ich werde die Analyse strukturiert aufbauen.
+
+
+</details>
+
+---
+
+
+
+# i18n & Accessibility Review: hallenfussball-pwa
+
+## Zusammenfassung
+Das Projekt zeigt eine **exzellente Grundstruktur** für Internationalisierung und Barrierefreiheit. Die Trennung in Namespaces, die Typisierung via TypeScript und die Nutzung von `Intl` für Datumsformate sind Best Practices. Die Accessibility-Implementierung ist bewusst angelegt (ARIA-Labels, Live-Regions), muss aber in der Komponentenebene konsequent umgesetzt werden.
+
+---
+
+## 1. i18n-Lücken & Analyse
+
+### ✅ Starke Punkte
+*   **Namespace-Struktur:** Klare Trennung (`common`, `auth`, `cockpit`, etc.) verhindert "Translation Bloat".
+*   **Typisierung:** `src/i18n/types.ts` nutzt Module-Augmentation für **Type-Safety** bei `t()`. Das verhindert Tippfehler bei Keys zur Compile-Zeit.
+*   **Pluralisierung:** Korrekte Nutzung von `one`/`other` (z.B. `gamesRunning_one` vs `gamesRunning_other`) in DE und EN.
+*   **Datumsformate:** `src/i18n/utils/dateFormatting.ts` nutzt `Intl.DateTimeFormat` basierend auf `i18n.language`. Das ist der richtige Weg (keine manuellen String-Manipulationen).
+*   **Fallback:** `returnNull: false` sorgt dafür, dass Keys angezeigt werden, falls Übersetzungen fehlen (besser als leere Strings).
+
+### ⚠️ Potenzielle Lücken & Risiken
+1.  **Vollständigkeit der EN-Übersetzungen:**
+    *   Bei einem schnellen Abgleich der JSON-Strukturen (DE vs. EN) sieht es konsistent aus.
+    *   **Risiko:** Dynamische Inhalte (z.B. Teamnamen, Fehlermeldungen von Supabase) sind nicht übersetzbar.
+    *   **Empfehlung:** Stelle sicher, dass alle Fehlermeldungen aus `auth.json` auch in EN vorhanden sind. (Im Review-Code waren sie vorhanden, aber prüfe `wizard.json` auf "Coming Soon"-Texte).
+2.  **Hardcodierte Icons/Texte:**
+    *   In `ContactForm.tsx`: `showExtended ? '▼' : '▶'`.
+    *   **Problem:** Diese Symbole sind technisch Text. Screenreader könnten sie vorlesen ("Down Arrow", "Right Arrow").
+    *   **Fix:** Nutze `aria-hidden="true"` für dekorative Icons oder nutze SVG-Icons mit `aria-label` wenn sie interaktiv sind.
+3.  **Plural-Regeln für EN:**
+    *   `gamesRunning_one` vs `gamesRunning_other` ist korrekt.
+    *   **Achtung:** Prüfe `admin.json` -> `groups_one` vs `groups_other`. In EN ist "Group" (singular) und "Groups" (plural). Das ist korrekt.
+4.  **Fallback-Sprache:**
+    *   Fallback ist `de`. Wenn ein Nutzer `en` wählt, aber eine Übersetzung fehlt, wird `de` angezeigt.
+    *   **Empfehlung:** Für eine PWA, die international sein soll, sollte der Fallback `en` sein (oder `de` wenn DE die Primärsprache ist). Aktuell ist `de` als Fallback gesetzt, was für den deutschen Markt okay ist.
+
+---
+
+## 2. WCAG 2.1 AA Verstöße & Risiken
+
+### 🔴 Kritisch (High Severity)
+1.  **Live-Regionen im Cockpit:**
+    *   **Problem:** `cockpit.json` definiert `ariaLive` Keys (`running`, `paused`, `ended`).
+    *   **Risiko:** Wenn diese nicht in einer `<div role="status" aria-live="polite">` (oder `assertive` für Tore) im Cockpit gerendert werden, **erfahren Screenreader-Nutzer nichts vom Spielverlauf**.
+    *   **Empfehlung:** Implementiere ein `useEffect` im Cockpit, das bei Statusänderungen den Text in einem unsichtbaren Live-Region-Container aktualisiert.
+2.  **Fokus-Management in Dialogen:**
+    *   **Problem:** Dialoge wie `cardDialog`, `timeAdjust`, `penaltyShootout` sind modal.
+    *   **Risiko:** Wenn der Fokus beim Öffnen nicht in den Dialog springt und beim Schließen zurück zum Auslöser, ist die Navigation für Tastaturnutzer kaputt.
+    *   **Empfehlung:** Nutze eine Bibliothek wie `@radix-ui/react-dialog` oder implementiere `focus-trap` manuell.
+3.  **Touch Targets (PWA):**
+    *   **Problem:** Buttons im Cockpit (z.B. "Tor hinzufügen") müssen auf Touchscreens gut bedienbar sein.
+    *   **Risiko:** Wenn `padding` zu klein ist (< 44px/48px), ist die Bedienung auf dem Handy frustrierend.
+    *   **Empfehlung:** Prüfe `cssVars` auf `minTouchTarget: 48px`.
+
+### 🟠 Mittel (Medium Severity)
+1.  **Farbkontraste:**
+    *   **Problem:** `cssVars.colors.primary` etc. sind nicht im Code definiert.
+    *   **Risiko:** Wenn `primary` zu hell ist (z.B. Hellgrün auf Weiß), ist der Text nicht lesbar (WCAG AA: 4.5:1).
+    *   **Empfehlung:** Nutze Tools wie "Stark" oder "axe DevTools", um Kontraste zu prüfen.
+2.  **Fehlermeldungen:**
+    *   **Problem:** `ErrorBoundary.tsx` zeigt `error.message` an.
+    *   **Risiko:** Technische Fehlermeldungen sind für Nutzer verwirrend.
+    *   **Empfehlung:** Zeige nur den `t('errorBoundary.message')` an. `error.message` nur im `pre`-Tag für Entwickler (wie bereits implementiert).
+3.  **Icons ohne Text:**
+    *   **Problem:** `ContactForm.tsx` nutzt `▶` / `▼` als Text.
+    *   **Risiko:** Screenreader lesen "Right Triangle" / "Down Triangle".
+    *   **Empfehlung:** `aria-hidden="true"` auf diese Elemente setzen.
+
+### 🟢 Gering (Low Severity)
+1.  **Skip Links:**
+    *   **Problem:** Keine "Skip to Content"-Links sichtbar.
+    *   **Empfehlung:** Füge einen unsichtbaren Link am Anfang des `<body>` hinzu, der zum Hauptinhalt springt.
+2.  **Formular-Labels:**
+    *   **Problem:** `ContactForm` nutzt `label={t(...)}`. Das ist gut.
+    *   **Empfehlung:** Stelle sicher, dass `id` auf Input und `htmlFor` auf Label übereinstimmen.
+
+---
+
+## 3. Screenreader-Probleme (Live-Daten)
+
+### Das größte Risiko: Live-Cockpit
+Da dies eine **Live-Scoreboard-App** ist, ist die Barrierefreiheit für Screenreader-Nutzer extrem wichtig.
+
+1.  **Timer-Updates:**
+    *   **Problem:** Wenn der Timer jede Sekunde aktualisiert wird, darf das **nicht** `aria-live="polite"` sein, da es sonst jede Sekunde vorgelesen wird ("5 Minuten", "4 Minuten 59 Sekunden"...).
+    *   **Lösung:** Nutze `aria-live="off"` für den Timer selbst. Lies nur **Statusänderungen** vor (z.B. "Spiel gestartet", "Halbzeit", "Spiel beendet").
+2.  **Tore:**
+    *   **Problem:** Ein Tor muss sofort und deutlich angekündigt werden.
+    *   **Lösung:** Nutze `aria-live="assertive"` für Toresignale.
+    *   **Code-Beispiel:**
+        ```tsx
+        <div role="status" aria-live="assertive" className="sr-only">
+          {t('cockpit.toast.goalScored', { teamName: team })}
+        </div>
+        ```
+3.  **Statusänderungen:**
+    *   Die `ariaLive` Keys in `cockpit.json` sind gut.
+    *   **Aber:** Sie müssen dynamisch in den DOM eingefügt werden, wenn sich der Status ändert.
+
+---
+
+## 4. Positive Patterns
+
+1.  **Type-Safe i18n:** Die Nutzung von `CustomTypeOptions` in `types.ts` ist ein **Best Practice**. Es verhindert, dass falsche Keys verwendet werden.
+2.  **Offline-First i18n:** Alle Lokales werden gebündelt (`static imports`). Das ist perfekt für eine PWA, da keine Netzwerklatenz beim Sprachwechsel entsteht.
+3.  **Semantisches HTML:** `ErrorBoundary` nutzt `role="alert"`. Das ist korrekt für Fehlermeldungen.
+4.  **Datumsformatierung:** `Intl.DateTimeFormat` ist der richtige Weg für i18n-freundliche Datumsformate.
+5.  **Aria-Labels für Aktionen:** Viele Buttons haben `AriaLabel` Keys (z.B. `undoAria`, `pauseAria`). Das zeigt, dass Accessibility von Anfang an mitgedacht wurde.
+
+---
+
+## 5. Scores
+
+### i18n Score: **9/10**
+*   **Begründung:** Exzellente Struktur, Typisierung und Pluralisierung.
+*   **Abzug:** -1 für potenzielle Lücken in EN-Übersetzungen (müssen manuell geprüft werden) und die Nutzung von Text-Icons (`▶`) statt SVGs mit `aria-hidden`.
+
+### Accessibility Score: **8/10**
+*   **Begründung:** Starke Basis (ARIA-Labels, semantisches HTML, Live-Region-Keys vorhanden).
+*   **Abzug:** -2 für das Risiko bei Live-Updates (Timer-Flut) und Fokus-Management in Modals (muss im Component-Code geprüft werden).
+
+---
+
+## 6. Konkrete Handlungsempfehlungen
+
+1.  **Live-Regionen im Cockpit implementieren:**
+    *   Erstelle eine `useLiveAnnouncement` Hook, die Statusänderungen (`running` -> `paused`) in einem `aria-live` Container aktualisiert.
+    *   Stelle sicher, dass der Timer **nicht** jede Sekunde vorgelesen wird.
+2.  **Fokus-Trap für Dialoge:**
+    *   Nutze `react-focus-lock` oder implementiere ein `useEffect` im `Dialog`-Component, das den Fokus beim Öffnen in den Dialog setzt und beim Schließen zurück.
+3.  **Icons bereinigen:**
+    *   Ersetze `▶` / `▼` in `ContactForm.tsx` durch SVG-Icons und füge `aria-hidden="true"` hinzu.
+4.  **Touch Targets prüfen:**
+    *   Stelle sicher, dass alle interaktiven Elemente mindestens **48x48px** groß sind (insbesondere im Cockpit auf Mobilgeräten).
+5.  **EN-Übersetzungen validieren:**
+    *   Führe einen automatisierten Test durch, der prüft, ob alle DE-Keys auch in EN existieren (z.B. mit einem Script, das die JSON-Keys vergleicht).
+
+**Fazit:** Das Projekt ist technisch sehr gut aufgestellt. Mit der konsequenten Umsetzung der Live-Regionen und Fokus-Management wird es eine exzellente barrierefreie PWA.

--- a/reviews/2026-03-16_1935_live_cockpit.md
+++ b/reviews/2026-03-16_1935_live_cockpit.md
@@ -1,0 +1,217 @@
+# Code Review: Live-Cockpit & Spielsteuerung
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 50.6s  
+**Status:** success  
+**Code-Kontext:** 148,805 Zeichen  
+
+<details><summary>Thinking Process (7,385 Zeichen)</summary>
+
+Der Nutzer bittet um eine QA-Analyse des Live-Cockpits für Spielsteuerung in einer Hallenfussball-PWA.
+Ich habe den Code-Review-Output erhalten, der sich jedoch stark auf den `ScheduleEditor` (Spielplan-Editor) konzentriert, nicht auf das `Live-Cockpit` (Spielsteuerung, Timer, Tore).
+Der Prompt sagt: "Analysiere das Live-Cockpit fuer Spielsteuerung."
+Der bereitgestellte Code ist jedoch fast ausschließlich `src/features/schedule-editor/...`.
+Es gibt keine Dateien wie `LiveCockpit.tsx`, `Timer.tsx`, `Scoreboard.tsx` etc. im bereitgestellten Kontext.
+
+Ich muss den Nutzer darauf hinweisen, dass der bereitgestellte Code den Schedule-Editor betrifft, nicht das Live-Cockpit.
+Aber ich soll trotzdem eine Analyse basierend auf dem Kontext liefern, oder besser: Ich muss annehmen, dass der Nutzer den Code für das Live-Cockpit erwartet hat, aber versehentlich den Schedule-Editor gepostet hat, ODER ich soll den Schedule-Editor im Kontext des Live-Cockpits bewerten (z.B. Vorbereitung für Live-Spiele).
+Allerdings ist die Aufgabe spezifisch: "Analysiere das Live-Cockpit".
+Wenn ich den Schedule-Editor analysiere, antworte ich nicht auf die Frage.
+Aber ich kann keine Analyse des Live-Cockpits durchführen, wenn der Code fehlt.
+
+Strategie:
+1.  Klarstellen, dass der bereitgestellte Code den `ScheduleEditor` betrifft, nicht das `Live-Cockpit`.
+2.  Dennoch eine Bewertung des `ScheduleEditor` im Hinblick auf seine Rolle für das Live-Cockpit vornehmen (z.B. Spielplan-Validierung vor dem Start).
+3.  Eine Liste von kritischen Punkten für das *fehlende* Live-Cockpit erstellen, basierend auf Best Practices für Realtime-Anwendungen (Timer, Sync, Race Conditions), um dem Nutzer zu zeigen, worauf ich achten würde, wenn der Code da wäre.
+4.  Alternativ: Ich interpretiere "Live-Cockpit" vielleicht breiter als "Verwaltungsoberfläche". Aber "Timer, Tore" sind explizit genannt.
+5.  Da ich den Code nicht habe, kann ich keine spezifischen Bugs im Timer finden. Ich muss dies transparent machen.
+
+Besserer Ansatz: Ich werde den bereitgestellten Code (ScheduleEditor) analysieren, aber explizit darauf hinweisen, dass dies nicht das Live-Cockpit ist. Ich werde dann basierend auf der Architektur (Supabase Realtime, React 19) eine Prognose für das Live-Cockpit geben und kritische Punkte auflisten, die im Live-Cockpit *sein müssen*, aber im ScheduleEditor nicht relevant sind.
+Oder ich frage den Nutzer nach dem Code.
+Nein, ich soll eine Analyse liefern.
+Ich werde die Analyse auf den bereitgestellten Code anwenden, aber den Kontext korrigieren.
+"Der bereitgestellte Code betrifft den Spielplan-Editor (`ScheduleEditor`), nicht das Live-Cockpit. Hier ist die Analyse des Editors mit Fokus auf Stabilität für den Live-Betrieb, gefolgt von einer Checkliste für das fehlende Live-Cockpit."
+
+Warte, der Prompt sagt "Analysiere das Live-Cockpit". Der Code ist `ScheduleEditor`.
+Ich muss dem Nutzer sagen: "Du hast mir den Schedule-Editor geschickt, nicht das Live-Cockpit. Hier ist die Analyse dessen, was du geschickt hast, und was ich für das Cockpit brauche."
+Aber ich soll "Gib ein strukturiertes Review mit...".
+Ich werde das Review für den *ScheduleEditor* machen, aber im Kontext der Vorbereitung auf Live-Spiele, und dann eine Sektion "Fehlende Komponenten für Live-Cockpit" hinzufügen.
+Das ist die ehrlichste und hilfreichste Antwort.
+
+Allerdings: Der Prompt ist "Du bist ein QA-Engineer... Analysiere das Live-Cockpit".
+Wenn ich sage "Das ist nicht das Cockpit", enttäusche ich den Nutzer vielleicht.
+Vielleicht ist der `ScheduleEditor` Teil des Cockpits? Nein, "Live-Cockpit (Timer, Tore)" ist explizit anders.
+Ich werde klarstellen, dass der Code den Editor betrifft, aber ich werde die Analyse so strukturieren, dass sie die Stabilität des Systems insgesamt bewertet (da der Editor die Basis für das Cockpit ist).
+Und ich werde eine "Gap Analysis" für das Live-Cockpit hinzufügen.
+
+Struktur:
+1.  **Disclaimer**: Code ist ScheduleEditor, nicht Live-Cockpit.
+2.  **Analyse des ScheduleEditors** (als Basis für Live-Operationen).
+3.  **Gap Analysis**: Was fehlt für das Live-Cockpit (Timer, Tore, Sync).
+4.  **Score**: Basierend auf dem Editor + Architektur-Verdacht.
+
+Nein, ich sollte nicht raten. Ich analysiere den Code, der da ist.
+Ich werde den Code als "Spielplan-Editor" identifizieren und bewerten, wie gut er für den Live-Betrieb vorbereitet ist (z.B. Konflikterkennung vor Spielstart).
+Dann werde ich explizit die fehlenden Live-Cockpit-Komponenten auflisten.
+
+Kritische Punkte im ScheduleEditor Code:
+- `useScheduleEditor`: State Management mit `useReducer`. Gut.
+- `useMatchConflicts`: Echtzeit-Konflikterkennung. Gut.
+- `DraggableMatch`: DnD mit `@dnd-kit`. Gut.
+- `Supabase Realtime`: Wird erwähnt, aber im Code nicht direkt sichtbar (nur in Props).
+- Tests: Gut abgedeckt.
+
+Ich werde das Review so aufbauen, als ob ich den ScheduleEditor als Teil des Cockpits betrachte (Vorbereitung), aber klarstelle, dass das eigentliche Live-Management fehlt.
+
+Wait, looking at the prompt again: "Analysiere das Live-Cockpit fuer Spielsteuerung."
+The user *thinks* they provided the Live-Cockpit code.
+I must inform them politely that the code provided is the Schedule Editor.
+Then I will analyze the provided code for its impact on the Live-Cockpit (e.g., data integrity before games start).
+And I will list what I would look for in the actual Live-Cockpit code.
+
+Let's refine the "Live-Cockpit Score". Since the actual Cockpit code is missing, I can't score the Cockpit itself. I will score the *Schedule Editor's readiness* for Live operations.
+
+Okay, Plan:
+1.  **Klarstellung**: Code ist ScheduleEditor, nicht Live-Cockpit.
+2.  **Review des ScheduleEditors** (Fokus: Datenintegrität vor Spielstart).
+3.  **Gap-Analyse**: Was im Live-Cockpit fehlen muss (Timer, Tore, Sync).
+4.  **Score**: Für den bereitgestellten Code.
+
+Wait, I should check if there are any hidden Live-Cockpit components in the imports or types.
+`src/features/schedule-editor/...`
+No, it's definitely the editor.
+
+Okay, let's draft the response.
+- Start with the disclaimer.
+- Analyze the Schedule Editor for "Live-Readiness" (Conflict detection, Undo/Redo, State Management).
+- List the missing Live-Cockpit features based on the prompt's requirements (Timer, Goals, Sync).
+- Give a score based on the provided code quality.
+
+Wait, I need to be careful not to hallucinate features.
+I will focus on the provided code's quality and its implications for the system.
+
+Key findings in provided code:
+- `useScheduleEditor` uses `useReducer` for state. Good for complex state.
+- `useMatchConflicts` uses `useMemo` for performance. Good.
+- `DraggableMatch` uses `@dnd-kit`. Good for UX.
+- Tests are extensive. Good for QA.
+- No visible Supabase Realtime subscription logic in the editor code itself (likely in a parent or hook not shown).
+- No visible "Live Mode" switch in the editor (it's for planning).
+
+Okay, I will structure the review as requested but adapt it to the reality of the code.
+
+**Kritische Timing-Bugs**: Nicht im Code (da Editor), aber Risiko bei Synchronisation.
+**Logik-Fehler**: Konflikterkennung scheint robust.
+**UX-Probleme**: Drag & Drop ist gut gelöst.
+**Positive Patterns**: Typisierung, Tests, Reducer.
+**Score**: 8/10 für Editor, aber N/A für Cockpit.
+
+I will adjust the score to reflect the provided code's quality, while noting the missing Cockpit.
+
+Let's write the response in German.
+
+
+</details>
+
+---
+
+
+
+## QA-Review: Live-Cockpit & Spielsteuerung
+
+**⚠️ Wichtiger Hinweis vorab:**
+Der bereitgestellte Code (`src/features/schedule-editor/...`) betrifft den **Spielplan-Editor** (Planung vor dem Turnier), nicht das **Live-Cockpit** (Steuerung während des Spiels, Timer, Tore).
+Da das eigentliche Live-Cockpit fehlt, analysiere ich hier die **Vorbereitung der Datenbasis** (Schedule Editor) und leite daraus **kritische Risiken** für das fehlende Live-Cockpit ab.
+
+---
+
+### 1. Kritische Timing-Bugs & Sync-Risiken
+
+Da das Live-Cockpit-Code fehlt, basieren diese Punkte auf der Architektur des Editors und typischen Fallstricken bei Realtime-Apps.
+
+*   **Race Conditions bei Spielstart (Hochrisiko):**
+    *   Im `ScheduleEditor` wird `matchStatus` via `skipMatch`/`unskipMatch` geändert.
+    *   **Risiko:** Wenn das Live-Cockpit den Status auf `running` setzt, während der Editor noch Konflikte prüft (`useMatchConflicts`), kann es zu Inkonsistenzen kommen.
+    *   **Empfehlung:** Der `matchStatus` muss im Live-Cockpit atomar mit dem Timer-Start synchronisiert werden (Supabase Transaction).
+*   **Timer-Drift im Browser:**
+    *   Im Editor wird `Date.now()` für Timestamps genutzt.
+    *   **Risiko:** Im Live-Cockpit darf der Timer nicht auf `setInterval` basieren, da Tabs im Hintergrund pausieren.
+    *   **Empfehlung:** Server-seitige Zeitquelle nutzen (`supabase.now()`) und Client-seitig nur die Differenz berechnen.
+*   **Realtime-Sync-Latenz:**
+    *   Der Editor nutzt `useReducer` für lokalen State.
+    *   **Risiko:** Wenn zwei User gleichzeitig Tore eintragen (z.B. Trainer A und B), kann es zu Überschreibungen kommen, wenn keine Optimistic UI mit Conflict Resolution (z.B. Last-Write-Wins oder CRDT) implementiert ist.
+
+### 2. Logik-Fehler & Datenintegrität
+
+Der `ScheduleEditor` zeigt eine sehr robuste Logik, die als Fundament für das Cockpit dienen muss.
+
+*   **Konflikterkennung (`useMatchConflicts`):**
+    *   ✅ **Stark:** `detectTeamConflicts` und `detectRefereeConflicts` sind gut getestet und nutzen `useMemo` für Performance.
+    *   ⚠️ **Risiko:** Die Logik ignoriert `finished` und `skipped` Matches. Im Live-Cockpit muss sichergestellt sein, dass ein Spiel nicht beendet wird, bevor der Status korrekt gesetzt ist (Vermeidung von "Ghost Goals").
+*   **Undo/Redo (`useScheduleEditor`):**
+    *   ✅ **Stark:** `useReducer` mit `undoStack` und `redoStack` ist sauber implementiert.
+    *   ⚠️ **Risiko:** Im Live-Cockpit ist "Undo" bei Toren kritisch. Ein "Undo" muss nicht nur den Score, sondern auch die Spielzeit und Event-Logs zurücksetzen.
+*   **Datenvalidierung:**
+    *   ✅ **Stark:** Zod-Typen werden implizit genutzt (durch TS).
+    *   ⚠️ **Risiko:** Fehlt im Code sichtbar. Im Live-Cockpit müssen Tore und Zeitstempel serverseitig validiert werden (Zod im Supabase Edge Function), um Manipulationen zu verhindern.
+
+### 3. UX-Probleme unter Zeitdruck (Halle-Szenario)
+
+*   **Drag & Drop (`DraggableMatch`):**
+    *   ✅ **Positiv:** `@dnd-kit` mit `PointerSensor` und `TouchSensor` ist gut für Mobile/Tablet geeignet.
+    *   ⚠️ **Risiko:** Im Live-Cockpit darf kein Drag & Drop für Tore verwendet werden. Das muss ein **großer, eindeutiger Button** sein (Touch-Friendly, 44px+).
+*   **Konflikt-Feedback (`ConflictDialog`):**
+    *   ✅ **Positiv:** Klare Trennung von `error` und `warning`.
+    *   ⚠️ **Risiko:** Im Live-Betrieb darf ein Konflikt-Dialog das Spiel nicht blockieren. Es braucht ein "Toast"-Notification-System, nicht ein Modal.
+*   **Offline-First:**
+    *   ❌ **Fehlend:** Im Code keine PWA-Caching-Strategie für den Editor sichtbar.
+    *   **Kritisch:** In der Halle ist das WLAN oft schlecht. Das Live-Cockpit muss **Offline-Queue** für Tore haben und später synchronisieren.
+
+### 4. Positive Patterns (Best Practices)
+
+*   **Typ-Sicherheit:** Durchgängig TypeScript mit `Match`, `Team`, `Tournament` Types. Reduziert Runtime-Fehler massiv.
+*   **Testabdeckung:** Sehr gute Unit-Tests für `useMatchConflicts` und `autoReassign`. Das gibt Sicherheit bei Änderungen.
+*   **State Management:** `useReducer` statt `useState` für komplexe Editor-Logik ist die richtige Wahl.
+*   **Komponenten-Architektur:** Saubere Trennung von `ScheduleEditor` (Container), `DraggableMatch` (UI) und `useScheduleEditor` (Logic).
+
+### 5. Gap-Analyse: Fehlende Live-Cockpit-Komponenten
+
+Basierend auf dem fehlenden Code muss das Live-Cockpit folgende Features enthalten, die im Editor nicht relevant sind:
+
+1.  **Timer-Service:**
+    *   Muss server-seitige Zeit nutzen.
+    *   Muss Pause/Resume/Stop exakt synchronisieren.
+2.  **Score-Board:**
+    *   Große Buttons (+1, +2, +3).
+    *   Undo-Funktion mit Bestätigung (z.B. "Tor zurücknehmen?").
+3.  **Realtime-Channel:**
+    *   Supabase `subscribe` auf `matches` Tabelle.
+    *   Optimistic UI für sofortiges Feedback.
+4.  **Anzeigetafel (Monitor):**
+    *   Separate View (`/monitor`), die nur liest und nicht schreibt.
+    *   Auto-Refresh oder WebSocket-Stream.
+
+---
+
+### Live-Cockpit Score
+
+Da der eigentliche Code für das Live-Cockpit fehlt, kann ich diesen nicht direkt bewerten. Ich bewerte hier die **Bereitschaft der Architektur** basierend auf dem Schedule-Editor.
+
+| Kategorie | Score | Kommentar |
+| :--- | :---: | :--- |
+| **Code-Qualität (Editor)** | **9/10** | Sehr sauber, gut getestet, typisiert. |
+| **Datenintegrität** | **8/10** | Konflikterkennung ist robust, aber Server-Validation fehlt sichtbar. |
+| **Realtime-Readiness** | **6/10** | Editor ist lokal fokussiert. Live-Sync muss noch implementiert werden. |
+| **UX für Stress-Szenario** | **7/10** | Editor ist gut, aber Live-Buttons fehlen (müssen groß/kontrastreich sein). |
+| **Gesamt (Architektur)** | **7.5/10** | Solide Basis, aber das kritische Live-Cockpit fehlt noch. |
+
+### Fazit & Nächste Schritte
+
+Der **Schedule-Editor** ist hervorragend implementiert und bietet eine stabile Datenbasis. Für das **Live-Cockpit** müssen jedoch folgende Punkte priorisiert werden:
+
+1.  **Timer-Logik:** Nicht client-seitig basierend auf `Date.now()`, sondern server-seitig validieren.
+2.  **Offline-Queue:** Tore müssen lokal gespeichert und bei Netzwerkwiederherstellung synchronisiert werden.
+3.  **Konflikt-Handling:** Was passiert, wenn zwei Trainer gleichzeitig ein Tor eintragen? (Server-Transaction nötig).
+4.  **UI für Live:** Trennung von "Planung" (Editor) und "Steuerung" (Cockpit). Das Cockpit muss simpler und robuster sein (weniger Klicks, mehr Bestätigungen).
+
+**Empfehlung:** Bitte den Code für `src/features/live-cockpit/` bereitstellen, um die spezifischen Timer- und Sync-Bugs zu analysieren.

--- a/reviews/2026-03-16_1935_performance.md
+++ b/reviews/2026-03-16_1935_performance.md
@@ -1,0 +1,276 @@
+# Code Review: Performance, Bundle & PWA
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 44.8s  
+**Status:** success  
+**Code-Kontext:** 32,532 Zeichen  
+
+<details><summary>Thinking Process (6,118 Zeichen)</summary>
+
+Der Benutzer möchte eine Performance-Analyse für ein React 19 + TypeScript PWA-Projekt namens "hallenfussball-pwa".
+Der Fokus liegt auf Performance, Bundle-Size und PWA-Verhalten.
+Ich habe den Code für das Storage-Modul erhalten (IndexedDB, LocalStorage, Factory, Migration, Quota-Monitoring).
+
+**Analyse der bereitgestellten Daten:**
+1.  **Code-Umfang:** Es handelt sich um das `src/core/storage` Modul. Das ist nur ein Teil der 626 Dateien.
+2.  **Technologie:** Vite 7, React 19, Supabase, PWA.
+3.  **Inhalt:**
+    *   `IStorageAdapter`: Interface.
+    *   `IndexedDBAdapter`: Wrapper um IndexedDB (Promis, Error Handling).
+    *   `LocalStorageAdapter`: Wrapper um LocalStorage.
+    *   `QuotaMonitor`: Nutzung der Storage Estimate API.
+    *   `StorageFactory`: Singleton-Pattern, Fallback-Logik (IDB -> LS), Migration.
+    *   `migrateToIndexedDB`: Logik zum Migrieren von LS nach IDB.
+    *   Tests: Unit & E2E Tests für Storage.
+
+**Fehlende Informationen für eine vollständige Analyse:**
+*   `vite.config.ts`: Hier liegen die meisten Bundle-Optimierungen (Splitting, Tree Shaking, Minification).
+*   `manifest.json`: Wichtig für PWA (Icons, Theme Color, Start URL).
+*   `service-worker.ts` (oder Vite PWA Plugin Config): Caching-Strategien sind entscheidend für PWA/Offline.
+*   `package.json`: Abhängigkeiten (Größe der Libraries).
+*   Routing-Konfiguration: Code Splitting pro Route?
+*   Asset-Nutzung: Bilder, Fonts.
+
+**Strategie:**
+Ich muss basierend auf dem vorliegenden Code (Storage-Layer) und dem Kontext (Vite, PWA, Supabase) eine fundierte Analyse erstellen. Ich kann nicht *tatsächlich* messen, aber ich kann Muster erkennen, die Performance beeinflussen.
+
+**Potenzielle Issues im vorliegenden Code:**
+1.  **StorageFactory Initialization:** `createStorage` wird wahrscheinlich bei App-Start aufgerufen. Wenn `autoMigrate` synchron/blockierend aufgerufen wird, könnte das den Start verzögern.
+2.  **IndexedDB Overhead:** Für kleine Datenmengen ist IDB langsamer als LS. Der Fallback ist gut, aber die Initialisierung von IDB ist asynchron.
+3.  **Migration:** `autoMigrate` wird im `StorageFactory` aufgerufen. Wenn das bei jedem Start passiert (auch wenn nicht nötig), ist das Overhead. `isMigrationNeeded` prüft das, aber es ist ein asynchroner Check vor dem eigentlichen Start.
+4.  **Quota Monitoring:** `getStorageQuota` nutzt `navigator.storage.estimate()`. Das ist asynchron und kann blockieren, wenn es zu oft aufgerufen wird.
+5.  **Bundle Size:** `jsPDF` (im Kontext erwähnt) ist oft riesig. `i18next` kann bloaten, wenn nicht lazy geladen. `Supabase` Client ist okay, aber Realtime-Listener sollten sauber cleanup werden.
+
+**Struktur des Reports:**
+1.  **Critical Issues:** Was blockiert den Start oder die Offline-Fähigkeit?
+2.  **Bundle-Optimierungen:** Was fehlt in der Config (basierend auf Best Practices für Vite)?
+3.  **PWA-Lücken:** Was ist für eine echte PWA noch nötig?
+4.  **Positive Patterns:** Was ist gut gemacht (z.B. Storage Abstraction, Fallbacks)?
+5.  **Score:** 1-10.
+
+**Spezifische Punkte für den Storage-Code:**
+*   **Singleton Pattern:** Gut, verhindert doppelte IDB-Connections.
+*   **Error Handling:** Sehr gut (`StorageError` Klasse).
+*   **Migration:** Sehr robust (`dryRun`, `excludeKeys`, Verifizierung).
+*   **Performance:** IDB ist asynchron. Das muss im UI-Flow berücksichtigt werden (Loading States).
+
+**Vite/PWA spezifische Annahmen (da Config fehlt):**
+*   Vite PWA Plugin (`vite-plugin-pwa`) wird wahrscheinlich genutzt.
+*   Code Splitting muss manuell konfiguriert werden (`manualChunks`).
+*   `jsPDF` ist ein klassischer Performance-Killer.
+
+**Erstellung des Reports:**
+Ich werde die Analyse so strukturieren, als ob ich den Rest des Projekts kenne, aber mich auf die Logik des Storage-Layers und typische Fallstricke in diesem Stack stütze.
+
+**Kritische Punkte:**
+*   **Startzeit:** `autoMigrate` kann den First Paint verzögern.
+*   **Offline:** Der Code zeigt *lokale* Speicherung, aber nicht, wie die App offline funktioniert (Service Worker Caching von API-Calls?).
+*   **Bundle:** `jsPDF` und `i18next` sind Risikofaktoren.
+
+**Positive Aspekte:**
+*   Abstraktionsebene (Adapter Pattern) ist exzellent für Testbarkeit und Fallbacks.
+*   Migration ist sicher implementiert.
+
+**Score:**
+Da der Storage-Layer sehr solide ist, aber die PWA-Config und Bundle-Strategie nicht sichtbar sind, gebe ich einen moderaten bis guten Score, mit Hinweis auf die "Black Box" der Config.
+
+**Refinement:**
+Ich muss darauf hinweisen, dass ich die `vite.config.ts` nicht sehe, aber basierend auf dem Code Schlüsse ziehe.
+Ich sollte auch auf `Supabase Realtime` eingehen, da das im Kontext erwähnt wurde (Memory Leaks bei Event Listeners).
+
+**Letzter Check:**
+Der Prompt verlangt ein "strukturiertes Performance-Report".
+Ich werde die Abschnitte strikt einhalten.
+Ich werde spezifische Code-Snippets aus dem Storage-Modul zitieren, um meine Punkte zu untermauern.
+
+**Plan:**
+1.  **Critical Issues:** Start-Blocking Migration, Realtime Memory Leaks (Vermutung), Offline-First Strategie (Service Worker).
+2.  **Bundle-Optimierungen:** `jsPDF` Lazy Loading, `i18next` Splitting, `manualChunks` für Vite.
+3.  **PWA-Lücken:** Manifest, SW-Caching-Strategien (Stale-While-Revalidate für API?), Install-Prompt.
+4.  **Positive Patterns:** Storage Abstraction, Migration Safety, Quota Monitoring.
+5.  **Score:** 7.5/10 (Gute Basis, aber PWA/Bundle Details fehlen).
+
+Ich werde den Ton professionell, technisch und direkt halten.
+Ich werde spezifische Optimierungen für Vite 7 und React 19 vorschlagen.
+Ich werde auf die `StorageFactory` Logik eingehen (Singleton, Fallback).
+
+**Self-Correction während des Denkens:**
+Ich darf nicht zu viel raten. Ich muss klarstellen, dass die Analyse auf dem *vorliegenden Code* und dem *Kontext* basiert.
+Ich sollte erwähnen, dass `IndexedDB` für große Datenmengen (Turnierdaten) besser ist als `LocalStorage`, was gut implementiert ist.
+Aber: `autoMigrate` blockiert den Start? Nein, es ist `async`, aber wenn `createStorage` `await`et, blockiert es den Initialisierungs-Flow der App. Das ist ein kritischer Punkt.
+
+Okay, let's write the report.
+
+
+</details>
+
+---
+
+
+
+# 🚀 Performance & PWA Audit: hallenfussball-pwa
+
+Basierend auf dem analysierten Code (Storage-Layer) und dem Projekt-Kontext (Vite 7, React 19, Supabase, PWA).
+
+---
+
+## 🔴 Critical Issues (Sofortige Risiken)
+
+| Issue | Schweregrad | Beschreibung |
+| :--- | :--- | :--- |
+| **Blocking Storage Init** | 🔴 Hoch | `createStorage()` wird im App-Start-Flow wahrscheinlich `await`et. Die `autoMigrate()`-Logik prüft `isMigrationNeeded()` (LS vs. IDB Keys). Bei großen LS-Datenmengen kann dies den **First Contentful Paint (FCP)** verzögern. |
+| **Offline-First Lücke** | 🔴 Hoch | Der Code speichert Daten lokal, aber es fehlt im vorliegenden Code die **Service Worker Caching-Strategie**. Ohne SW-Caching für API-Requests (Supabase) ist die App bei Netzausfall nur teilweise nutzbar (nur gespeicherte Daten, keine Live-Updates). |
+| **Realtime Memory Leaks** | 🟠 Mittel | `Supabase Realtime` Listener werden oft nicht sauber cleanuped. Bei Navigation (React Router) müssen `channel.unsubscribe()` aufgerufen werden, sonst steigt der **Memory Usage** bei jedem Seitenwechsel. |
+| **jsPDF Bundle Bloat** | 🟠 Mittel | `jsPDF` ist eine riesige Abhängigkeit (~500KB+). Wenn es beim Initial Load importiert wird, blockiert es den Main Thread. |
+
+---
+
+## 📦 Bundle-Optimierungen (Vite 7 & React 19)
+
+Da die `vite.config.ts` nicht im Code-Review enthalten ist, basieren diese Empfehlungen auf Best Practices für den Stack:
+
+### 1. Code Splitting & Manual Chunks
+Vite 7 optimiert standardmäßig gut, aber große Libraries müssen explizit getrennt werden.
+**Empfehlung:**
+```ts
+// vite.config.ts
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        'vendor-react': ['react', 'react-dom', 'react-router'],
+        'vendor-supabase': ['@supabase/supabase-js'],
+        'vendor-pdf': ['jspdf', 'jspdf-autotable'], // WICHTIG: PDF separat laden
+        'vendor-i18n': ['i18next', 'react-i18next']
+      }
+    }
+  }
+}
+```
+
+### 2. Lazy Loading für `jsPDF`
+Vermeide Top-Level-Importe für PDF-Generierung. Nutze dynamische Imports nur bei Bedarf (z.B. "Export"-Button Klick).
+```ts
+// src/features/export/exportTournament.ts
+export const generatePDF = async (data: Tournament) => {
+  const { jsPDF } = await import('jspdf'); // Dynamic Import
+  // ... PDF Logic
+};
+```
+**Impact:** Reduziert Initial Bundle Size um ca. **300-500 KB**.
+
+### 3. Tree Shaking bei `i18next`
+Stelle sicher, dass nur genutzte Übersetzungen geladen werden.
+**Check:** Werden alle Sprach-Dateien (`de.json`, `en.json`) im Bundle gebündelt?
+**Fix:** Nutze `i18next-http-backend` mit Lazy Loading der Sprach-Dateien, statt sie alle im `main.js` zu haben.
+
+### 4. React 19 Compiler
+Aktiviere den React Compiler (falls noch nicht geschehen), um unnötige Re-Renders zu eliminieren.
+```ts
+// vite.config.ts
+react: {
+  compiler: true // Experimental, aber Performance-Boost
+}
+```
+
+---
+
+## 📱 PWA-Lücken (Offline & Install)
+
+Der Storage-Layer ist exzellent für **Datenpersistenz**, aber eine PWA benötigt mehr als nur `IndexedDB`.
+
+### 1. Service Worker Strategie (Missing)
+Der Code zeigt keine SW-Konfiguration. Für eine Turnier-App ist eine **Stale-While-Revalidate** Strategie für API-Daten und **Cache-First** für Assets (Bilder, CSS) essenziell.
+**Empfehlung:** Konfiguriere `vite-plugin-pwa` mit Workbox-Strategien:
+```ts
+// vite.config.ts
+VitePWA({
+  registerType: 'autoUpdate',
+  workbox: {
+    globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+    runtimeCaching: [
+      {
+        urlPattern: /^https:\/\/api\.supabase\.co.*/i,
+        handler: 'StaleWhileRevalidate', // API-Daten schnell laden, im Hintergrund aktualisieren
+        options: {
+          cacheName: 'supabase-cache',
+          expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 }, // 24h
+        },
+      },
+    ],
+  },
+})
+```
+
+### 2. Manifest & Icons
+Prüfe `public/manifest.json`.
+*   **Icons:** Sind 512x512 und 192x192 vorhanden?
+*   **Display Mode:** `standalone` oder `fullscreen` für den "App-Feeling"-Effekt auf dem Monitor/Anzeigetafel?
+*   **Theme Color:** Passt zur Branding?
+
+### 3. Install-Prompt UX
+Der Code enthält keinen `beforeinstallprompt` Handler.
+**Empfehlung:** Implementiere einen "App installieren"-Button im UI, der nur angezeigt wird, wenn `window.addEventListener('beforeinstallprompt')` feuert. Verstecke den Standard-Browser-Install-Button.
+
+### 4. Offline-Fallback UI
+Da `IndexedDBAdapter` Daten speichert, muss die UI wissen, ob sie offline ist.
+**Implementierung:**
+```ts
+// src/hooks/useOnlineStatus.ts
+export const useOnlineStatus = () => {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  useEffect(() => {
+    const update = () => setIsOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+  return isOnline;
+};
+```
+*Zeige ein Banner an: "Offline-Modus: Änderungen werden lokal gespeichert und synchronisiert, sobald das Netzwerk wieder da ist."*
+
+---
+
+## ✅ Positive Patterns (Best Practices)
+
+1.  **Storage Abstraction (Adapter Pattern):**
+    *   `IStorageAdapter` Interface ermöglicht einfaches Mocking für Tests.
+    *   Fallback-Logik (`IndexedDB` → `LocalStorage`) ist robust implementiert (`StorageFactory.ts`).
+    *   **Impact:** Erhöht Stabilität in Browsern mit eingeschränkter IDB-Unterstützung (z.B. Safari Private Mode).
+
+2.  **Sichere Migration:**
+    *   `migrateToIndexedDB` prüft Datenintegrität (`verifyValue`) nach dem Schreiben.
+    *   `dryRun` Option ist exzellent für Debugging.
+    *   `clearSource` ist standardmäßig `false` (Safety First).
+
+3.  **Quota Monitoring:**
+    *   `QuotaMonitor` nutzt die moderne `navigator.storage.estimate()` API.
+    *   Warnschwellen (80% / 95%) helfen, Speicherüberlauf-Errors (`QuotaExceededError`) proaktiv zu behandeln.
+
+4.  **Singleton Pattern:**
+    *   `StorageFactory` verhindert mehrfache IDB-Initialisierungen (`initializationPromise`), was Race Conditions und Performance-Einbrüche beim Start verhindert.
+
+5.  **Type Safety:**
+    *   Generische Typen `<T>` in `get/set` Methoden sorgen für TypeScript-Sicherheit bei gespeicherten Objekten (z.B. `Tournament`, `Team`).
+
+---
+
+## 📊 Performance Score
+
+| Kategorie | Score | Kommentar |
+| :--- | :--- | :--- |
+| **Bundle Size** | 7/10 | Guter Code, aber Risiko durch `jsPDF` und fehlendes Splitting im Code-Review. |
+| **Runtime Perf** | 8/10 | Storage-Layer ist effizient. React 19 Compiler könnte helfen. |
+| **PWA Readiness** | 6/10 | Daten-Persistenz ist top, aber Service Worker & Offline-UI fehlen im Code. |
+| **Code Quality** | 9/10 | Exzellente Struktur, Testing, Error Handling und Typisierung. |
+| **Gesamt** | **7.5/10** | **Solide Basis, benötigt PWA-Config-Fokus.** |
+
+### Nächste Schritte (Action Items)
+1.  **Vite Config prüfen:** `manualChunks` für `jsPDF` und `i18next` hinzufügen.
+2.  **Service Worker:** `vite-plugin-pwa` Konfiguration auf `StaleWhileRevalidate` für Supabase-API setzen.
+3.  **Offline-UI:** `useOnlineStatus` Hook implementieren und UI-Feedback bei Netzausfall hinzufügen.
+4.  **Memory Check:** Prüfen, ob Supabase Realtime-Listener bei `useEffect` Cleanup (`return () => channel.unsubscribe()`) entfernt werden.

--- a/reviews/2026-03-16_1935_screens_navigation.md
+++ b/reviews/2026-03-16_1935_screens_navigation.md
@@ -1,0 +1,435 @@
+# Code Review: Screens, Routing & Navigation
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 38.1s  
+**Status:** success  
+**Code-Kontext:** 150,737 Zeichen  
+
+<details><summary>Thinking Process (3,816 Zeichen)</summary>
+
+The user wants me to analyze the routing and navigation structure of their React PWA application based on the provided code snippets. I need to identify:
+
+1. **Routing Problems** - Missing guards, broken links, route structure issues
+2. **Navigation UX Problems** - Dead ends, missing back functionality, confusing flows
+3. **Deep Link Gaps** - URLs that don't work properly for sharing/bookmarking
+4. **Positive Patterns** - What's working well
+5. **Navigation Score** - Overall rating 1-10
+
+Let me analyze the code systematically:
+
+## Route Structure Analysis
+
+From the screens provided, I can see:
+
+1. **DashboardScreen** - Main tournament dashboard with tabs (Turniere, Archiv, Papierkorb)
+2. **TournamentCreationScreen** - Wizard-based tournament creation with URL-based step navigation
+3. **TournamentManagementScreen** - Main tournament management with tabs (Schedule, Tabellen, Management, Monitor, Settings, Teams, MonitorsConfig)
+4. **LiveViewScreen** - Public view via share code `/live/:shareCode`
+5. **PublicTournamentViewScreen** - Public view via tournament ID
+6. **PublicLiveViewScreen** - Another public view variant
+7. **SettingsScreen** - App settings
+8. **DatenschutzScreen** - Privacy policy
+9. **ImpressumScreen** - Legal imprint
+10. **MatchCockpitDemoScreen** - Demo screen
+11. **LocalTestScreen** - Local test view
+
+## Key Issues I'm Identifying
+
+### 1. Route Structure Problems
+
+**Duplicate Public Views**: There are THREE different public view screens:
+- `PublicLiveViewScreen` (via share code)
+- `PublicTournamentViewScreen` (via tournament ID)
+
+
+- `LiveViewScreen` (also via share code)
+
+This creates confusion and potential maintenance issues.
+
+**Missing Route Guards**: No authentication guards visible for protected routes like tournament management.
+
+**Inconsistent URL Patterns**:
+- `/tournament/:id/schedule`
+- `/tournament/:id/management`
+- `/live/:shareCode`
+- `/test-live` (dev only)
+- `/privacy` / `/impressum`
+
+### 2. Navigation UX Problems
+
+**Back Button Issues**:
+- `TournamentCreationScreen` has `onBack` prop but no clear navigation history management
+- `TournamentManagementScreen` has `onBack` but no browser history integration
+- Legal pages have `onBack` but no clear destination
+
+**Tab Navigation**:
+- Mobile uses bottom nav with "more" menu
+- Desktop uses top tabs
+- Tab state is URL-synced (good!) but some tabs may not be accessible via direct URL
+
+**Sackgassen (Dead Ends)**:
+- Settings screen has no clear "exit" path
+- Legal pages have back button but no clear destination
+- Public views have no way to return to app
+
+### 3. Deep Link Gaps
+
+**Missing Deep Links**:
+- No direct link to specific match in cockpit
+- No direct link to specific tournament step in wizard
+- No direct link to specific tab in management screen (though some URL support exists)
+
+**Share Code Handling**:
+- `LiveViewScreen` uses `shareCode` prop but URL pattern unclear
+- `PublicTournamentViewScreen` uses `tournamentId` but logic for determining which to use is complex
+
+### 4. Positive Patterns
+
+**URL State Sync**:
+- Wizard steps are URL-synced (`buildWizardStepPath`, `getStepFromSearchParams`)
+- Tournament tabs are URL-synced (`buildTournamentTabPath`, `getTabFromPath`)
+- Live view filters are URL-synced (`updateUrlParams`, `useSearchParams`)
+
+**Lazy Loading**:
+- Settings screen is lazy-loaded
+- Wizard steps are lazy-loaded
+
+**Consistent Layout**:
+- Legal pages use `LegalPageLayout`
+- Mobile/desktop responsive design
+
+**Error Handling**:
+- Loading states
+- Error states with clear messages
+- 404 handling (implied but not shown)
+
+### 5. Navigation Score
+
+I'd rate this around **6.5/10** - Good foundation with URL state sync and lazy loading, but needs work on route guards, consistent public views, and better back navigation handling.
+
+Let me create a comprehensive review.
+
+
+</details>
+
+---
+
+
+
+# 📱 Routing & Navigation Review: hallenfussball-pwa
+
+## Executive Summary
+
+Die App hat eine solide Basis mit URL-State-Sync und Lazy-Loading, zeigt aber **kritische Inkonsistenzen bei Public Views** und **fehlende Route Guards**. Die Navigation ist teilweise verwirrend durch redundante Screens und unklare Back-Button-Logik.
+
+---
+
+## 🔴 Routing-Probleme
+
+### 1. **Drei Public View Screens (Redundanz)**
+```
+❌ PublicLiveViewScreen.tsx      → /live/:shareCode
+❌ PublicTournamentViewScreen.tsx → /tournament/:id
+❌ LiveViewScreen.tsx             → /live/:shareCode (ähnlich wie #1)
+```
+**Problem**: Drei Screens für gleiche Funktionalität → Wartungsaufwand, Inkonsistenzen, Verwirrung.
+
+**Lösung**: Ein Screen mit Parameter-Adapter:
+```tsx
+// /live/:code OR /tournament/:id → Unified PublicViewScreen
+const route = useParams();
+const shareCode = route.code;
+const tournamentId = route.id;
+```
+
+### 2. **Fehlende Route Guards**
+```tsx
+// ❌ Keine Auth-Prüfung in TournamentManagementScreen
+export const TournamentManagementScreen: React.FC = ({ tournamentId }) => {
+  // Wer darf hier hin? Organiser? Admin?
+}
+```
+**Problem**: Jeder kann Turnier-Management-URL aufrufen → Datenlecks.
+
+**Lösung**:
+```tsx
+<Route path="/tournament/:id/*" element={<ProtectedRoute><TournamentManagementScreen /></ProtectedRoute>} />
+```
+
+### 3. **Inkonsistente URL-Muster**
+```
+✅ /tournament/:id/schedule
+✅ /tournament/:id/management
+✅ /live/:shareCode
+❌ /test-live (Dev-Only, sollte /dev/test-live sein)
+❌ /privacy (sollte /legal/privacy sein)
+❌ /impressum (sollte /legal/impressum sein)
+```
+
+### 4. **Missing 404 Route**
+Kein `*` Catch-All Route → Benutzer sehen leere Seite bei falscher URL.
+
+---
+
+## 🟡 Navigation-UX-Probleme
+
+### 1. **Back-Button-Logik inkonsistent**
+```tsx
+// DashboardScreen
+const onBack = () => navigate(-1); // ❌ Browser History nicht immer vorhanden
+
+// LegalPageLayout
+const onBack = () => navigate(-1); // ❌ Wohin zurück? Dashboard? Home?
+```
+**Problem**: Bei direktem Link (z.B. `/impressum`) gibt es kein "Zurück".
+
+**Lösung**:
+```tsx
+const onBack = () => {
+  if (window.history.length > 1) {
+    navigate(-1);
+  } else {
+    navigate('/'); // Fallback
+  }
+};
+```
+
+### 2. **Tournament Creation Wizard - History Clutter**
+```tsx
+// Jede Step-Änderung pushet History
+void navigate(newPath, { replace: true }); // ✅ Gut
+// Aber: Browser Back-Button führt durch ALLE Steps
+```
+**Problem**: User will zurück zum Dashboard, landet aber in Step 3.
+
+**Lösung**:
+```tsx
+// Ersten Entry im History Stack markieren
+const wizardStartRef = useRef(false);
+useEffect(() => {
+  if (!wizardStartRef.current) {
+    navigate(-1); // Remove wizard entry from history
+    wizardStartRef.current = true;
+  }
+}, []);
+```
+
+### 3. **Settings Screen - Kein Clear Exit**
+```tsx
+// SettingsScreen.tsx
+const onBack = () => navigate(-1); // ❌ Wohin?
+```
+**Problem**: User kommt von Dashboard → Settings → Back → Dashboard. Aber was wenn von Tournament Management?
+
+**Lösung**:
+```tsx
+interface SettingsScreenProps {
+  onBack?: () => void;
+  defaultBackPath?: string; // '/dashboard' | '/tournament/:id'
+}
+```
+
+### 4. **Mobile Bottom Nav - "More" Menu**
+```tsx
+// TournamentManagementScreen
+const handleMobileNavChange = (tab: BottomNavTab) => {
+  if (tab === 'more') {
+    setShowMoreMenu(true); // ❌ BottomSheet ohne URL-Sync
+  }
+};
+```
+**Problem**: BottomSheet ist nicht URL-synced → Refresh verliert Zustand.
+
+**Lösung**:
+```tsx
+// Query param für More-Menu
+const [showMore, setShowMore] = useSearchParams('more');
+```
+
+---
+
+## 🟠 Deep-Link-Lücken
+
+### 1. **Kein direkter Link zu Match im Cockpit**
+```tsx
+// ✅ exists: ?matchId=xyz in URL
+// ❌ Aber: Keine URL-Generierung von ScheduleTab
+```
+**Problem**: User kann Spielstand nicht teilen.
+
+**Lösung**:
+```tsx
+// In ScheduleDisplay
+const shareMatchLink = `${window.location.origin}/tournament/${id}/management?matchId=${match.id}`;
+```
+
+### 2. **Wizard Steps - URL Sync funktioniert, aber...**
+```tsx
+// ✅ /tournament/create?step=3
+// ❌ Aber: Keine Validierung → /tournament/create?step=999 crashet
+```
+**Problem**: Ungültige Step-Parameter führen zu Error.
+
+**Lösung**:
+```tsx
+const urlStep = getStepFromSearchParams(searchParams);
+const safeStep = Math.max(1, Math.min(6, urlStep)); // Clamp to valid range
+```
+
+### 3. **Live View - Filter nicht persistent**
+```tsx
+// ✅ URL syncs: ?g=A&p=groupStage&s=live
+// ❌ Aber: Keine "Share View"-Funktion
+```
+**Problem**: User kann gefilterte Ansicht nicht teilen.
+
+**Lösung**:
+```tsx
+const shareViewLink = `${window.location.origin}/live/${shareCode}${window.location.search}`;
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **URL-State-Sync (Excellent!)**
+```tsx
+// ✅ Wizard Steps
+const newPath = buildWizardStepPath(newStep as WizardStep, existingTournament?.id);
+void navigate(newPath, { replace: true });
+
+// ✅ Tournament Tabs
+void navigate(buildTournamentTabPath(tournamentId, newTab));
+
+// ✅ Live View Filters
+updateUrlParams({ g: group, p: phase, s: status });
+```
+**Bewertung**: 9/10 - Sehr gut implementiert mit `replace: true` für History-Cleanup.
+
+### 2. **Lazy Loading (Performance)**
+```tsx
+// ✅ Settings Screen
+export { SettingsScreen } from '../features/settings/components/SettingsScreen';
+
+// ✅ Wizard Steps
+const Step1_SportAndType = lazy(() =>
+  import('../features/tournament-creation').then(module => ({ default: module.Step1_SportAndType }))
+);
+```
+**Bewertung**: 8/10 - Gute Code-Splitting-Strategie.
+
+### 3. **Legal Page Layout (Consistency)**
+```tsx
+// ✅ Shared Layout
+<LegalPageLayout title="Datenschutzerklärung" onBack={onBack}>
+  {/* Content */}
+</LegalPageLayout>
+```
+**Bewertung**: 9/10 - Konsistente UX für alle Legal-Pages.
+
+### 4. **Error & Loading States**
+```tsx
+// ✅ Clear states
+if (loadingError) {
+  return <div style={errorStyle}>❌ {loadingError}</div>;
+}
+if (isLoading) {
+  return <div style={loadingStyle}>Turnier wird geladen...</div>;
+}
+```
+**Bewertung**: 8/10 - Gute User Feedback.
+
+---
+
+## 📊 Navigation Score
+
+| Kategorie | Score | Notes |
+|-----------|-------|-------|
+| **Route Structure** | 6/10 | Redundante Public Views, fehlende Guards |
+| **URL State Sync** | 9/10 | Excellent implementation |
+| **Back Navigation** | 5/10 | Inconsistent, no fallback logic |
+| **Deep Linking** | 6/10 | Basic support, missing share features |
+| **Mobile UX** | 7/10 | Bottom nav good, More menu needs URL sync |
+| **Error Handling** | 8/10 | Clear states, missing 404 route |
+| **Performance** | 8/10 | Good lazy loading |
+
+### **Gesamtnote: 6.5/10**
+
+---
+
+## 🎯 Top 5 Prioritized Fixes
+
+### **P1 - Critical**
+1. **Consolidate Public Views** → 1 Screen statt 3
+2. **Add Route Guards** → Auth-Check für Management-Screens
+3. **Add 404 Route** → Catch-all handler
+
+### **P2 - High**
+4. **Fix Back-Button Logic** → Fallback zu `/` wenn keine History
+5. **URL-Sync Bottom Sheet** → Query param für More-Menu
+
+### **P3 - Medium**
+6. **Add Share Links** → Match, Filtered Views, Wizard Steps
+7. **Validate URL Parameters** → Clamp invalid values
+8. **Add Breadcrumbs** → Navigation context
+
+---
+
+## 💡 Quick Wins
+
+```tsx
+// 1. Add 404 Route (5 min)
+<Route path="*" element={<NotFoundScreen />} />
+
+// 2. Fix Back Button (10 min)
+const safeBack = () => {
+  if (window.history.length > 1) navigate(-1);
+  else navigate('/');
+};
+
+// 3. Consolidate Public Views (1h)
+// Merge PublicLiveViewScreen + PublicTournamentViewScreen + LiveViewScreen
+```
+
+---
+
+## 📝 Recommended Route Structure
+
+```tsx
+// src/router.tsx
+const router = createBrowserRouter([
+  // Public Routes
+  { path: '/', element: <DashboardScreen /> },
+  { path: '/legal/privacy', element: <DatenschutzScreen /> },
+  { path: '/legal/impressum', element: <ImpressumScreen /> },
+  
+  // Protected Routes
+  {
+    path: '/tournament/create',
+    element: <ProtectedRoute><TournamentCreationScreen /></ProtectedRoute>,
+    children: [
+      { path: '?step=:step', element: <WizardSteps /> }
+    ]
+  },
+  {
+    path: '/tournament/:id',
+    element: <ProtectedRoute><TournamentManagementScreen /></ProtectedRoute>,
+    children: [
+      { path: 'schedule', element: <ScheduleTab /> },
+      { path: 'management', element: <ManagementTab /> },
+      { path: 'monitor', element: <MonitorTab /> },
+      { path: 'settings', element: <SettingsTab /> },
+    ]
+  },
+  
+  // Public Live View (Unified)
+  { path: '/live/:code', element: <PublicLiveViewScreen /> },
+  
+  // 404
+  { path: '*', element: <NotFoundScreen /> },
+]);
+```
+
+---
+
+**Fazit**: Solide technische Basis, aber UX-Konsistenz und Security-Guards benötigen dringend Aufmerksamkeit. Mit den P1-Fixes kann die Note auf **8/10** steigen.

--- a/reviews/2026-03-16_1935_security.md
+++ b/reviews/2026-03-16_1935_security.md
@@ -1,0 +1,539 @@
+# Code Review: Security & Datenschutz
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 53.6s  
+**Status:** success  
+**Code-Kontext:** 151,331 Zeichen  
+
+<details><summary>Thinking Process (2,997 Zeichen)</summary>
+
+The user wants me to perform a security audit of their PWA application. They've provided a significant amount of code including:
+
+1. Authentication components (AuthCallback, AuthConfirmPage, AuthGuard, GuestBanner, various login/register screens)
+2. Invitation system components (InviteAcceptScreen, InviteDialog, InviteLinkDialog)
+3. Member management (MemberList, RoleBadge, RoleChangeDialog)
+4. Account merge functionality (MergeAccountDialog, merge-accounts Edge Function)
+5. Storage adapter interface
+
+This is a React 19 + TypeScript PWA for hallen football tournament management using:
+- Vite 7
+- Supabase (Auth + DB + Realtime)
+- Zod
+- React Router
+- i18next
+- jsPDF
+- Deployed on Vercel
+
+I need to create a structured security report with:
+- Critical Findings (fix immediately)
+- High Findings (before next release)
+- Medium Findings (backlog)
+- Recommendations (hardening)
+- Security Score (1-10)
+
+Let me analyze the code for security issues:
+
+## Authentication & Authorization
+
+1. **AuthCallback.tsx** - Looks good with proper timeout handling and session checking
+2. **AuthConfirmPage.tsx** - Good protection against email scanner auto-consumption
+3. **AuthGuard.tsx** - Client-side only protection (major issue - needs server-side RLS)
+4. **GuestBanner.tsx** - Tournament limit tracking for anonymous users
+5. **InviteAcceptScreen.tsx** - Token validation before accepting
+6. **MergeAccountDialog.tsx** - Account merge flow
+7. **merge-accounts Edge Function** - Server-side merge with proper JWT validation
+
+## Key Security Concerns I Can Identify:
+
+### Critical:
+1. **Client-side AuthGuard only** - No mention of Supabase RLS (Row Level Security) policies in the code. Client-side auth guards can be bypassed.
+
+
+2. **Token in URL** - Invite tokens exposed in URL parameters (potential logging, browser history)
+3. **No CSP configured** - No Content Security Policy mentioned in the code
+4. **No rate limiting** - No visible rate limiting on auth endpoints
+5. **Sensitive data in LocalStorage** - Need to check what's stored
+
+### High:
+1. **Error messages leak information** - Some error messages could reveal system information
+2. **No CSRF protection** - PWA with forms needs CSRF tokens
+3. **Missing security headers** - No mention of security headers in Vercel config
+4. **Password reset flow** - Could be improved with additional verification
+5. **No session timeout** - Sessions may persist indefinitely
+
+### Medium:
+1. **No input sanitization visible** - Need to check Zod schemas
+2. **No audit logging** - No security event logging
+3. **No 2FA support** - For admin accounts
+4. **No account lockout** - After failed login attempts
+5. **No secure cookie flags** - If using cookies
+
+### Recommendations:
+1. Implement Supabase RLS policies
+2. Add CSP headers
+3. Implement rate limiting
+4. Add security headers (Vercel config)
+5. Implement session timeout
+6. Add audit logging
+7. Consider 2FA for admins
+8. Implement account lockout
+
+Let me create a comprehensive security report.
+
+
+</details>
+
+---
+
+
+
+# 🔒 Security Audit Report: hallenfussball-pwa
+
+**Audit Date:** 2025-01-24  
+**Auditor:** Application Security Engineer  
+**Scope:** Authentication, Authorization, Data Protection, PWA Security  
+**Code Reviewed:** ~150k LOC (Auth Components, Edge Functions, Storage Layer)
+
+---
+
+## 📊 Security Score: **6.5/10**
+
+| Category | Score | Status |
+|----------|-------|--------|
+| Authentication | 7/10 | ⚠️ Needs Hardening |
+| Authorization | 4/10 | 🔴 Critical Gap |
+| Data Protection | 6/10 | ⚠️ Partial |
+| PWA Security | 5/10 | ⚠️ Missing Headers |
+| Input Validation | 7/10 | ✅ Good |
+
+---
+
+## 🔴 CRITICAL FINDINGS (Fix Immediately)
+
+### 1. **Missing Row Level Security (RLS) Policies**
+**Severity:** 🔴 Critical  
+**Location:** Supabase Database (not in code, but implied)  
+**Risk:** Client-side `AuthGuard` can be bypassed via API calls
+
+**Issue:**
+```tsx
+// src/features/auth/components/AuthGuard.tsx
+// Client-side only protection - NO server-side enforcement
+if (!user) {
+  onUnauthenticated?.();
+  return <div>Bitte melde dich an...</div>;
+}
+```
+
+**Impact:** Attacker can directly call Supabase API and access/modify any tournament data without authentication.
+
+**Recommendation:**
+```sql
+-- Enable RLS on ALL tables
+ALTER TABLE tournaments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams ENABLE ROW LEVEL SECURITY;
+
+-- Create policies (example)
+CREATE POLICY "Users can view own tournaments"
+ON tournaments FOR SELECT
+USING (auth.uid() IN (SELECT user_id FROM memberships WHERE tournament_id = tournaments.id));
+
+CREATE POLICY "Only members can modify tournaments"
+ON tournaments FOR ALL
+USING (auth.uid() IN (SELECT user_id FROM memberships WHERE tournament_id = tournaments.id));
+```
+
+---
+
+### 2. **Sensitive Tokens in URL Parameters**
+**Severity:** 🔴 Critical  
+**Location:** `AuthConfirmPage.tsx`, `InviteAcceptScreen.tsx`  
+**Risk:** Tokens logged in browser history, server logs, referer headers
+
+**Issue:**
+```tsx
+// src/features/auth/components/AuthConfirmPage.tsx
+const token = searchParams.get('token') ?? searchParams.get('token_hash');
+// Token visible in URL: /auth/confirm?token=abc123...
+
+// src/features/auth/components/InviteAcceptScreen.tsx
+void navigate(`/invite?token=${encodeURIComponent(token)}`, { replace: true });
+```
+
+**Impact:**
+- Browser history exposes tokens
+- Server logs may capture tokens
+- Referer header leaks tokens to third parties
+- Shared screen shows tokens
+
+**Recommendation:**
+```tsx
+// Use POST request instead of URL params
+const handleConfirm = async () => {
+  // Store token in memory only, not URL
+  const result = await supabase.auth.verifyOtp({
+    token_hash: token, // Supabase handles this securely
+    type: 'email',
+  });
+  // Clear token from memory immediately
+  // Redirect without token in URL
+  void navigate(redirectTo, { replace: true });
+};
+
+// For invites, use short-lived tokens + POST verification
+```
+
+---
+
+### 3. **No Content Security Policy (CSP)**
+**Severity:** 🔴 Critical  
+**Location:** Vercel Configuration (not in code)  
+**Risk:** XSS attacks, unauthorized script execution
+
+**Issue:** No CSP headers configured for PWA deployment.
+
+**Impact:**
+- XSS vulnerabilities can execute arbitrary scripts
+- Data exfiltration via malicious scripts
+- PWA can be hijacked
+
+**Recommendation:**
+```json
+// vercel.json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://*.vercel.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### 4. **No Rate Limiting on Auth Endpoints**
+**Severity:** 🔴 Critical  
+**Location:** Supabase Auth Configuration  
+**Risk:** Brute force attacks, credential stuffing, DoS
+
+**Issue:** No visible rate limiting on login, password reset, or magic link endpoints.
+
+**Impact:**
+- Unlimited login attempts
+- Password spraying attacks
+- Magic link flooding
+
+**Recommendation:**
+```typescript
+// In Supabase Dashboard → Auth → Rate Limiting
+// OR implement via Edge Functions
+
+// Example: Rate limit middleware
+export const rateLimit = (maxRequests: number, windowMs: number) => {
+  const requests = new Map<string, number[]>();
+  
+  return async (req: Request) => {
+    const ip = req.headers.get('x-forwarded-for') || 'unknown';
+    const now = Date.now();
+    const windowStart = now - windowMs;
+    
+    const userRequests = requests.get(ip) || [];
+    const validRequests = userRequests.filter(time => time > windowStart);
+    
+    if (validRequests.length >= maxRequests) {
+      return new Response('Too many requests', { status: 429 });
+    }
+    
+    validRequests.push(now);
+    requests.set(ip, validRequests);
+  };
+};
+```
+
+---
+
+## 🟠 HIGH FINDINGS (Before Next Release)
+
+### 5. **Session Timeout Not Configured**
+**Severity:** 🟠 High  
+**Location:** Supabase Auth Configuration  
+**Risk:** Stolen sessions remain valid indefinitely
+
+**Issue:** No session expiration policy visible. Default Supabase sessions may persist too long.
+
+**Recommendation:**
+```typescript
+// In Supabase Dashboard → Auth → Settings
+// Set session duration to 1 hour for sensitive operations
+// Implement refresh token rotation
+
+// In client code
+const { data: { session } } = await supabase.auth.getSession();
+if (session && Date.now() > session.expires_at * 1000 - 300000) {
+  // Refresh 5 minutes before expiry
+  await supabase.auth.refreshSession();
+}
+```
+
+---
+
+### 6. **No Account Lockout After Failed Attempts**
+**Severity:** 🟠 High  
+**Location:** `LoginScreen.tsx`, `RegisterScreen.tsx`  
+**Risk:** Brute force attacks on user accounts
+
+**Issue:**
+```tsx
+// src/features/auth/components/LoginScreen.tsx
+// No tracking of failed attempts
+const handleSubmit = async (e: React.FormEvent) => {
+  // ... login attempt
+  // No counter for failed attempts
+};
+```
+
+**Recommendation:**
+```typescript
+// Implement in Edge Function or Supabase Auth settings
+// Lock account after 5 failed attempts for 15 minutes
+
+// Client-side tracking (supplementary)
+const failedAttempts = localStorage.getItem('login_attempts');
+if (parseInt(failedAttempts || '0') >= 5) {
+  setError('Too many failed attempts. Try again in 15 minutes.');
+  return;
+}
+```
+
+---
+
+### 7. **Invite Tokens Not Short-Lived**
+**Severity:** 🟠 High  
+**Location:** `InviteDialog.tsx`, `InviteLinkDialog.tsx`  
+**Risk:** Stolen invite links can be used indefinitely
+
+**Issue:**
+```tsx
+// src/features/auth/components/InviteDialog.tsx
+const [expiresInDays, setExpiresInDays] = useState<number>(7);
+// User can select "Unbegrenzt" (0 days)
+```
+
+**Recommendation:**
+```typescript
+// Enforce maximum expiry in backend
+const MAX_INVITE_EXPIRY_DAYS = 7;
+
+// In Edge Function validation
+if (expiresInDays > MAX_INVITE_EXPIRY_DAYS) {
+  throw new Error('Invite expiry too long');
+}
+
+// Default to 24 hours for security
+const [expiresInDays, setExpiresInDays] = useState<number>(1);
+```
+
+---
+
+### 8. **No Input Sanitization for User-Generated Content**
+**Severity:** 🟠 High  
+**Location:** Tournament names, team names, user names  
+**Risk:** XSS via tournament/team names displayed in UI
+
+**Issue:**
+```tsx
+// src/features/auth/components/MemberList.tsx
+<p style={styles.memberName}>
+  {user?.name ?? 'Unbekannt'}
+</p>
+// No sanitization of user input
+```
+
+**Recommendation:**
+```typescript
+// Use DOMPurify or similar
+import DOMPurify from 'dompurify';
+
+const sanitize = (input: string) => DOMPurify.sanitize(input);
+
+// In display components
+<p>{sanitize(user?.name ?? 'Unbekannt')}</p>
+
+// OR use React's built-in escaping (preferred)
+// React automatically escapes text content
+// Only use dangerouslySetInnerHTML with sanitized content
+```
+
+---
+
+## 🟡 MEDIUM FINDINGS (Backlog)
+
+### 9. **No Audit Logging**
+**Severity:** 🟡 Medium  
+**Risk:** No visibility into security events
+
+**Recommendation:**
+```typescript
+// Log security events
+const logSecurityEvent = async (event: string, userId: string, details: object) => {
+  await supabase.from('security_logs').insert({
+    event_type: event,
+    user_id: userId,
+    details,
+    ip_address: '...',
+    timestamp: new Date().toISOString(),
+  });
+};
+
+// Log: login_success, login_failed, password_reset, role_change, etc.
+```
+
+---
+
+### 10. **No 2FA Support for Admin Accounts**
+**Severity:** 🟡 Medium  
+**Risk:** Admin accounts compromised via phishing
+
+**Recommendation:**
+```typescript
+// Implement TOTP-based 2FA
+// Store TOTP secret encrypted in database
+// Require 2FA for admin actions (role changes, tournament deletion)
+```
+
+---
+
+### 11. **Sensitive Data in LocalStorage**
+**Severity:** 🟡 Medium  
+**Location:** `IStorageAdapter.ts`  
+**Risk:** XSS can access stored tokens
+
+**Recommendation:**
+```typescript
+// Use httpOnly cookies instead of LocalStorage
+// OR encrypt sensitive data before storage
+
+// Example encryption
+import { encrypt, decrypt } from './crypto';
+
+const setSecure = async (key: string, value: string) => {
+  const encrypted = await encrypt(value);
+  await localStorage.setItem(key, encrypted);
+};
+```
+
+---
+
+### 12. **No Secure Cookie Flags**
+**Severity:** 🟡 Medium  
+**Risk:** Session hijacking via network attacks
+
+**Recommendation:**
+```typescript
+// If using cookies, set secure flags
+// In Vercel config or Supabase settings
+{
+  "secure": true,
+  "httpOnly": true,
+  "sameSite": "strict"
+}
+```
+
+---
+
+## ✅ POSITIVE FINDINGS
+
+1. **Good Auth Flow Design** - Magic links, OAuth, and password flows are well-structured
+2. **Token Validation** - Invite tokens are validated before use
+3. **Account Merge Security** - Edge function properly validates JWT and uses transactions
+4. **Focus Trap Implementation** - Good accessibility/security for modals
+5. **Offline Handling** - Graceful degradation when cloud unavailable
+6. **Type Safety** - TypeScript reduces injection risks
+7. **Error Handling** - User-friendly error messages without leaking internals
+
+---
+
+## 🛡️ SECURITY HARDENING RECOMMENDATIONS
+
+### Immediate Actions (Week 1)
+1. **Enable Supabase RLS** on all tables
+2. **Configure CSP headers** in Vercel
+3. **Set session timeout** to 1 hour
+4. **Enable rate limiting** on auth endpoints
+5. **Remove tokens from URL** - use POST for verification
+
+### Short Term (Month 1)
+1. Implement account lockout policy
+2. Add audit logging table
+3. Sanitize all user-generated content
+4. Set invite token expiry to 24 hours max
+5. Add security headers (X-Frame-Options, etc.)
+
+### Long Term (Quarter 1)
+1. Implement 2FA for admin accounts
+2. Add security event monitoring
+3. Implement secure session storage
+4. Add security training for developers
+5. Schedule regular security audits
+
+---
+
+## 📋 COMPLIANCE CHECKLIST
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| GDPR Data Minimization | ⚠️ Partial | Review what data is collected |
+| GDPR Right to Erasure | ❌ Missing | Need account deletion flow |
+| GDPR Data Export | ❌ Missing | Need data export feature |
+| Cookie Consent | ❌ Missing | Need consent banner |
+| Security Headers | ❌ Missing | Configure in Vercel |
+| RLS Policies | ❌ Missing | Critical for Supabase |
+| Rate Limiting | ❌ Missing | Configure in Supabase |
+| Audit Logging | ❌ Missing | Implement logging |
+| 2FA Support | ❌ Missing | For admin accounts |
+| Session Timeout | ⚠️ Partial | Configure in Supabase |
+
+---
+
+## 🎯 PRIORITY ACTION PLAN
+
+| Priority | Action | Owner | Deadline |
+|----------|--------|-------|----------|
+| 🔴 P0 | Enable Supabase RLS on all tables | Backend | 3 days |
+| 🔴 P0 | Configure CSP + Security Headers | DevOps | 3 days |
+| 🔴 P0 | Remove tokens from URL | Frontend | 1 week |
+| 🟠 P1 | Implement rate limiting | Backend | 1 week |
+| 🟠 P1 | Set session timeout | Backend | 1 week |
+| 🟠 P1 | Add account lockout | Backend | 2 weeks |
+| 🟡 P2 | Implement audit logging | Backend | 1 month |
+| 🟡 P2 | Sanitize user content | Frontend | 1 month |
+| 🟡 P2 | Add 2FA for admins | Fullstack | 2 months |
+
+---
+
+**Final Recommendation:** The application has good security foundations but lacks critical server-side protections. **Do not deploy to production** until RLS policies and security headers are implemented. The current score of 6.5/10 indicates significant security gaps that could lead to data breaches.
+
+**Next Audit:** Schedule follow-up audit after P0 items are completed.

--- a/reviews/2026-03-16_1935_sport_config.md
+++ b/reviews/2026-03-16_1935_sport_config.md
@@ -1,0 +1,343 @@
+# Code Review: Sport-Konfiguration & Datenmodell
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 32.7s  
+**Status:** success  
+**Code-Kontext:** 134,330 Zeichen  
+
+<details><summary>Thinking Process (3,140 Zeichen)</summary>
+
+The user wants me to analyze the data model and sport configuration for a sports tournament software (hallenfussball-pwa). They want a structured review with:
+
+1. Model Problems (missing constraints, inconsistencies)
+2. Schema Gaps (unvalidated inputs)
+3. Scalability Problems
+4. Positive Patterns
+5. Data Model Score (1-10)
+
+Let me analyze the code provided:
+
+## Key Areas to Review:
+
+### 1. Sport Configuration System
+- `src/config/sports/` - Football configs (indoor/outdoor)
+- `src/config/sports/types.ts` - SportConfig interface
+- `src/config/sports/index.ts` - Registry pattern
+
+### 2. Core Models
+- `src/core/models/LiveMatch.ts` - Runtime match state
+- `src/core/models/schemas/` - Zod validation schemas
+- `src/types/tournament.ts` - Domain types
+
+### 3. Database/Supabase Types
+- `src/types/supabase.ts` - Auto-generated DB types
+
+### 4. Constants & Options
+- `src/constants/` - DFB patterns, finals options, etc.
+
+## Issues I've Identified:
+
+### Model Problems:
+1. **Inconsistent SportId handling** - `SportId` type in `types.ts` vs `config/sports/types.ts`
+2. **Date handling** - `scheduledTime` can be `Date | string` in MatchSchema but JSON serialization loses Date type
+3. **Missing constraints** - No validation that teamA != teamB in Match
+4. **Tiebreaker logic** - `canDrawInFinals: false` but `hasShootout: true` - what if shootout is disabled?
+5. **Version control** - `version` field exists but no clear optimistic locking implementation
+6. **Match status enum** - `MatchStatus` defined in multiple places (tournament.ts, LiveMatch.ts)
+
+
+7. **Schema passthrough** - `.passthrough()` on Zod schemas can hide data corruption issues
+
+### Schema Gaps:
+1. **RuntimeMatchEventSchema** - `matchId` is optional but should be required
+2. **TournamentSchema** - `sport` and `sportId` both exist (redundant)
+3. **No validation** for score consistency (scoreA/scoreB should match events)
+4. **Missing validation** for team references in matches (teamA/teamB must exist in teams array)
+5. **No validation** for group assignments (group must exist in groups array)
+
+### Scalability Problems:
+1. **Hardcoded sport registry** - Adding new sports requires code changes
+2. **No sport versioning** - What if config changes mid-tournament?
+3. **Tiebreaker modes** - Limited to 3 modes, not extensible
+4. **Age classes** - Hardcoded in config, not configurable per tournament
+5. **DFB patterns** - Only supports 2-18 teams, no dynamic generation
+
+### Positive Patterns:
+1. **Zod validation** - Comprehensive runtime validation
+2. **Separation of concerns** - LiveMatch vs Match (runtime vs persisted)
+3. **Type safety** - Good TypeScript usage
+4. **Test coverage** - Tests for schemas and configs
+5. **Extensibility hooks** - `SportConfig` interface is well-designed
+6. **Passthrough strategy** - Preserves unknown fields for forward compatibility
+7. **Legacy compatibility** - Migration functions for old sport types
+
+### Data Model Score:
+I'd rate this around 7/10. The foundation is solid with good type safety and validation, but there are gaps in constraint enforcement and some architectural decisions that could limit future growth.
+
+
+</details>
+
+---
+
+
+
+# Code Review: Sport-Konfiguration & Datenmodell
+
+## Executive Summary
+
+Das Datenmodell ist **grundsätzlich solide** mit guter Trennung zwischen Runtime- und Persistenz-Modellen. Die Sport-Konfiguration ist gut strukturiert, aber es gibt kritische Inkonsistenzen bei Typ-Definitionen und fehlende Geschäftsregel-Validierungen.
+
+---
+
+## 1. Modell-Probleme
+
+### 🔴 Kritisch
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Doppelte Typ-Definitionen** | `types/tournament.ts` vs `config/sports/types.ts` | `SportId` wird an zwei Stellen definiert → Inkonsistenz-Risiko |
+| **Date-Handling** | `TournamentSchema.ts` | `scheduledTime?: Date` → JSON serialisiert zu String, Zod transformiert nicht automatisch |
+| **Fehlende Match-Constraints** | `MatchSchema` | Keine Validierung: `teamA !== teamB`, `teamA/teamB existieren in teams[]` |
+| **Tiebreaker-Logik** | `football.ts` | `canDrawInFinals: false` + `hasShootout: true` → Was wenn Shootout deaktiviert? |
+
+### 🟡 Mittel
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Status-Duplikation** | `LiveMatch.ts` vs `tournament.ts` | `MatchStatus` in beiden Dateien definiert |
+| **Passthrough-Risiko** | Alle Schemas | `.passthrough()` kann Datenkorruption verschleiern |
+| **Versionierung** | `LiveMatch.ts` | `version`-Feld existiert, aber kein Optimistic-Locking-Workflow |
+| **Redundante Felder** | `TournamentSchema` | `sport` (legacy) + `sportId` (neu) → Inkonsistenz möglich |
+
+### 🟢 Gering
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Score-Validierung** | `MatchSchema` | Keine Prüfung: `scoreA/scoreB` müssen mit `events` übereinstimmen |
+| **Gruppen-Referenzen** | `TournamentSchema` | `group` in Match muss in `groups[]` existieren |
+
+---
+
+## 2. Schema-Lücken
+
+### 🔴 Unvalidierte Eingaben
+
+```typescript
+// ❌ Problem: matchId ist optional, sollte required sein
+export const RuntimeMatchEventSchema = z.object({
+  id: z.string(),
+  matchId: z.string().optional(), // ← Sollte required sein!
+  // ...
+});
+
+// ❌ Problem: Keine Cross-Field-Validierung
+export const MatchSchema = z.object({
+  teamA: z.string(),
+  teamB: z.string(),
+  // ❌ Keine Prüfung: teamA !== teamB
+  // ❌ Keine Prüfung: teamA/teamB existieren in teams[]
+});
+
+// ❌ Problem: Date-Transformation fehlt
+export const MatchSchema = z.object({
+  scheduledTime: z.union([z.string(), z.date()]).optional(),
+  // ❌ Sollte transformieren: z.preprocess(...)
+});
+```
+
+### 🟡 Fehlende Geschäftsregeln
+
+```typescript
+// ❌ Keine Validierung für Finals-Logik
+// Wenn hasQuarterfinal=true, dann muss hasSemifinal=true sein
+// (Constraint existiert in tournamentSchemas.ts, aber nicht im Match-Schema)
+
+// ❌ Keine Prüfung: scoreA/scoreB >= 0
+// ❌ Keine Prüfung: events.timestampSeconds monoton steigend
+```
+
+---
+
+## 3. Erweiterbarkeits-Probleme
+
+### 🔴 Hardcoded Sport-Registry
+
+```typescript
+// ❌ Neue Sportart erfordert Code-Änderung
+export const sportRegistry = new Map<SportId, SportConfig>([
+  ['football-indoor', footballIndoorConfig],
+  ['football-outdoor', footballOutdoorConfig],
+  // ← Hand-Registrierung, keine dynamische Erweiterung
+]);
+```
+
+**Lösung:** Plugin-System oder dynamisches Laden aus DB/Config-File.
+
+### 🟡 Limitierte Tiebreaker-Modi
+
+```typescript
+export type TiebreakerMode =
+  | 'shootout'
+  | 'overtime-then-shootout'
+  | 'goldenGoal';
+// ❌ Keine Erweiterung ohne Code-Änderung
+```
+
+### 🟡 Age Classes nicht konfigurierbar
+
+```typescript
+// ❌ Hardcoded in Config, nicht pro-Tournament anpassbar
+ageClasses: [
+  { value: 'G-Jugend', label: 'G-Jugend (U7)', minAge: 5, maxAge: 7 },
+  // ...
+]
+```
+
+### 🟢 Positiv: DFB-Patterns
+
+```typescript
+// ✅ DFB_ROUND_ROBIN_PATTERNS ist erweiterbar
+// ✅ Unterstützt 2-18 Teams mit BYE-Logik
+```
+
+---
+
+## 4. Positive Patterns
+
+### ✅ Starke Trennung von Concerns
+
+```typescript
+// ✅ LiveMatch (Runtime) vs Match (Persistenz)
+export interface LiveMatch { /* Timer, Events, Status */ }
+export interface Match { /* DB-Schema, korrigierte Ergebnisse */ }
+```
+
+### ✅ Zod-Validierung mit Tests
+
+```typescript
+// ✅ Umfassende Testabdeckung
+describe('TournamentSchema round-trip', () => {
+  it('validates a complete tournament with all sub-schemas', () => {
+    // ...
+  });
+});
+```
+
+### ✅ Forward Compatibility
+
+```typescript
+// ✅ .passthrough() erhält unbekannte Felder
+export const TournamentSchema = z.object({
+  // ...
+}).passthrough();
+```
+
+### ✅ Legacy-Migration
+
+```typescript
+// ✅ BC-Funktionen für Migration
+export function legacySportToSportId(sport: 'football' | 'other'): SportId;
+export function sportIdToLegacySport(sportId: SportId): 'football' | 'other';
+```
+
+### ✅ Type-Safe Enums
+
+```typescript
+// ✅ Exhaustive Checks möglich
+export type MatchStatus = 'scheduled' | 'waiting' | 'running' | 'finished' | 'skipped';
+```
+
+---
+
+## 5. Datenmodell Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Typ-Sicherheit** | 8/10 | Gute TypeScript-Nutzung, aber Doppeldefinitionen |
+| **Validierung** | 6/10 | Zod vorhanden, aber fehlende Geschäftsregeln |
+| **Erweiterbarkeit** | 6/10 | Sport-Registry ist hardcoded |
+| **Datenintegrität** | 7/10 | Passthrough gut, aber Cross-Field-Validierung fehlt |
+| **Testabdeckung** | 9/10 | Umfassende Tests für Schemas und Configs |
+| **Dokumentation** | 8/10 | Gute JSDoc-Kommentare, aber fehlende Invarianten |
+
+### **Gesamtscore: 7.3/10**
+
+---
+
+## 6. Kritische Empfehlungen
+
+### 🔴 Sofort (P0)
+
+1. **Einheitliche SportId-Definition**
+   ```typescript
+   // src/config/sports/types.ts exportieren und importieren
+   export type { SportId } from './types';
+   // In types/tournament.ts entfernen
+   ```
+
+2. **Date-Transformation hinzufügen**
+   ```typescript
+   scheduledTime: z.preprocess(
+     (arg) => typeof arg === 'string' ? new Date(arg) : arg,
+     z.date().optional()
+   )
+   ```
+
+3. **Match-Constraints validieren**
+   ```typescript
+   z.object({
+     teamA: z.string(),
+     teamB: z.string(),
+   }).refine(data => data.teamA !== data.teamB, {
+     message: 'Teams müssen unterschiedlich sein'
+   })
+   ```
+
+### 🟡 Kurzfristig (P1)
+
+4. **Sport-Registry dynamisch machen**
+   ```typescript
+   // Config-File oder DB statt hardcoded Map
+   export async function loadSportRegistry(): Promise<Map<SportId, SportConfig>>;
+   ```
+
+5. **Cross-Field-Validierung**
+   ```typescript
+   // Prüfen: teamA/teamB existieren in teams[]
+   // Prüfen: group existiert in groups[]
+   ```
+
+### 🟢 Mittelfristig (P2)
+
+6. **Tiebreaker-Logik erweitern**
+   ```typescript
+   // Konfigurierbare Tiebreaker pro Tournament
+   tiebreaker: {
+     mode: TiebreakerMode,
+     enabled: boolean,
+     duration?: number
+   }
+   ```
+
+7. **Optimistic Locking implementieren**
+   ```typescript
+   // version-basierte Konflikterkennung bei Concurrent Updates
+   ```
+
+---
+
+## 7. Zusammenfassung
+
+**Stärken:**
+- ✅ Gute Trennung Runtime vs. Persistenz
+- ✅ Umfassende Zod-Validierung mit Tests
+- ✅ Type-Safe Enums und Discriminated Unions
+- ✅ Legacy-Migration unterstützt
+
+**Schwächen:**
+- ❌ Doppelte Typ-Definitionen
+- ❌ Fehlende Cross-Field-Validierung
+- ❌ Hardcoded Sport-Registry
+- ❌ Date-Handling nicht robust
+
+**Empfehlung:** Die Architektur ist solide, aber **Business-Logic-Validierungen** müssen in die Schemas integriert werden, bevor das System production-ready ist.

--- a/reviews/2026-03-16_1935_supabase_data.md
+++ b/reviews/2026-03-16_1935_supabase_data.md
@@ -1,0 +1,329 @@
+# Code Review: Supabase, Datenbank & Sync
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 41.7s  
+**Status:** success  
+**Code-Kontext:** 150,340 Zeichen  
+
+<details><summary>Thinking Process (2,609 Zeichen)</summary>
+
+The user wants a structured review of their Supabase/PostgreSQL architecture for a Hallenfussball (indoor soccer) PWA. They've provided extensive code including:
+
+1. Edge Functions (merge-accounts, validate-registration-code)
+2. Multiple SQL migrations (RLS policies, versioning, denormalization, indexes, etc.)
+3. Repository implementations (OfflineRepository, HybridRepository, LocalStorageRepository, SupabaseRepository, LiveMatch repositories)
+4. Storage adapters
+
+I need to analyze:
+1. Database Schema — Migrations, Foreign Keys, Indexes, Constraints
+2. Row Level Security (RLS) — Policies, Gaps, Security
+3. Auth Integration — Token handling, Anonymous users, Merge logic
+4. Realtime Subscriptions — Efficiency, Cleanup, Conflict Resolution
+5. LocalStorage ↔ Supabase Sync — Synchronization strategy, Offline-first
+6. Data Migration — Schema migration concepts
+7. Repository Pattern — Abstraction quality
+8. Connection Handling — Pooling, Retry, Error Recovery
+9. Edge Functions — Security, Usage
+10. Storage — File uploads, Policies
+
+Let me create a structured review with:
+- Critical DB/Auth Problems
+- Sync Problems
+- Optimization Potential
+- Positive Patterns
+- Supabase Score (1-10)
+
+Key observations from the code:
+
+**Database/RLS:**
+- Good denormalization strategy (owner_id, is_public on child tables)
+- Multiple RLS policy versions (v2, v3) - some cleanup needed
+- Optimistic locking with version columns (good!)
+- FK indexes added (good!)
+- Some potential RLS gaps with collaborator logic
+- Anonymous user limits implemented (good!)
+
+**Auth:**
+- Anonymous user merge flow is well-designed
+- Edge function for merge-accounts is secure
+- Registration code validation is server-side (good!)
+
+
+- Profile creation trigger is UPSERT safe
+
+**Sync:**
+- Offline-first architecture with LocalStorage + Supabase
+- Granular sync (metadata vs matches) - good optimization
+- Mutation queue for offline operations
+- Version-based conflict detection
+- Some potential issues with version handling in sync logic
+
+**Realtime:**
+- LiveMatch repository with Realtime subscriptions
+- Optimistic locking for match updates
+- Event caching strategy
+
+**Issues I notice:**
+1. RLS policy cleanup - old policies might still exist
+2. Some version handling inconsistencies in sync logic
+3. Potential race conditions in multi-tab scenarios (though Web Locks API is used)
+4. Some migrations might have ordering dependencies
+5. The search_path security fix is good but needs verification
+6. Some edge cases in anonymous user limits
+
+I'll structure the review to highlight these findings and provide actionable recommendations.
+
+
+</details>
+
+---
+
+
+
+# Supabase/PostgreSQL Architektur-Review: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt eine **hochgradig durchdachte Offline-First-Architektur** mit professioneller RLS-Implementierung, Optimistic Locking und granularer Synchronisation. Die Architektur ist für Multi-User-Szenarien und Live-Synchronisation gut vorbereitet.
+
+---
+
+## 🔴 Kritische DB/Auth-Probleme
+
+### 1. RLS Policy-Konflikte & Cleanup-Risiko
+**Problem:** Migration `20260128_002_consolidate_rls_v3.sql` erstellt v3-Policies, aber `20260128_006_drop_old_policies.sql` (nicht im Code) wird benötigt.
+
+**Risiko:** Wenn v2-Policies nicht explizit gelöscht werden, können sie mit v3 kollidieren oder veraltete Zugriffsrechte gewähren.
+
+**Lösung:**
+```sql
+-- Vor dem Deployment prüfen:
+SELECT tablename, policyname, roles, cmd, qual, with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+ORDER BY tablename, policyname;
+
+-- Alte Policies explizit löschen (in einer separaten Migration)
+DROP POLICY IF EXISTS "tournaments_select_v2" ON tournaments;
+DROP POLICY IF EXISTS "teams_select_v2" ON teams;
+-- ... alle v2 Policies
+```
+
+### 2. Optimistic Locking Race Condition bei Match-Initialisierung
+**Problem:** In `SupabaseLiveMatchRepository.save()`:
+```ts
+// Version-Mismatch bei "not_started" Status wird als Initialisierung behandelt
+if (currentMatch && (currentMatch.match_status === 'not_started' || ...)) {
+  // Retry mit currentVersion
+}
+```
+
+**Risiko:** Wenn ein Match parallel von zwei Clients initialisiert wird, kann dies zu inkonsistenten `live_state`-Daten führen.
+
+**Lösung:**
+- Match-Initialisierung sollte atomar über eine **Edge Function** erfolgen
+- Oder: `live_state` nur einmalig setzen (INSERT statt UPDATE)
+
+### 3. Anonymous User Limit - RLS vs. Function
+**Problem:** Die Limit-Prüfung erfolgt in der RLS-Policy (`tournaments_insert_v3`), aber die Funktion `count_active_tournaments()` hat `SECURITY DEFINER`.
+
+**Risiko:** Wenn jemand direkt SQL ausführt (nicht über Edge Functions), kann das Limit umgangen werden.
+
+**Lösung:**
+- `count_active_tournaments()` sollte **nicht** `SECURITY DEFINER` sein
+- Oder: Limit auch in der Edge Function prüfen (dual validation)
+
+### 4. Denormalized Owner Sync - Trigger Race Condition
+**Problem:** Trigger `sync_owner_from_tournament()` setzt `owner_id` bei INSERT, aber wenn `tournaments`-Tabelle später geändert wird, bleiben `teams`/`matches` veraltet.
+
+**Risiko:** Inkonsistente `owner_id`-Werte nach `tournament.owner_id`-Änderung.
+
+**Lösung:**
+- Trigger auf `tournaments`-UPDATE hinzufügen, der alle Kinder aktualisiert
+- Oder: `owner_id` in RLS-Policies dynamisch aus `tournaments` berechnen (langsamer, aber sicherer)
+
+---
+
+## 🟡 Sync-Probleme
+
+### 1. Version-Inkrementierung in LocalStorageRepository
+**Problem:**
+```ts
+// LocalStorageRepository.save()
+list[index] = { ...tournament, version: currentVersion + 1, ... };
+```
+
+**Risiko:** Bei Offline-Operationen wird die Version **lokal** inkrementiert, aber die Cloud-Version bleibt gleich. Nach Sync kann es zu Konflikten kommen.
+
+**Lösung:**
+- Version sollte **nur** bei Cloud-Sync aktualisiert werden
+- LocalStorage sollte `pendingVersion` separat tracken
+- `OfflineRepository.syncUp()` sollte Version-Konflikte explizit auflösen
+
+### 2. Granular Sync - Delta-Erkennung unvollständig
+**Problem:** `OfflineRepository.syncTournamentDelta()` prüft nur `version`, nicht strukturelle Änderungen.
+
+**Risiko:** Wenn Teams umbenannt werden (gleiche IDs), wird Full-Save ausgelöst (ineffizient).
+
+**Lösung:**
+- Hash-basierte Delta-Erkennung (z.B. `JSON.stringify(matches)` hash)
+- Oder: `match_events` statt `matches` für Score-Updates verwenden
+
+### 3. MutationQueue - Keine Retry-Backoff-Strategie
+**Problem:** `MutationQueue` queueing ist implementiert, aber kein exponentieller Backoff bei wiederholten Fehlern.
+
+**Risiko:** Bei instabiler Verbindung werden viele Requests gesendet, was zu Rate-Limiting führen kann.
+
+**Lösung:**
+```ts
+// In MutationQueue
+private async processQueue() {
+  let retryCount = 0;
+  while (this.queue.length > 0) {
+    try {
+      await this.processMutation(this.queue[0]);
+      retryCount = 0;
+    } catch (error) {
+      retryCount++;
+      const delay = Math.min(1000 * Math.pow(2, retryCount), 30000);
+      await sleep(delay);
+    }
+  }
+}
+```
+
+---
+
+## 🟢 Optimierungspotenzial
+
+### 1. RLS Performance - Denormalisierung ist gut!
+**Status:** ✅ **Ausgezeichnet**
+- `owner_id` und `is_public` auf allen Child-Tabellen
+- Vermeidet `EXISTS`-Subqueries in RLS
+- **100x schneller** als JOIN-basierte Policies
+
+**Empfehlung:**
+- `owner_id` auf `NOT NULL` setzen (nach Backfill)
+- Index auf `(owner_id, is_public)` für kombinierte Queries
+
+### 2. Index-Strategie
+**Status:** ✅ **Sehr gut**
+- FK-Indexes für `team_a_id`, `team_b_id` (kritisch für LiveMatch)
+- Audit-Trail-Indexes für `last_modified_by`
+- Cleanup von ungenutzten `is_public`-Indexes
+
+**Empfehlung:**
+- Partial Index für `is_public = true` (bereits vorhanden)
+- `EXCLUDE`-Index für `share_code` (bereits vorhanden)
+- Consider: `BRIN`-Index für `updated_at` (zeitbasierte Queries)
+
+### 3. Optimistic Locking Implementation
+**Status:** ✅ **Professionell**
+- `version`-Spalte auf allen relevanten Tabellen
+- Trigger-basierte Auto-Inkrementierung
+- CAS-Pattern in `SupabaseLiveMatchRepository.save()`
+
+**Empfehlung:**
+- `version`-Spalte auch auf `tournaments` (fehlt aktuell)
+- `version`-Check auch in `updateMatches()` (nicht nur `save()`)
+
+### 4. Realtime Subscriptions Cleanup
+**Problem:** `SupabaseLiveMatchRepository` speichert Subscriptions in `Map`, aber kein `unsubscribe()` bei Component-Unmount.
+
+**Risiko:** Memory Leaks bei häufigen Navigationen.
+
+**Lösung:**
+```ts
+// In SupabaseLiveMatchRepository
+async unsubscribe(tournamentId: string) {
+  const channel = this.subscriptions.get(tournamentId);
+  if (channel) {
+    await supabase.removeChannel(channel);
+    this.subscriptions.delete(tournamentId);
+  }
+}
+```
+
+### 5. Edge Function - Rate Limiting
+**Problem:** `validate-registration-code` hat kein Rate Limiting.
+
+**Risiko:** Brute-Force-Angriffe auf Registrierungs-Codes.
+
+**Lösung:**
+- Supabase Edge Functions Rate Limiting aktivieren
+- Oder: Redis-basiertes Rate Limiting in der Function
+
+---
+
+## ✅ Positive Patterns
+
+### 1. Offline-First mit Granularer Sync
+**Exzellent:**
+- `OfflineRepository` mit LocalStorage + Cloud
+- Granularer Sync (Metadata vs. Matches)
+- MutationQueue für persistente Hintergrund-Sync
+
+### 2. Anonymous User Merge Flow
+**Exzellent:**
+- Edge Function `merge-accounts` mit Service Role
+- Atomare PostgreSQL-Funktion `merge_user_data()`
+- Validierung vor und nach dem Merge
+
+### 3. RLS mit Denormalisierung
+**Exzellent:**
+- `owner_id` auf allen Tabellen
+- Trigger-basierte Synchronisation
+- Partial Indexes für `is_public = true`
+
+### 4. Optimistic Locking mit Version
+**Exzellent:**
+- Trigger-basierte Auto-Inkrementierung
+- CAS-Pattern in Repository
+- `OptimisticLockError` für UI-Feedback
+
+### 5. Security Hardening
+**Exzellent:**
+- `SECURITY DEFINER` mit `SET search_path = public, pg_temp`
+- Keine direkten `auth.uid()` in Funktionen (vermeidet RLS-Recursion)
+- Edge Functions mit JWT-Validierung
+
+---
+
+## 📊 Supabase Score: **8.5/10**
+
+| Kategorie | Score | Bewertung |
+|-----------|-------|-----------|
+| **RLS Security** | 9/10 | Sehr gut, aber Cleanup nötig |
+| **Schema Design** | 9/10 | Denormalisierung exzellent |
+| **Sync Architecture** | 8/10 | Offline-First gut, Version-Handling verbesserbar |
+| **Auth Integration** | 9/10 | Merge-Flow professionell |
+| **Performance** | 8/10 | Indexe gut, aber Realtime Cleanup fehlt |
+| **Error Handling** | 7/10 | Retry-Strategie unvollständig |
+| **Maintainability** | 8/10 | Migrationen gut strukturiert |
+
+---
+
+## 🚀 Priorisierte Action Items
+
+### P0 (Kritisch)
+1. **RLS Policy Cleanup** - Alte v2-Policies explizit löschen
+2. **Version-Handling Fix** - LocalStorage Version nicht inkrementieren vor Cloud-Sync
+3. **Realtime Cleanup** - `unsubscribe()` bei Component-Unmount
+
+### P1 (Hoch)
+4. **Retry-Backoff** - Exponentieller Backoff in MutationQueue
+5. **Match Initialization** - Atomare Initialisierung via Edge Function
+6. **Owner Sync Trigger** - Trigger auf `tournaments.UPDATE` für Kinder
+
+### P2 (Mittel)
+7. **Version auf tournaments** - `version`-Spalte auch auf `tournaments`
+8. **Rate Limiting** - Für `validate-registration-code`
+9. **BRIN Index** - Für `updated_at`-basierte Queries
+
+---
+
+## 📝 Zusammenfassung
+
+Die Architektur ist **professionell und production-ready** mit wenigen kritischen Lücken. Die Denormalisierungs-Strategie für RLS ist exzellent, und das Offline-First-Design mit granularer Sync ist für eine PWA ideal. Die größten Risiken liegen in der **RLS-Policy-Konsistenz** und **Version-Handling** bei Offline-Operationen.
+
+**Empfehlung:** P0-Items vor Production-Release fixen, P1-Items im nächsten Sprint.

--- a/reviews/2026-03-16_1935_testing.md
+++ b/reviews/2026-03-16_1935_testing.md
@@ -1,0 +1,468 @@
+# Code Review: Testing & Qualitaetssicherung
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 45.0s  
+**Status:** success  
+**Code-Kontext:** 99,118 Zeichen  
+
+<details><summary>Thinking Process (2,769 Zeichen)</summary>
+
+Der Nutzer möchte eine umfassende Analyse der Test-Strategie für das "hallenfussball-pwa" Projekt. Ich habe den Code-Review erhalten, der verschiedene Test-Dateien und Test-Setup enthält. Ich muss als QA-Lead und Testing-Experte eine strukturierte Analyse erstellen.
+
+Lass mich die Test-Strategie analysieren:
+
+1. **Test-Pyramide Analyse:**
+   - Unit Tests: Es gibt Unit Tests für Utilities (calculations, scheduleGenerator, playoffResolver, teamDisplayNames, design-tokens)
+   - Integration Tests: Nicht explizit sichtbar
+   - E2E Tests: Nicht im Code sichtbar
+   - Component Tests: Custom render setup vorhanden, aber keine konkreten Component Tests sichtbar
+
+2. **Testabdeckung:**
+   - Core Business Logic: calculations, scheduleGenerator, playoffResolver - gut abgedeckt
+   - Design Tokens: cssVars, token-sync - gut abgedeckt
+   - UI Components: Keine sichtbaren Component Tests
+   - API/Supabase Integration: Keine Tests sichtbar
+   - Realtime Features: Keine Tests sichtbar
+   - PWA Features: Keine Tests sichtbar
+   - i18n: Mock vorhanden, aber keine Tests der tatsächlichen Übersetzungen
+
+3. **Test-Qualität:**
+   - Factories: Gut strukturiert (createMockTournament, createMockTeam, etc.)
+   - Setup: Solides Setup mit i18n Mock, localStorage Mock, etc.
+   - Test-Daten: Realistische Mock-Daten vorhanden
+   - Edge Cases: Werden teilweise getestet (z.B. 2 Teams, 13 Teams, 64 Teams)
+   - Known Issues: 128 Teams Test ist .skip() - bekanntes Problem
+
+4. **Testlücken:**
+   - Keine E2E Tests (Playwright/Cypress)
+   - Keine Accessibility Tests
+   - Keine Performance Tests
+   - Keine Security Tests
+   - Keine Supabase Integration Tests
+   - Keine Realtime Tests
+   - Keine PWA Tests (Service Worker, Offline)
+   - Keine Component Tests für React Components
+   - Keine Snapshot Tests
+
+5. **Test-Qualitätsprobleme:**
+   - Test-Daten teilweise hardcodiert
+   - Keine Test-Daten-Factories für komplexe Szenarien
+   - Keine Test-Abdeckungs-Metriken sichtbar
+   - Keine Flaky-Test-Management
+   - Keine Performance-Baseline für Tests
+
+6. **Fehlende Test-Typen:**
+   - E2E Tests
+   - Accessibility Tests (a11y)
+   - Performance Tests
+   - Security Tests
+   - Integration Tests mit Supabase
+   - Realtime Tests
+   - PWA Tests
+   - Component Tests
+
+7. **Empfehlungen:**
+   - Priorität 1: E2E Tests für kritische Pfade
+   - Priorität 2: Accessibility Tests
+   - Priorität 3: Supabase Integration Tests
+   - Priorität 4: Performance Tests
+   - Priorität 5: Component Tests
+
+8. **Testing Score:**
+   - Unit Tests: 7/10 (gut für Business Logic, aber keine Component Tests)
+   - Integration Tests: 3/10 (fehlend)
+   - E2E Tests: 0/10 (fehlend)
+   - Accessibility: 0/10 (fehlend)
+   - Overall: 4/10
+
+Ich sollte eine strukturierte Analyse mit konkreten Empfehlungen erstellen.
+
+
+</details>
+
+---
+
+
+
+# 🧪 Test-Strategie Analyse: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt **starke Unit-Test-Abdeckung für Business-Logic** (Schedule-Generierung, Standings-Berechnung, Playoff-Resolver), aber **kritische Lücken** in E2E, Integration und UI-Testing. Die Test-Infrastruktur ist solide aufgebaut, deckt aber nicht die gesamte Anwendung ab.
+
+---
+
+## 📊 Testing Score: **4.2/10**
+
+| Kategorie | Score | Status |
+|-----------|-------|--------|
+| Unit Tests (Business Logic) | 7.5/10 | ✅ Gut |
+| Component Tests | 0/10 | ❌ Fehlend |
+| Integration Tests | 2/10 | ⚠️ Minimal |
+| E2E Tests | 0/10 | ❌ Fehlend |
+| Accessibility Tests | 0/10 | ❌ Fehlend |
+| Performance Tests | 1/10 | ⚠️ Baseline vorhanden |
+| Security Tests | 0/10 | ❌ Fehlend |
+| PWA/Offline Tests | 0/10 | ❌ Fehlend |
+
+---
+
+## 🔴 Testlücken (Ungetestete Kritische Pfade)
+
+### 1. **Supabase Integration & Realtime**
+```
+❌ Keine Tests für:
+   - Supabase Auth Flow (Login, Register, Password Reset)
+   - Realtime Subscription (Live-Score Updates)
+   - Database CRUD Operations
+   - Row-Level Security Policies
+   - Offline Sync mit Supabase
+```
+
+**Impact:** 🔴 **KRITISCH** - Kern-Features der PWA
+
+### 2. **React Components**
+```
+❌ Keine Component Tests für:
+   - Tournament Wizard (Multi-Step Form)
+   - Live-Cockpit (Timer, Score-Entry)
+   - Playoff Bracket Visualization
+   - PDF Export Functionality
+   - Monitor/Anzeigetafel View
+```
+
+**Impact:** 🔴 **KRITISCH** - UI-Interaktionen nicht validiert
+
+### 3. **E2E User Flows**
+```
+❌ Keine E2E Tests für:
+   - Turnier-Erstellung bis Publishing
+   - Live-Score Entry während Turnier
+   - Public View (Zuschauer)
+   - Multi-User Concurrent Access
+   - Mobile Responsiveness
+```
+
+**Impact:** 🔴 **KRITISCH** - User Experience nicht validiert
+
+### 4. **Accessibility (a11y)**
+```
+❌ Keine Accessibility Tests:
+   - Screen Reader Compatibility
+   - Keyboard Navigation
+   - Color Contrast
+   - ARIA Labels
+   - Focus Management
+```
+
+**Impact:** 🟡 **HOCH** - Compliance-Risiko
+
+### 5. **PWA Features**
+```
+❌ Keine PWA Tests:
+   - Service Worker Caching
+   - Offline Functionality
+   - Install Prompt
+   - Background Sync
+   - Push Notifications
+```
+
+**Impact:** 🟡 **HOCH** - PWA-Kernfeatures nicht validiert
+
+---
+
+## ⚠️ Test-Qualitätsprobleme
+
+### 1. **Fragile Test-Daten**
+```typescript
+// src/test-data/mockTournament.ts
+// Problem: Hardcodierte Team-Namen und IDs
+const MOCK_TEAMS: Team[] = [
+  { id: 'team-1', name: 'TSV Grünwald', ... },
+  { id: 'team-2', name: 'FC Bayern München II', ... },
+  // ...
+];
+```
+**Problem:** Test-Daten sind nicht isoliert, können bei Änderungen brechen.
+
+**Lösung:** Factory Pattern konsistent verwenden (wie in `factories.ts`)
+
+### 2. **Missing Test Coverage für Edge Cases**
+```typescript
+// fairScheduler.minimal.test.ts
+it.skip('completes 128 teams (stress test - KNOWN ISSUE)', () => {
+  // ⚠️ Bekannter Bug, aber nicht dokumentiert oder gefixt
+});
+```
+**Problem:** Bekannte Bugs werden mit `.skip()` umgangen statt gefixt.
+
+**Lösung:** Known Issues im Issue-Tracker dokumentieren, nicht in Tests
+
+### 3. **Inconsistent Team Matching**
+```typescript
+// calculations.test.ts
+it('matches teams by name', () => {
+  teamA: 'Team 1' // String Name
+});
+
+it('matches teams by ID (edge case)', () => {
+  teamA: 'team-1' // ID
+});
+```
+**Problem:** Inkonsistente Team-Referenzierung (Name vs ID) kann zu Bugs führen.
+
+**Lösung:** Einheitliche ID-basierte Referenzierung erzwingen
+
+### 4. **No Test Coverage for Error Handling**
+```typescript
+// Keine Tests für:
+- Network Failures
+- Supabase Errors
+- Invalid Input Validation
+- Timeout Scenarios
+```
+
+### 5. **Missing Snapshot Tests**
+```typescript
+// Keine Snapshot Tests für:
+- UI Component Rendering
+- PDF Output Structure
+- Bracket Visualization
+```
+
+---
+
+## 🎯 Fehlende Test-Typen
+
+| Test-Typ | Status | Priorität |
+|----------|--------|-----------|
+| **E2E Tests (Playwright)** | ❌ Fehlend | 🔴 P1 |
+| **Accessibility Tests (axe-core)** | ❌ Fehlend | 🔴 P1 |
+| **Component Tests (RTL)** | ❌ Fehlend | 🔴 P1 |
+| **Supabase Integration Tests** | ❌ Fehlend | 🔴 P1 |
+| **Realtime Tests (WebSocket)** | ❌ Fehlend | 🟡 P2 |
+| **Performance Tests (Lighthouse)** | ⚠️ Baseline | 🟡 P2 |
+| **Security Tests (OWASP)** | ❌ Fehlend | 🟡 P2 |
+| **PWA Tests (Workbox)** | ❌ Fehlend | 🟡 P2 |
+| **Visual Regression Tests** | ❌ Fehlend | 🟢 P3 |
+| **Contract Tests (API)** | ❌ Fehlend | 🟢 P3 |
+
+---
+
+## 📋 Empfehlungen (Priorisiert)
+
+### 🔴 **P1 - Kritisch (Sofort umsetzen)**
+
+#### 1. E2E Test-Setup mit Playwright
+```bash
+npm install -D @playwright/test
+```
+
+**Test-Coverage:**
+```typescript
+// tests/e2e/tournament-creation.spec.ts
+test('should create and publish a tournament', async ({ page }) => {
+  await page.goto('/');
+  await page.click('button:has-text("Neues Turnier")');
+  // ... Wizard Steps
+  await expect(page).toHaveURL(/\/tournament\/\w+$/);
+});
+```
+
+#### 2. Component Test-Setup mit React Testing Library
+```typescript
+// src/components/__tests__/LiveScoreInput.test.tsx
+test('should update score on button click', async () => {
+  const { user } = render(<LiveScoreInput />);
+  await user.click(screen.getByRole('button', { name: '+1' }));
+  expect(screen.getByText('1')).toBeInTheDocument();
+});
+```
+
+#### 3. Accessibility Tests
+```typescript
+// tests/a11y/tournament-view.spec.ts
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+test('should have no accessibility violations', async () => {
+  const { container } = render(<TournamentView />);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+### 🟡 **P2 - Hoch (Nächste Sprint)**
+
+#### 4. Supabase Integration Tests
+```typescript
+// src/integration/__tests__/supabase.spec.ts
+import { createClient } from '@supabase/supabase-js';
+
+test('should create tournament in database', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const { data, error } = await supabase
+    .from('tournaments')
+    .insert({ title: 'Test' });
+  
+  expect(error).toBeNull();
+  expect(data).toBeDefined();
+});
+```
+
+#### 5. Realtime Tests
+```typescript
+// src/integration/__tests__/realtime.spec.ts
+test('should receive live score updates', async () => {
+  const subscription = supabase
+    .channel('scores')
+    .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'matches' }, (payload) => {
+      expect(payload.new.scoreA).toBe(2);
+    })
+    .subscribe();
+  
+  // Trigger update
+  await supabase.from('matches').update({ scoreA: 2 }).eq('id', 'match-1');
+  
+  subscription.unsubscribe();
+});
+```
+
+#### 6. Performance Baseline
+```typescript
+// tests/performance/schedule-generation.spec.ts
+test('should generate schedule for 64 teams in <5s', async () => {
+  const start = performance.now();
+  await generateSchedule(64);
+  const duration = performance.now() - start;
+  expect(duration).toBeLessThan(5000);
+});
+```
+
+### 🟢 **P3 - Mittel (Langfristig)**
+
+#### 7. Visual Regression Tests
+```typescript
+// tests/visual/bracket.spec.ts
+import { matchSnapshot } from '@applitools/eyes-playwright';
+
+test('should render bracket correctly', async ({ page }) => {
+  await page.goto('/tournament/bracket');
+  await matchSnapshot('bracket-view');
+});
+```
+
+#### 8. Contract Tests für API
+```typescript
+// tests/contract/api.spec.ts
+import { Pact } from '@pact-foundation/pact';
+
+test('should match tournament API contract', async () => {
+  // Verify API responses match expected schema
+});
+```
+
+---
+
+## 🏗️ Test-Strategie Verbesserungen
+
+### 1. **Test-Pyramide Optimierung**
+
+```
+        E2E (5-10%)
+       /    \
+      /      \
+ Integration (20-30%)
+    /          \
+   /            \
+Component (30-40%)
+  /              \
+ /                \
+Unit (40-50%)
+```
+
+**Aktuell:** 90% Unit, 10% Sonstiges  
+**Ziel:** 50% Unit, 30% Component, 15% Integration, 5% E2E
+
+### 2. **Test-Daten-Management**
+
+```typescript
+// src/test/factories.ts (erweitern)
+export const createTournamentFactory = factory<Tournament>({
+  id: () => `tournament-${uuid()}`,
+  title: () => `Test Tournament ${random()}`,
+  teams: (n) => createMockTeams(n),
+  matches: (t) => createMockMatches(t.teams),
+});
+
+// Usage
+const tournament = createTournamentFactory.build({
+  numberOfTeams: 8,
+  groupSystem: 'roundRobin',
+});
+```
+
+### 3. **CI/CD Integration**
+
+```yaml
+# .github/workflows/test.yml
+name: Test Suite
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci
+      - run: npm run test:unit
+      - run: npm run test:integration
+      - run: npm run test:e2e
+      - run: npm run test:a11y
+      - run: npm run test:coverage
+```
+
+### 4. **Test Coverage Thresholds**
+
+```json
+// package.json
+{
+  "scripts": {
+    "test:coverage": "vitest run --coverage"
+  },
+  "coverage": {
+    "thresholds": {
+      "lines": 80,
+      "functions": 80,
+      "branches": 70,
+      "statements": 80
+    }
+  }
+}
+```
+
+---
+
+## 📈 Roadmap
+
+| Phase | Zeitraum | Ziele |
+|-------|----------|-------|
+| **Phase 1** | Sprint 1-2 | E2E Tests, Component Tests, Accessibility |
+| **Phase 2** | Sprint 3-4 | Supabase Integration, Realtime Tests |
+| **Phase 3** | Sprint 5-6 | Performance, Security, PWA Tests |
+| **Phase 4** | Sprint 7+ | Visual Regression, Contract Tests |
+
+---
+
+## 🎯 Fazit
+
+**Stärken:**
+- ✅ Solide Unit-Test-Infrastruktur (Vitest, Factories)
+- ✅ Gute Business-Logic Abdeckung
+- ✅ Design Token Synchronisation getestet
+
+**Schwächen:**
+- ❌ Keine E2E/Integration Tests
+- ❌ Keine Component Tests
+- ❌ Keine Accessibility/PWA Tests
+- ⚠️ Bekannte Bugs werden umgangen statt gefixt
+
+**Empfehlung:** Test-Strategie um **E2E und Component Tests** erweitern, um Produktions-Release-Sicherheit zu gewährleisten. Priorität auf **kritische User Flows** (Turnier-Erstellung, Live-Score) setzen.

--- a/reviews/2026-03-16_1935_tournament_admin.md
+++ b/reviews/2026-03-16_1935_tournament_admin.md
@@ -1,0 +1,421 @@
+# Code Review: Turnier-Admin & Playoff-Logik
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 44.7s  
+**Status:** success  
+**Code-Kontext:** 151,454 Zeichen  
+
+<details><summary>Thinking Process (2,297 Zeichen)</summary>
+
+Der Nutzer bittet um eine Analyse der Admin-Features und Playoff-Logik basierend auf dem bereitgestellten Code. Ich muss systematisch prüfen:
+
+1. **Playoff-Bracket** — Wird korrekt generiert? Ist Seeding fair (1. vs Letzter)?
+2. **Tiebreaker-Regeln** — Was passiert bei Punktgleichheit? Direkter Vergleich → Tordifferenz → Torverhältnis → Los?
+3. **Bye-Handling** — Wie werden Freilose in Playoffs behandelt? Automatischer Sieg ohne Ergebnis?
+4. **Team-Zurückziehung** — Was passiert, wenn ein Team mitten im Turnier ausscheidet?
+5. **Nachträgliche Änderungen** — Ergebnis-Korrektur nach Spielende? Auswirkung auf Tabelle?
+6. **Turnier-Abbruch** — Kann ein Turnier vorzeitig beendet werden? Endstand?
+7. **Spielplan-Regenerierung** — Kann der Spielplan nach Start geändert werden?
+8. **Multi-Gruppen → Playoff** — Übergang korrekt? Kreuzspiele?
+9. **Dritter-Platz-Spiel** — Optional? Korrekt integriert?
+10. **Export** — PDF-Spielplan, Ergebnisse. Vollständig und korrekt?
+
+Aus dem Code sehe ich:
+- `TournamentAdminCenter.tsx` — Haupt-Container für Admin-Funktionen
+- `ActivityLogCategory.tsx` — Audit Trail für Änderungen
+- `DangerZoneCategory.tsx` — Kritische Aktionen (Regenerierung, Reset, Ende, Archivierung, Löschung)
+- `DashboardCategory.tsx` — Übersicht mit Statistiken
+- `ExportsCategory.tsx` — Export und Backup
+- `HelpCategory.tsx` — Hilfe und Support
+- `MatchCockpitCategory.tsx` — Live-Cockpit-Konfiguration
+- `MetadataCategory.tsx` — Turnier-Metadaten
+- `NotificationsCategory.tsx` — Push-Benachrichtigungen (Coming Soon)
+- `SettingsCategory.tsx` — Turnier-Einstellungen
+- `SponsorsCategory.tsx` — Sponsoren-Management
+- `TeamHelpersCategory.tsx` — Team- und Helfer-Management
+- `VisibilityCategory.tsx` — Sichtbarkeit und QR-Code
+- `LiveMatch.ts` — Live-Match-Modell
+
+Ich muss die Code-Struktur analysieren und potenzielle Probleme identifizieren. Die Admin-Features sind gut strukturiert, aber es gibt einige kritische Lücken in der Playoff-Logik und Turnierverwaltung.
+
+Die Implementierung zeigt eine solide Basis, aber spezifische Turnier-Management-Aspekte wie Playoff-Bracket-Generierung und Tiebreaker-Regeln sind nicht vollständig implementiert. Die bestehenden Komponenten bieten einen Rahmen, aber die tiefergehende Turnierlogik muss noch detailliert ausgearbeitet werden.
+
+
+</details>
+
+---
+
+
+
+# 🏆 Tournament Admin & Playoff Logic Review
+
+## Executive Summary
+
+Die Admin-Struktur ist **exzellent** (modular, responsive, UX-fokussiert), aber die **Playoff-Logik und Turnier-Engine** sind in den bereitgestellten Dateien **nicht implementiert**. Die Admin-Features sind "Container" für Funktionen, die in anderen Modulen liegen müssen.
+
+---
+
+## 🔍 Systematische Analyse
+
+### 1. **Playoff-Bracket-Generierung**
+
+**Status:** ❌ **NICHT IM CODE VORHANDEN**
+
+- Keine `PlayoffBracketGenerator`-Komponente gefunden
+- Keine `generatePlayoffBracket()`-Funktion in den Imports
+- `generateFullSchedule()` wird in `ExportsCategory.tsx` importiert, aber nicht implementiert
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/playoffBracketGenerator.ts
+function generatePlayoffBracket(
+  teams: Team[], 
+  groupStandings: GroupStandings[],
+  bracketSize: number
+): Match[] {
+  // 1. Seeding: 1. Platz Gruppe A vs 4. Platz Gruppe B
+  // 2. Bracket-Struktur: Quarter → Semi → Final
+  // 3. Bye-Handling bei ungerader Teamzahl
+}
+```
+
+**Logik-Fehler:**
+- Kein Seeding-Algorithmus (1. vs Letzter)
+- Keine Bracket-Struktur-Validierung
+- Keine Kreuzspiel-Logik (A1 vs B4, B1 vs A4)
+
+---
+
+### 2. **Tiebreaker-Regeln**
+
+**Status:** ⚠️ **PARTIELL IMPLEMENTIERT**
+
+In `LiveMatch.ts` existieren Tiebreaker-Typen:
+```typescript
+export type TiebreakerMode = 'shootout' | 'overtime-then-shootout' | 'goldenGoal';
+```
+
+**Fehlende Implementierung:**
+- Keine `calculateStandings()`-Logik für Gruppenphase (Punkte → Tordifferenz → Tore → Direkter Vergleich)
+- Keine `resolveTiebreaker()`-Funktion für Playoff-Endstand
+- Keine Los-Entscheidung bei Gleichstand
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/utils/tiebreakerResolver.ts
+function resolveTiebreaker(
+  teams: Team[], 
+  matches: Match[]
+): Team[] {
+  // 1. Punkte
+  // 2. Tordifferenz
+  // 3. Gegentore
+  // 4. Direkter Vergleich
+  // 5. Los
+}
+```
+
+---
+
+### 3. **Bye-Handling (Freilose)**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `ByeMatch`-Logik in `LiveMatch.ts`
+- Keine automatische Weitergabe bei Freilos
+- Keine "Walkover"-Regelung
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/byeHandler.ts
+function handleBye(match: Match): Match {
+  // Team A gewinnt automatisch 3:0 (oder 0:0)
+  // Team B rückt ins nächste Runde
+  // Match wird als "finished" markiert
+}
+```
+
+---
+
+### 4. **Team-Zurückziehung**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `withdrawTeam()`-Funktion
+- Keine Neuberechnung des Brackets bei Ausscheiden
+- Keine "Walkover"-Regel für verbleibende Teams
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/teamWithdrawalService.ts
+function handleTeamWithdrawal(
+  tournament: Tournament,
+  teamId: string
+): Tournament {
+  // 1. Alle verbleibenden Matches des Teams als "forfeit" markieren
+  // 2. Gegner rücken automatisch weiter
+  // 3. Bracket neu berechnen
+}
+```
+
+---
+
+### 5. **Nachträgliche Ergebnisänderungen**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `ActivityLogCategory.tsx`:
+```typescript
+if (match.correctionHistory && match.correctionHistory.length > 0) {
+  match.correctionHistory.forEach((correction: CorrectionEntry) => {
+    // Historie wird protokolliert
+  });
+}
+```
+
+**Fehlende Logik:**
+- Keine automatische Neuberechnung der Tabelle nach Korrektur
+- Keine Validierung (darf Ergebnis nach Playoff-Start geändert werden?)
+- Keine Benachrichtigung an betroffene Teams
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/resultCorrectionService.ts
+function correctMatchResult(
+  matchId: string,
+  newScore: Score,
+  reason: string
+): Tournament {
+  // 1. Alte Werte in correctionHistory speichern
+  // 2. Tabelle neu berechnen
+  // 3. Bracket neu berechnen (wenn in Playoffs)
+  // 4. ActivityLog eintragen
+}
+```
+
+---
+
+### 6. **Turnier-Abbruch**
+
+**Status:** ✅ **IMPLEMENTIERT (DANGER ZONE)**
+
+In `DangerZoneCategory.tsx`:
+```typescript
+case 'end_tournament':
+  onTournamentUpdate({
+    ...tournament,
+    dashboardStatus: 'finished',
+    updatedAt: now,
+  });
+  break;
+```
+
+**Fehlende Logik:**
+- Keine "Endstand"-Berechnung (wer ist Gewinner?)
+- Keine "Abbruch-Protokoll"-Funktion
+- Keine Export-Funktion für abgebrochene Turniere
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/services/tournamentAbbruchService.ts
+function abortTournament(
+  tournament: Tournament,
+  reason: string
+): Tournament {
+  // 1. Status auf 'aborted' setzen
+  // 2. Endstand basierend auf aktuellem Stand berechnen
+  // 3. Abbruch-Protokoll erstellen
+}
+```
+
+---
+
+### 7. **Spielplan-Regenerierung**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `DangerZoneCategory.tsx`:
+```typescript
+case 'regenerate_schedule': {
+  const resetMatches = tournament.matches.map(match => {
+    if (match.matchStatus === 'finished') {
+      return match; // Keep finished matches
+    }
+    return {
+      ...match,
+      matchStatus: 'scheduled' as const,
+      scoreA: undefined,
+      scoreB: undefined,
+      // ...
+    };
+  });
+  // ...
+}
+```
+
+**Fehlende Logik:**
+- Keine `generateSchedule()`-Funktion (nur Reset)
+- Keine Validierung (darf Spielplan nach Turnierstart geändert werden?)
+- Keine Konflikt-Erkennung (Zeitplan-Überlappungen)
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/scheduleGenerator.ts
+function regenerateSchedule(
+  tournament: Tournament,
+  options: ScheduleOptions
+): Match[] {
+  // 1. Alle nicht-beendeten Matches zurücksetzen
+  // 2. Neue Zeitpläne berechnen
+  // 3. Konflikte vermeiden
+}
+```
+
+---
+
+### 8. **Multi-Gruppen → Playoff Übergang**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `generatePlayoffQualifiers()`-Funktion
+- Keine Kreuzspiel-Logik (A1 vs B4)
+- Keine "Beste 2. Platz"-Logik
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/playoffQualifiersGenerator.ts
+function generatePlayoffQualifiers(
+  groups: Group[],
+  playoffFormat: 'roundOf16' | 'quarterfinal' | 'semifinal'
+): Match[] {
+  // 1. Gruppensieger und beste Zweite ermitteln
+  // 2. Kreuzspiele generieren
+  // 3. Bracket erstellen
+}
+```
+
+---
+
+### 9. **Dritter-Platz-Spiel**
+
+**Status:** ❌ **NICHT IMPLEMENTIERT**
+
+- Keine `thirdPlaceMatch`-Option
+- Keine Integration in Bracket
+- Keine Export-Funktion
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/core/generators/thirdPlaceMatchGenerator.ts
+function generateThirdPlaceMatch(
+  semiFinalLosers: Team[]
+): Match {
+  // Spiel zwischen den Verlierern der Halbfinale
+}
+```
+
+---
+
+### 10. **Export (PDF)**
+
+**Status:** ✅ **TEILWEISE IMPLEMENTIERT**
+
+In `ExportsCategory.tsx`:
+```typescript
+const schedule = useMemo(() => {
+  return generateFullSchedule(tournament);
+}, [tournament]);
+
+const standings = useMemo(() => {
+  return calculateStandings(tournament.teams, tournament.matches, tournament);
+}, [tournament]);
+```
+
+**Fehlende Logik:**
+- Keine `generateFullSchedule()`-Implementierung
+- Keine `calculateStandings()`-Implementierung
+- Keine Playoff-Bracket-Export-Funktion
+
+**Erwartete Logik:**
+```typescript
+// Fehlend: src/lib/pdfExporter.ts
+function exportPlayoffBracketPDF(tournament: Tournament): Blob {
+  // Bracket als PDF rendern
+}
+```
+
+---
+
+## 📊 Admin-UX-Probleme
+
+| Problem | Schweregrad | Beschreibung |
+|---------|-------------|--------------|
+| **Keine Playoff-Übersicht** | 🔴 Hoch | Kein Bracket-Viewer im Admin Center |
+| **Keine Live-Bracket-Updates** | 🔴 Hoch | Bracket wird nicht in Echtzeit aktualisiert |
+| **Keine Tiebreaker-Visualisierung** | 🟡 Mittel | Admin sieht nicht, wer bei Gleichstand weiterkommt |
+| **Keine Team-Status-Übersicht** | 🟡 Mittel | Wer ist qualifiziert? Wer ausgeschieden? |
+| **Keine "Was-wäre-wenn"-Simulation** | 🟢 Niedrig | Admin kann nicht testen, was bei bestimmten Ergebnissen passiert |
+
+---
+
+## 🔧 Fehlende Edge Cases
+
+1. **Ungerade Teamzahl in Playoffs** → Bye-Handling
+2. **Mehrere Teams mit gleichen Punkten** → Tiebreaker-Kaskade
+3. **Spielabbruch durch Wetter/Verletzung** → Walkover-Regel
+4. **Team scheidet nach Playoff-Start aus** → Bracket-Neuberechnung
+5. **Zeitplan-Konflikte** → Feld-Überlappungserkennung
+6. **Mehrere Playoffs gleichzeitig** → Feld-Zuweisung
+7. **Golden Goal vs. Penalty** → Konfigurations-Option
+8. **Dritter-Platz-Spiel optional** → Toggle im Setup
+
+---
+
+## 🎯 Tournament Admin Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Admin-UI/UX** | 9/10 | Exzellente Struktur, responsive, modular |
+| **Playoff-Logik** | 2/10 | Nicht implementiert |
+| **Tiebreaker-Regeln** | 3/10 | Nur Typ-Definitionen, keine Logik |
+| **Bye-Handling** | 1/10 | Nicht implementiert |
+| **Team-Zurückziehung** | 1/10 | Nicht implementiert |
+| **Ergebnis-Korrektur** | 6/10 | Historie vorhanden, aber keine Neuberechnung |
+| **Turnier-Abbruch** | 5/10 | Status-Änderung vorhanden, aber keine Endstand-Berechnung |
+| **Spielplan-Regenerierung** | 4/10 | Reset vorhanden, aber keine Generierung |
+| **Multi-Gruppen → Playoff** | 1/10 | Nicht implementiert |
+| **Dritter-Platz-Spiel** | 1/10 | Nicht implementiert |
+| **Export** | 4/10 | PDF-Dialog vorhanden, aber keine Implementierung |
+| **Inkonsistenzen** | 7/10 | Admin-Struktur ist konsistent, aber Logik fehlt |
+
+### **Gesamtscore: 4.5/10**
+
+---
+
+## 🚀 Empfehlungen
+
+### **Kurzfristig (1-2 Wochen)**
+1. **Implementiere `calculateStandings()`** mit Tiebreaker-Logik
+2. **Implementiere `generatePlayoffBracket()`** mit Seeding
+3. **Füge `ByeMatch`-Logik** hinzu
+4. **Implementiere `correctMatchResult()`** mit Neuberechnung
+
+### **Mittelfristig (1-2 Monate)**
+1. **Bracket-Viewer-Komponente** im Admin Center
+2. **Team-Zurückziehungs-Workflow**
+3. **Dritter-Platz-Spiel-Option**
+4. **Live-Bracket-Updates** via Supabase Realtime
+
+### **Langfristig (3-6 Monate)**
+1. **"Was-wäre-wenn"-Simulation**
+2. **Automatische Tiebreaker-Erkennung**
+3. **Multi-Field-Playoff-Management**
+4. **Export von Bracket als Bild/PDF**
+
+---
+
+## 📝 Fazit
+
+Die **Admin-Struktur ist hervorragend**, aber die **Turnier-Engine (Playoff-Logik, Tiebreaker, Bracket-Generierung)** fehlt vollständig. Die Admin-Features sind "Container" für Funktionen, die in `src/core/generators/` und `src/core/services/` implementiert werden müssen.
+
+**Priorität:** Implementiere zuerst `calculateStandings()` und `generatePlayoffBracket()`, da dies die Basis für alle anderen Features ist.

--- a/reviews/2026-03-16_1935_tournament_creation.md
+++ b/reviews/2026-03-16_1935_tournament_creation.md
@@ -1,0 +1,289 @@
+# Code Review: Turnier-Erstellung (Wizard Flow)
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 56.9s  
+**Status:** success  
+**Code-Kontext:** 149,162 Zeichen  
+
+<details><summary>Thinking Process (8,170 Zeichen)</summary>
+
+Der Benutzer möchte eine detaillierte Analyse des Turnier-Erstellungs-Wizards aus der bereitgestellten Codebasis. Ich muss als QA-Engineer und UX-Spezialist agieren und den Code auf Logikfehler, fehlende Validierungen, UX-Probleme und Edge Cases untersuchen.
+
+**Analyse der bereitgestellten Dateien:**
+
+1.  **Step1_SportAndType.tsx:**
+    *   **UX:** Gute visuelle Trennung der Turniertypen (Classic vs. Bambini).
+    *   **Logik:** `handleSportChange` setzt viele Default-Werte. Es gibt eine `onSportChange` Callback, der optional ist.
+    *   **Validierung:** Keine explizite Validierung hier, aber Defaults werden gesetzt.
+    *   **Edge Case:** Was passiert, wenn `sportId` nicht gesetzt ist? Es gibt einen Fallback `?? 'football-indoor'`. Das ist okay, aber implizit.
+
+2.  **Step2_ModeAndSystem.tsx:**
+    *   **UX:** Viele Konfigurationsoptionen. `DurationEstimate` ist ein gutes Feature.
+    *   **Logik:** `handleTeamCountChange` aktualisiert automatisch das DFB-Pattern. Das ist gut.
+    *   **Validierung:** `structureFieldsLocked` verhindert Änderungen, wenn Ergebnisse existieren. Das ist wichtig für Datenkonsistenz.
+    *   **Edge Case:** `numberOfGroups` wird nur angezeigt, wenn `canUseGroups` (also `groupSystem === 'groupsAndFinals'`). Aber was ist, wenn der User den Modus wechselt? Die `numberOfGroups` bleibt im State, könnte aber verwirrend sein.
+    *   **DFB Key System:** Zeigt Warnungen bei BYEs. Gut.
+
+3.  **Step3_Metadata.tsx:**
+    *   **UX:** Standard Formularfelder.
+    *   **Validierung:** `required` Attribute sind gesetzt.
+    *   **Edge Case:** `startDate` und `date` werden synchronisiert. `startTime` und `timeSlot` auch. Das ist gut für Legacy-Kompatibilität.
+
+4.  **Step4_Teams.tsx:**
+    *   **UX:** Team-Verwaltung mit Avatar, Farben, Logo.
+    *   **Logik:** `analyzeGroupDistribution` prüft auf leere Gruppen, ungleiche Verteilung etc.
+    *   **Validierung:** Duplikatserkennung für Team-Namen (`isTeamDuplicate`, `isTeamOriginal`).
+    *   **Edge Case:** `needsMoreTeams` prüft, ob `teams.length < numberOfTeams`. Aber was ist, wenn `numberOfTeams` geändert wird? Die Teams-Liste wird nicht automatisch angepasst (außer über `handleGenerateTeams`).
+    *   **Auto-Assign:** `handleAutoAssignGroups` verteilt Teams rotierend. Das ist fair.
+
+5.  **Step5_Overview.tsx:**
+    *   **UX:** Zusammenfassung aller Daten.
+    *   **Logik:** Zeigt Teams und Gruppen an.
+    *   **Validierung:** Keine explizite Validierung hier, aber der "Show Preview" Button führt zur nächsten Phase.
+
+6.  **Step_GroupsAndFields.tsx:**
+    *   **UX:** Collapsible Sections für Felder und Gruppen.
+    *   **Logik:** `useGroupsAndFieldsState` Hook verwaltet den State.
+    *   **Validierung:** `NameGrid` prüft auf Duplikate.
+    *   **Edge Case:** `GroupFieldMatrix` erlaubt Zuordnung von Gruppen zu Feldern. Was passiert, wenn eine Gruppe keinem Feld zugeordnet ist? (Sollte verhindert werden, aber nicht explizit im Code sichtbar).
+
+7.  **TournamentPreview.tsx:**
+    *   **UX:** Vorschau des Spielplans.
+    *   **Logik:** `generateFullSchedule` wird aufgerufen.
+    *   **Validierung:** Keine explizite Validierung, aber der Schedule-Generator sollte Fehler werfen.
+
+8.  **BambiniSettings.tsx:**
+    *   **UX:** Checkboxen für Sichtbarkeit.
+    *   **Logik:** Nur sichtbar bei `tournamentType === 'bambini'`.
+
+9.  **DFBKeySystem.tsx:**
+    *   **UX:** Checkbox zum Aktivieren. Info-Panel mit Statistiken.
+    *   **Logik:** `getDFBPattern` wählt das passende Muster basierend auf Teamzahl.
+    *   **Validierung:** Warnung bei BYEs.
+
+10. **DurationEstimate.tsx:**
+    *   **UX:** Zeigt geschätzte Dauer an. Warnungen bei zu langer Dauer.
+    *   **Logik:** Berechnet Dauer basierend auf Spielen, Feldern, Pausen.
+    *   **Edge Case:** `calculateFinalsMatches` hat Hardcoded Werte für Presets.
+
+11. **FinalsConfiguration.tsx:**
+    *   **UX:** Auswahl der Final-Presets.
+    *   **Logik:** `getFinalsOptions` filtert basierend auf Gruppenzahl.
+    *   **Validierung:** Warnungen bei unpassenden Presets (z.B. Top-8 mit nur 2 Gruppen).
+
+12. **GameTimeConfig.tsx:**
+    *   **UX:** Stepper für Spielzeiten.
+    *   **Logik:** Unterscheidung zwischen Gruppenphase und Finale.
+    *   **Validierung:** Min/Max Werte gesetzt.
+
+13. **GroupFieldMatrix.tsx:**
+    *   **UX:** Matrix zur Zuordnung.
+    *   **Logik:** `onToggle` ändert die Zuordnung.
+    *   **Validierung:** `capacityWarnings` werden angezeigt.
+
+14. **ModeSelection.tsx:**
+    *   **UX:** Auswahl zwischen Classic und MiniFussball (disabled).
+    *   **Logik:** `miniFussball` ist disabled.
+
+15. **NameGrid.tsx:**
+    *   **UX:** Grid für Namen und ShortCodes.
+    *   **Logik:** `checkDuplicate` und `checkOriginal` prüfen auf Duplikate.
+    *   **Validierung:** Fehleranzeige bei Duplikaten.
+
+16. **PlacementLogicEditor.tsx:**
+    *   **UX:** Drag & Drop für Platzierungsregeln.
+    *   **Logik:** `@dnd-kit` für Drag & Drop.
+    *   **Validierung:** Keine explizite Validierung, aber die Reihenfolge ist wichtig.
+
+17. **PointSystemPicker.tsx:**
+    *   **UX:** Presets und Custom-Eingabe.
+    *   **Logik:** `isCustom` prüft, ob die Werte von den Presets abweichen.
+    *   **Validierung:** Keine explizite Validierung, aber `parseFloat` wird verwendet.
+
+18. **RefereeSettings.tsx:**
+    *   **UX:** Auswahl des Modus (None, Organizer, Teams).
+    *   **Logik:** `handleModeChange` initialisiert Defaults.
+    *   **Validierung:** Duplikatserkennung für Schiedsrichter-Namen.
+
+19. **ScheduleErrorBanner.tsx:**
+    *   **UX:** Fehleranzeige.
+    *   **Logik:** Zeigt Fehler an.
+
+20. **SmartConfig.module.css:**
+    *   **UX:** Styles für SmartConfig (nicht im Code, aber erwähnt).
+
+21. **LiveMatch.ts:**
+    *   **Logik:** Modell für Live-Spiele.
+    *   **Validierung:** Keine.
+
+**Zusammenfassung der Probleme:**
+
+*   **Logik-Fehler:**
+    *   `Step1_SportAndType.tsx`: `currentSportId` Fallback ist hardcoded.
+    *   `Step2_ModeAndSystem.tsx`: `numberOfGroups` bleibt im State, auch wenn `groupSystem` nicht `groupsAndFinals` ist.
+    *   `Step4_Teams.tsx`: `needsMoreTeams` prüft nur `teams.length < numberOfTeams`. Wenn `numberOfTeams` erhöht wird, werden keine neuen Teams automatisch hinzugefügt (nur `handleGenerateTeams` tut das).
+    *   `DurationEstimate.tsx`: `calculateFinalsMatches` hat Hardcoded Werte, die nicht immer korrekt sein könnten.
+    *   `RefereeSettings.tsx`: `handleNameChange` aktualisiert `refereeNames`, aber `refereeConfig` wird nicht korrekt typisiert (cast).
+
+*   **Fehlende Validierungen:**
+    *   `Step3_Metadata.tsx`: `startDate` sollte nicht in der Vergangenheit liegen.
+    *   `Step4_Teams.tsx`: Team-Namen sollten nicht leer sein (obwohl `Input` `required` hat, wird es nicht im Code geprüft).
+    *   `Step_GroupsAndFields.tsx`: ShortCodes sollten eindeutig sein (nicht nur Namen).
+    *   `TournamentPreview.tsx`: Keine Validierung vor dem Publish.
+
+*   **UX-Probleme:**
+    *   `Step2_ModeAndSystem.tsx`: Zu viele Optionen auf einmal. Collapsible Sections wären besser.
+    *   `Step4_Teams.tsx`: Auf Mobile ist die Team-Liste schwer zu bedienen (zu viele Inputs).
+    *   `FinalsConfiguration.tsx`: Warnungen sind nicht immer klar (z.B. Top-8 mit 2 Gruppen).
+    *   `RefereeSettings.tsx`: Die Checkbox für Namen ist nicht intuitiv (warum erst Checkbox, dann Inputs?).
+
+*   **Edge Cases:**
+    *   `Step4_Teams.tsx`: Was passiert, wenn ein Team gelöscht wird, aber `numberOfTeams` gleich bleibt?
+    *   `Step_GroupsAndFields.tsx`: Was passiert, wenn eine Gruppe keinem Feld zugeordnet ist?
+    *   `DurationEstimate.tsx`: Was passiert, wenn `numberOfFields` 0 ist? (Division durch Null).
+    *   `RefereeSettings.tsx`: Was passiert, wenn `numberOfReferees` auf 0 gesetzt wird?
+
+**Tournament Creation Score:**
+Der Wizard ist sehr umfangreich und gut strukturiert. Es gibt jedoch einige Logikfehler und fehlende Validierungen, die zu Problemen führen können. Die UX ist gut, aber auf Mobile könnte es besser sein. Ich würde einen Score von 7/10 geben.
+
+**Struktur der Antwort:**
+1.  Logik-Fehler
+2.  Fehlende Validierungen
+3.  UX-Probleme
+4.  Edge Cases
+5.  Tournament Creation Score
+
+Ich werde die Analyse in diesem Format strukturieren.
+
+
+</details>
+
+---
+
+
+
+# QA-Review: Turnier-Erstellungs-Wizard (hallenfussball-pwa)
+
+Als QA-Engineer und UX-Spezialist habe ich den Wizard-Flow und die zugehörigen Komponenten analysiert. Der Wizard ist funktional sehr umfangreich, weist jedoch einige kritische Logikfehler und UX-Schwachstellen auf, die vor dem Release behoben werden sollten.
+
+## 1. Logik-Fehler im Wizard oder Generator
+
+### **CRITICAL: Division durch Null in `DurationEstimate`**
+*   **Ort:** `src/features/tournament-creation/components/DurationEstimate.tsx`
+*   **Problem:** Die Berechnung `groupPhaseSlotsNeeded = Math.ceil(groupPhaseMatches / fields)` kann zu einer Division durch Null führen, wenn `numberOfFields` auf 0 gesetzt wird (obwohl der Stepper `min={1}` hat, kann der State inkonsistent sein).
+*   **Code:**
+    ```typescript
+    const groupPhaseSlotsNeeded = Math.ceil(groupPhaseMatches / fields); // fields kann 0 sein!
+    ```
+*   **Fix:** Sicherstellen, dass `fields` mindestens 1 ist, bevor dividiert wird.
+
+### **HIGH: Team-Count Synchronisation in `Step4_Teams`**
+*   **Ort:** `src/features/tournament-creation/Step4_Teams.tsx`
+*   **Problem:** Wenn `numberOfTeams` erhöht wird (z.B. von 4 auf 6), wird die Teams-Liste nicht automatisch erweitert. Der Button `needsMoreTeams` wird angezeigt, aber das Hinzufügen ist manuell. Wenn der User den Wizard verlässt und zurückkehrt, ist der State inkonsistent.
+*   **Code:**
+    ```typescript
+    const needsMoreTeams = teams.length < numberOfTeams;
+    // ...
+    if (needsMoreTeams && (
+      <Button onClick={handleGenerateTeams}>...
+    ```
+*   **Fix:** Automatische Generierung von Platzhaltern, wenn `numberOfTeams` erhöht wird, oder klare Fehlermeldung, wenn nicht genug Teams vorhanden sind.
+
+### **MEDIUM: `numberOfGroups` State-Leck**
+*   **Ort:** `src/features/tournament-creation/Step2_ModeAndSystem.tsx`
+*   **Problem:** `numberOfGroups` bleibt im State, auch wenn `groupSystem` auf `roundRobin` gewechselt wird. Das kann zu Verwirrung führen, wenn der User später wieder auf `groupsAndFinals` wechselt (alte Gruppenzahl wird übernommen).
+*   **Fix:** `numberOfGroups` zurücksetzen, wenn `groupSystem` gewechselt wird.
+
+### **MEDIUM: Referee Config Typisierung**
+*   **Ort:** `src/features/tournament-creation/components/RefereeSettings.tsx`
+*   **Problem:** `handleNameChange` castet `refereeConfig` zu `RefereeConfig`, was zu Laufzeitfehlern führen kann, wenn die Struktur nicht exakt passt.
+*   **Code:**
+    ```typescript
+    onUpdate('refereeConfig', { ...refereeConfig, refereeNames: updatedNames } as RefereeConfig);
+    ```
+*   **Fix:** Typsichere Updates ohne Cast.
+
+## 2. Fehlende Validierungen (Pflichtfelder, Grenzwerte)
+
+### **CRITICAL: `startDate` in der Vergangenheit**
+*   **Ort:** `src/features/tournament-creation/Step3_Metadata.tsx`
+*   **Problem:** Es wird nicht geprüft, ob das gewählte Datum in der Vergangenheit liegt.
+*   **Fix:** Validierung hinzufügen: `if (new Date(value) < new Date()) { setError('Datum in der Vergangenheit'); }`
+
+### **HIGH: Team-Namen Validierung**
+*   **Ort:** `src/features/tournament-creation/Step4_Teams.tsx`
+*   **Problem:** Team-Namen können leer sein, obwohl `Input` `required` hat. Die Validierung wird nicht im `onSubmit` oder `onSave` geprüft.
+*   **Fix:** Explizite Prüfung auf leere Team-Namen vor dem Speichern.
+
+### **MEDIUM: ShortCode Eindeutigkeit**
+*   **Ort:** `src/features/tournament-creation/components/NameGrid.tsx`
+*   **Problem:** ShortCodes (z.B. "HN" für Feld) werden nicht auf Eindeutigkeit geprüft. Zwei Felder könnten denselben ShortCode haben.
+*   **Fix:** `checkDuplicate` auch für `shortCode` implementieren.
+
+### **LOW: `numberOfReferees` auf 0 setzen**
+*   **Ort:** `src/features/tournament-creation/components/RefereeSettings.tsx`
+*   **Problem:** Der Stepper erlaubt `min={1}`, aber wenn der User manuell auf 0 ändert, kann es zu Fehlern kommen.
+*   **Fix:** `min={1}` erzwingen.
+
+## 3. UX-Probleme im Wizard-Flow
+
+### **HIGH: Mobile Team-Verwaltung (`Step4_Teams`)**
+*   **Problem:** Auf kleinen Bildschirmen ist die Team-Liste schwer zu bedienen. Die `teamRow` ist zu komplex für Mobile (Avatar, Name, Expand, Delete, Group Selector).
+*   **Code:**
+    ```css
+    .teamRow {
+      display: flex;
+      flex-direction: column; /* Mobile */
+    }
+    ```
+*   **Fix:** Auf Mobile die Gruppe und Farben in ein Collapsible-Panel auslagern, um Platz zu sparen.
+
+### **MEDIUM: Zu viele Optionen in `Step2_ModeAndSystem`**
+*   **Problem:** Der Schritt ist überladen. Viele Konfigurationsoptionen (DFB, Referee, Time, Finals) sind auf einmal sichtbar.
+*   **Fix:** Collapsible Sections für weniger wichtige Optionen (z.B. Referee, Finals) verwenden, um den Fokus zu lenken.
+
+### **MEDIUM: `FinalsConfiguration` Warnungen**
+*   **Problem:** Warnungen wie "Top-8 mit nur 2 Gruppen" sind nicht immer klar. Der User versteht nicht, warum das Problem ist.
+*   **Fix:** Erklärender Text hinzufügen: "Top-8 erfordert mindestens 4 Gruppen, da sonst nicht genug Teams für das Viertelfinale vorhanden sind."
+
+### **LOW: `BambiniSettings` Checkboxen**
+*   **Problem:** Die Checkboxen für "Ergebnisse verbergen" sind nicht intuitiv. Der User muss raten, was passiert.
+*   **Fix:** Tooltip oder Hilfetext hinzufügen: "Wenn aktiviert, werden Ergebnisse und Tabellen für die Öffentlichkeit ausgeblendet."
+
+## 4. Edge Cases die nicht abgedeckt sind
+
+### **CRITICAL: `numberOfFields` = 0**
+*   **Ort:** `DurationEstimate.tsx`
+*   **Problem:** Wenn `numberOfFields` auf 0 gesetzt wird (trotz `min={1}` im Stepper), führt dies zu einer Division durch Null.
+*   **Fix:** `min={1}` erzwingen und State validieren.
+
+### **HIGH: Gruppe ohne Feld-Zuordnung**
+*   **Ort:** `Step_GroupsAndFields.tsx`
+*   **Problem:** Wenn eine Gruppe keinem Feld zugeordnet ist, kann der Spielplan nicht generiert werden.
+*   **Fix:** Validierung hinzufügen: "Jede Gruppe muss mindestens einem Feld zugeordnet sein."
+
+### **MEDIUM: Team-Löschung bei `numberOfTeams`**
+*   **Ort:** `Step4_Teams.tsx`
+*   **Problem:** Wenn ein Team gelöscht wird, aber `numberOfTeams` gleich bleibt, ist die Liste inkonsistent.
+*   **Fix:** `numberOfTeams` automatisch anpassen oder Warnung anzeigen.
+
+### **LOW: `refereeNames` bei `numberOfReferees` Änderung**
+*   **Ort:** `RefereeSettings.tsx`
+*   **Problem:** Wenn `numberOfReferees` erhöht wird, werden neue Namen initialisiert. Wenn verringert, werden Namen gelöscht. Das ist okay, aber der User sollte gewarnt werden.
+*   **Fix:** Bestätigung anzeigen, wenn Namen gelöscht werden.
+
+## 5. Tournament Creation Score
+
+**Score: 7/10**
+
+**Begründung:**
+*   **Stärken:** Der Wizard ist sehr umfangreich und bietet viele Konfigurationsmöglichkeiten. Die UX ist auf Desktop gut, mit vielen visuellen Hilfen (Warnungen, Vorschauen).
+*   **Schwächen:** Es gibt kritische Logikfehler (Division durch Null, State-Inkonsistenzen) und fehlende Validierungen (Datum in der Vergangenheit, leere Team-Namen). Die Mobile-UX ist verbesserungswürdig.
+*   **Empfehlung:** Vor dem Release die kritischen Logikfehler beheben und die Validierungen erweitern. Die Mobile-UX sollte optimiert werden, um die Bedienung auf Smartphones zu erleichtern.
+
+**Priorisierte To-Dos:**
+1.  **Division durch Null in `DurationEstimate` beheben.** (CRITICAL)
+2.  **`startDate` Validierung hinzufügen.** (CRITICAL)
+3.  **Team-Namen Validierung vor dem Speichern.** (HIGH)
+4.  **Mobile Team-Verwaltung vereinfachen.** (HIGH)
+5.  **State-Inkonsistenzen bei `numberOfGroups` und `numberOfTeams` beheben.** (MEDIUM)

--- a/reviews/2026-05-07_2048_SUMMARY.md
+++ b/reviews/2026-05-07_2048_SUMMARY.md
@@ -1,0 +1,317 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:48  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 42.3s  
+**Agents:** 1  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Code-Qualitaet & TypeScript-Patterns | success | 42.3s | 147.0k | 45595 |
+
+---
+
+## Code-Qualitaet & TypeScript-Patterns
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metrik | Wert | Bewertung |
+|--------|------|-----------|
+| **Code Quality Score** | **7.2/10** | ⚠️ Gut mit Verbesserungspotenzial |
+| **Type Safety** | 6.5/10 | ⚠️ Häufige `any`-Casts in Tests |
+| **Test Coverage** | 8.5/10 | ✅ Umfangreiche Tests vorhanden |
+| **Maintainability** | 7.0/10 | ⚠️ ESLint-Disables häufig |
+| **Architecture** | 8.0/10 | ✅ Klare Trennung, gute Abstraktionen |
+
+---
+
+## 🔴 Code Smells (Schweregrad & Referenz)
+
+### Critical (P0)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/calculations.ts` | ~200 | `compareDirectMatches` hat 80+ LOC, tiefe Verschachtelung | Wartbarkeit |
+| `src/utils/scheduleGenerator_finals_bug.test.ts` | ~100 | `console.log` in Tests (Debug-Output) | Test-Clutter |
+| `src/utils/storageCleanup.ts` | ~80 | `cleanupOldLiveMatches` hat 70+ LOC mit komplexer Logik | Wartbarkeit |
+
+### High (P1)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/FairnessCalculator.ts` | 30-40 | `!` Non-Null Assertion (unsafe) | Runtime-Errors möglich |
+| `src/utils/__tests__/ScenarioHMK.test.ts` | 15 | `as ImportedTournament` Cast | Type-Safety verloren |
+| `src/utils/displayNames.ts` | 50 | `eslint-disable` für `prefer-nullish-coalescing` | Code-Style Inkonsistenz |
+| `src/utils/filterMatches.ts` | 40 | `||` statt `??` für Boolean-Checks | Logik-Risiko |
+
+### Medium (P2)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/idGenerator.ts` | 20 | Fallback-UUID ist "weak" | Kollisions-Risiko |
+| `src/utils/knockoutMatchGenerator.ts` | 60 | Dead-Code-Kommentar (nicht entfernt) | Verwirrung |
+| `src/utils/` | alle | Gemischte Deutsch/Englisch Namen | Konsistenz |
+
+---
+
+## ⚠️ TypeScript-Verstöße
+
+### `any`-Verwendung (15+ Vorkommen)
+
+```typescript
+// ❌ src/utils/__tests__/ScenarioHMK.test.ts:15
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+
+// ✅ Besser: Zod-Validation
+import { z } from 'zod';
+const TournamentSchema = z.object({...});
+const importedTournament = TournamentSchema.parse(JSON.parse(fileContent));
+```
+
+### Unsafe Type Assertions
+
+```typescript
+// ❌ src/utils/FairnessCalculator.ts:30
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// ... später
+const newAvg = this.computeAvgRest(state.matchSlots); // state könnte undefined sein!
+
+// ✅ Besser:
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// state ist jetzt sicher im Scope
+```
+
+### Non-Null Assertions (`!`)
+
+```typescript
+// ❌ src/utils/calculations.ts:200
+const teamAStanding = standings.find(...)!; // Kann undefined sein!
+
+// ✅ Besser:
+const teamAStanding = standings.find(...);
+if (!teamAStanding) return;
+```
+
+---
+
+## 📝 Naming-Inkonsistenzen
+
+### Funktion-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `getGroupLabel` (Singular) | `generateGroupLabels` (Plural) |
+| `createDefaultGroups` | `generateGroupLabels` |
+| `generateUniqueId` | `generateTournamentId` |
+| `getGroupDisplayName` | `getFieldDisplayName` |
+
+### Typ-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `TournamentCase` (Schema) | `Tournament` (Runtime) |
+| `ScheduledMatch` | `Match` |
+| `StoredSound` | `Sound` |
+
+### Empfehlung
+- **Singular vs. Plural**: `getGroupLabel` → `generateGroupLabel` (für Einzel)
+- **Verb-Konsistenz**: `generate` für Erzeugung, `get` für Lookup
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Incremental Caching Pattern**
+```typescript
+// ✅ src/utils/FairnessCalculator.ts
+export class FairnessCalculator {
+  private avgRestByTeam = new Map<string, number>();
+  private globalMinAvg = Infinity;
+  private globalMaxAvg = -Infinity;
+  
+  // O(1) Lookups durch Cache
+  recordAssignment(teamId: string): void {
+    // Incremental Update statt Neukalkulation
+    this.globalMinAvg = Math.min(this.globalMinAvg, newAvg);
+    this.globalMaxAvg = Math.max(this.globalMaxAvg, newAvg);
+  }
+}
+```
+
+### 2. **Test-Helper Pattern**
+```typescript
+// ✅ src/utils/__tests__/calculations.test.ts
+const createTournament = (overrides?: Partial<Tournament>): Tournament => ({
+  // Defaults + Overrides
+  ...defaults,
+  ...overrides,
+});
+```
+
+### 3. **Polyfill-Lazy-Loading**
+```typescript
+// ✅ src/utils/polyfills/inert.ts
+export async function initInertPolyfill(): Promise<void> {
+  if ('inert' in HTMLElement.prototype) return; // Native Support check
+  await import('wicg-inert'); // Only load if needed
+}
+```
+
+### 4. **Safe Storage Pattern**
+```typescript
+// ✅ src/utils/storageCleanup.ts
+export function safeLocalStorageSet(key: string, data: string): boolean {
+  try {
+    localStorage.setItem(key, data);
+    return true;
+  } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      cleanupOldLiveMatches(key); // Auto-cleanup
+      return false;
+    }
+  }
+}
+```
+
+---
+
+## 🔧 Refactoring-Empfehlungen (Priorisiert)
+
+### P0 - Critical (Sofort)
+
+1. **Type-Safety in Tests erhöhen**
+   ```bash
+   # Ersetze `as`-Casts durch Zod-Validation
+   # src/utils/__tests__/ScenarioHMK.test.ts
+   ```
+   
+2. **Non-Null Assertions entfernen**
+   ```typescript
+   // src/utils/FairnessCalculator.ts:30
+   // Statt: this.teamStates = teamStates!;
+   // Besser: this.teamStates = teamStates;
+   // Und: if (!state) { return; } statt state!
+   ```
+
+3. **ESLint-Disables reduzieren**
+   ```bash
+   # Ziel: < 10 eslint-disable pro Datei
+   # src/utils/displayNames.ts hat 5+ Disables
+   ```
+
+### P1 - High (Nächste Sprint)
+
+4. **`compareDirectMatches` refaktorisieren**
+   ```typescript
+   // src/utils/calculations.ts
+   // Aufteilen in:
+   // - findDirectMatches()
+   // - calculateMiniTableStats()
+   // - compareMiniTable()
+   ```
+
+5. **Magic Numbers extrahieren**
+   ```typescript
+   // src/utils/soundStorage.ts
+   export const MAX_SOUND_FILE_SIZE = 500 * 1024; // ✅ Gut
+   // src/utils/logoProcessor.ts
+   export const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // ✅ Gut
+   // Aber: 128px, 256, 0.8 - in Konstanten
+   ```
+
+6. **Dead Code entfernen**
+   ```typescript
+   // src/utils/knockoutMatchGenerator.ts
+   // NOTE: updateKnockoutMatchesAfterResult was removed
+   // → Kommentar löschen oder Funktion implementieren
+   ```
+
+### P2 - Medium (Tech Debt Backlog)
+
+7. **Namen konsistentieren**
+   ```bash
+   # getGroupLabel → generateGroupLabel
+   # createDefaultGroups → generateDefaultGroups
+   ```
+
+8. **Debug-Code aus Tests entfernen**
+   ```typescript
+   // src/utils/__tests__/scheduleGenerator_finals_bug.test.ts
+   // eslint-disable no-console → Entfernen
+   // console.log → debugLog() aus debug.ts
+   ```
+
+9. **ID Generator verbessern**
+   ```typescript
+   // src/utils/idGenerator.ts
+   // Fallback entfernen oder robust machen
+   // crypto.randomUUID() ist immer verfügbar in modernen Browsern
+   ```
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Type Safety** | 6.5 | `any` in Tests, Non-Null Assertions |
+| **Test Coverage** | 8.5 | Umfangreiche Tests, Edge Cases abgedeckt |
+| **Code Organization** | 8.0 | Klare Struktur, Utility-Kapselung |
+| **Error Handling** | 7.0 | try/catch vorhanden, aber Custom Errors fehlen |
+| **Performance** | 8.5 | FairnessCalculator mit O(n²) statt O(n³) |
+| **Maintainability** | 7.0 | ESLint-Disables, lange Funktionen |
+| **Security** | 7.5 | UUIDs gut, aber Fallback schwach |
+| **Documentation** | 8.0 | JSDoc vorhanden, aber nicht konsistent |
+
+**Gesamtscore: 7.2/10** ⚠️
+
+---
+
+## 🎯 Next Steps
+
+### Sprint 1 (Type Safety)
+- [ ] Zod-Schemas für alle Test-Fixtures
+- [ ] Non-Null Assertions entfernen
+- [ ] ESLint-Regeln verschärfen (`@typescript-eslint/no-non-null-assertion`)
+
+### Sprint 2 (Code Quality)
+- [ ] `compareDirectMatches` refaktorisieren
+- [ ] ESLint-Disables auf < 5 pro Datei reduzieren
+- [ ] Magic Numbers in Konstanten extrahieren
+
+### Sprint 3 (Tech Debt)
+- [ ] Naming-Konventionen konsistentieren
+- [ ] Dead Code entfernen
+- [ ] Debug-Code aus Production-Code entfernen
+
+---
+
+## 📋 ESLint-Konfigurations-Empfehlung
+
+```json
+{
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "no-console": ["error", { "allow": ["error", "warn"] }],
+    "max-lines-per-function": ["warn", { "max": 50 }],
+    "complexity": ["warn", { "max": 20 }]
+  }
+}
+```
+
+---
+
+**Fazit**: Das Projekt hat eine solide Architektur und gute Testabdeckung, aber Type-Safety und Code-Quality können durch gezielte Refaktorings deutlich verbessert werden. Priorisiere P0-Items für stabile Releases.
+
+---
+

--- a/reviews/2026-05-07_2048_code_quality.md
+++ b/reviews/2026-05-07_2048_code_quality.md
@@ -1,0 +1,364 @@
+# Code Review: Code-Qualitaet & TypeScript-Patterns
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 42.3s  
+**Status:** success  
+**Code-Kontext:** 146,980 Zeichen  
+
+<details><summary>Thinking Process (1,609 Zeichen)</summary>
+
+Der Code ist umfangreich und detailliert. Ich muss eine strukturierte Qualitätsanalyse erstellen, die Code Smells, TypeScript-Verstöße, Naming-Inkonsistenzen, positive Patterns, Refactoring-Empfehlungen und einen Code Quality Score enthält.
+
+Lass mich systematisch durchgehen:
+
+1. **TypeScript Strict Mode**
+   - Ich sehe `any`-Verwendung in Tests (ImportedMatch, ImportedTeam, etc.)
+   - `as`-Casts sind vorhanden
+   - Non-Null Assertions (`!`) werden verwendet
+   - `eslint-disable` Kommentare sind häufig
+
+2. **Type Definitions**
+   - Types sind gut strukturiert in `types/` Verzeichnis
+   - Union Types werden verwendet
+   - Branded Types fehlen teilweise
+
+3. **Utility Functions**
+   - DRY-Prinzip wird weitgehend eingehalten
+   - Abstraktionen sind angemessen
+   - Over-Engineering ist minimal
+
+4. **Constants**
+   - Magic Numbers sind vorhanden (z.B. 5MB, 128px)
+   - Konstanten sind definiert
+
+5. **Error Handling**
+   - try/catch ist konsistent
+   - Custom Error Types fehlen teilweise
+   - Error Boundaries nicht im Code sichtbar
+
+6. **Naming Conventions**
+   - Gemischt Deutsch/Englisch
+   - Generell konsistent
+   - Manche Inkonsistenzen (z.B. `getGroupLabel` vs `generateGroupLabels`)
+
+7. **Code Smells**
+   - Lange Funktionen (>50 LOC)
+   - Deep Nesting
+   - Switch-Ketten
+
+8. **DRY-Verstöße**
+   - Copy-Paste-Code in Tests
+   - Fehlende Abstraktionen
+
+9. **ESLint-Config**
+   - Viele eslint-disable Kommentare
+   - Regeln scheinen vorhanden
+
+10. **Dead Code**
+    - Kommentare erwähnen entfernte Funktionen
+    - Unbenutzte Exports möglich
+
+Ich werde jetzt eine detaillierte Analyse erstellen.
+
+
+</details>
+
+---
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metrik | Wert | Bewertung |
+|--------|------|-----------|
+| **Code Quality Score** | **7.2/10** | ⚠️ Gut mit Verbesserungspotenzial |
+| **Type Safety** | 6.5/10 | ⚠️ Häufige `any`-Casts in Tests |
+| **Test Coverage** | 8.5/10 | ✅ Umfangreiche Tests vorhanden |
+| **Maintainability** | 7.0/10 | ⚠️ ESLint-Disables häufig |
+| **Architecture** | 8.0/10 | ✅ Klare Trennung, gute Abstraktionen |
+
+---
+
+## 🔴 Code Smells (Schweregrad & Referenz)
+
+### Critical (P0)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/calculations.ts` | ~200 | `compareDirectMatches` hat 80+ LOC, tiefe Verschachtelung | Wartbarkeit |
+| `src/utils/scheduleGenerator_finals_bug.test.ts` | ~100 | `console.log` in Tests (Debug-Output) | Test-Clutter |
+| `src/utils/storageCleanup.ts` | ~80 | `cleanupOldLiveMatches` hat 70+ LOC mit komplexer Logik | Wartbarkeit |
+
+### High (P1)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/FairnessCalculator.ts` | 30-40 | `!` Non-Null Assertion (unsafe) | Runtime-Errors möglich |
+| `src/utils/__tests__/ScenarioHMK.test.ts` | 15 | `as ImportedTournament` Cast | Type-Safety verloren |
+| `src/utils/displayNames.ts` | 50 | `eslint-disable` für `prefer-nullish-coalescing` | Code-Style Inkonsistenz |
+| `src/utils/filterMatches.ts` | 40 | `||` statt `??` für Boolean-Checks | Logik-Risiko |
+
+### Medium (P2)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/idGenerator.ts` | 20 | Fallback-UUID ist "weak" | Kollisions-Risiko |
+| `src/utils/knockoutMatchGenerator.ts` | 60 | Dead-Code-Kommentar (nicht entfernt) | Verwirrung |
+| `src/utils/` | alle | Gemischte Deutsch/Englisch Namen | Konsistenz |
+
+---
+
+## ⚠️ TypeScript-Verstöße
+
+### `any`-Verwendung (15+ Vorkommen)
+
+```typescript
+// ❌ src/utils/__tests__/ScenarioHMK.test.ts:15
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+
+// ✅ Besser: Zod-Validation
+import { z } from 'zod';
+const TournamentSchema = z.object({...});
+const importedTournament = TournamentSchema.parse(JSON.parse(fileContent));
+```
+
+### Unsafe Type Assertions
+
+```typescript
+// ❌ src/utils/FairnessCalculator.ts:30
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// ... später
+const newAvg = this.computeAvgRest(state.matchSlots); // state könnte undefined sein!
+
+// ✅ Besser:
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// state ist jetzt sicher im Scope
+```
+
+### Non-Null Assertions (`!`)
+
+```typescript
+// ❌ src/utils/calculations.ts:200
+const teamAStanding = standings.find(...)!; // Kann undefined sein!
+
+// ✅ Besser:
+const teamAStanding = standings.find(...);
+if (!teamAStanding) return;
+```
+
+---
+
+## 📝 Naming-Inkonsistenzen
+
+### Funktion-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `getGroupLabel` (Singular) | `generateGroupLabels` (Plural) |
+| `createDefaultGroups` | `generateGroupLabels` |
+| `generateUniqueId` | `generateTournamentId` |
+| `getGroupDisplayName` | `getFieldDisplayName` |
+
+### Typ-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `TournamentCase` (Schema) | `Tournament` (Runtime) |
+| `ScheduledMatch` | `Match` |
+| `StoredSound` | `Sound` |
+
+### Empfehlung
+- **Singular vs. Plural**: `getGroupLabel` → `generateGroupLabel` (für Einzel)
+- **Verb-Konsistenz**: `generate` für Erzeugung, `get` für Lookup
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Incremental Caching Pattern**
+```typescript
+// ✅ src/utils/FairnessCalculator.ts
+export class FairnessCalculator {
+  private avgRestByTeam = new Map<string, number>();
+  private globalMinAvg = Infinity;
+  private globalMaxAvg = -Infinity;
+  
+  // O(1) Lookups durch Cache
+  recordAssignment(teamId: string): void {
+    // Incremental Update statt Neukalkulation
+    this.globalMinAvg = Math.min(this.globalMinAvg, newAvg);
+    this.globalMaxAvg = Math.max(this.globalMaxAvg, newAvg);
+  }
+}
+```
+
+### 2. **Test-Helper Pattern**
+```typescript
+// ✅ src/utils/__tests__/calculations.test.ts
+const createTournament = (overrides?: Partial<Tournament>): Tournament => ({
+  // Defaults + Overrides
+  ...defaults,
+  ...overrides,
+});
+```
+
+### 3. **Polyfill-Lazy-Loading**
+```typescript
+// ✅ src/utils/polyfills/inert.ts
+export async function initInertPolyfill(): Promise<void> {
+  if ('inert' in HTMLElement.prototype) return; // Native Support check
+  await import('wicg-inert'); // Only load if needed
+}
+```
+
+### 4. **Safe Storage Pattern**
+```typescript
+// ✅ src/utils/storageCleanup.ts
+export function safeLocalStorageSet(key: string, data: string): boolean {
+  try {
+    localStorage.setItem(key, data);
+    return true;
+  } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      cleanupOldLiveMatches(key); // Auto-cleanup
+      return false;
+    }
+  }
+}
+```
+
+---
+
+## 🔧 Refactoring-Empfehlungen (Priorisiert)
+
+### P0 - Critical (Sofort)
+
+1. **Type-Safety in Tests erhöhen**
+   ```bash
+   # Ersetze `as`-Casts durch Zod-Validation
+   # src/utils/__tests__/ScenarioHMK.test.ts
+   ```
+   
+2. **Non-Null Assertions entfernen**
+   ```typescript
+   // src/utils/FairnessCalculator.ts:30
+   // Statt: this.teamStates = teamStates!;
+   // Besser: this.teamStates = teamStates;
+   // Und: if (!state) { return; } statt state!
+   ```
+
+3. **ESLint-Disables reduzieren**
+   ```bash
+   # Ziel: < 10 eslint-disable pro Datei
+   # src/utils/displayNames.ts hat 5+ Disables
+   ```
+
+### P1 - High (Nächste Sprint)
+
+4. **`compareDirectMatches` refaktorisieren**
+   ```typescript
+   // src/utils/calculations.ts
+   // Aufteilen in:
+   // - findDirectMatches()
+   // - calculateMiniTableStats()
+   // - compareMiniTable()
+   ```
+
+5. **Magic Numbers extrahieren**
+   ```typescript
+   // src/utils/soundStorage.ts
+   export const MAX_SOUND_FILE_SIZE = 500 * 1024; // ✅ Gut
+   // src/utils/logoProcessor.ts
+   export const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // ✅ Gut
+   // Aber: 128px, 256, 0.8 - in Konstanten
+   ```
+
+6. **Dead Code entfernen**
+   ```typescript
+   // src/utils/knockoutMatchGenerator.ts
+   // NOTE: updateKnockoutMatchesAfterResult was removed
+   // → Kommentar löschen oder Funktion implementieren
+   ```
+
+### P2 - Medium (Tech Debt Backlog)
+
+7. **Namen konsistentieren**
+   ```bash
+   # getGroupLabel → generateGroupLabel
+   # createDefaultGroups → generateDefaultGroups
+   ```
+
+8. **Debug-Code aus Tests entfernen**
+   ```typescript
+   // src/utils/__tests__/scheduleGenerator_finals_bug.test.ts
+   // eslint-disable no-console → Entfernen
+   // console.log → debugLog() aus debug.ts
+   ```
+
+9. **ID Generator verbessern**
+   ```typescript
+   // src/utils/idGenerator.ts
+   // Fallback entfernen oder robust machen
+   // crypto.randomUUID() ist immer verfügbar in modernen Browsern
+   ```
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Type Safety** | 6.5 | `any` in Tests, Non-Null Assertions |
+| **Test Coverage** | 8.5 | Umfangreiche Tests, Edge Cases abgedeckt |
+| **Code Organization** | 8.0 | Klare Struktur, Utility-Kapselung |
+| **Error Handling** | 7.0 | try/catch vorhanden, aber Custom Errors fehlen |
+| **Performance** | 8.5 | FairnessCalculator mit O(n²) statt O(n³) |
+| **Maintainability** | 7.0 | ESLint-Disables, lange Funktionen |
+| **Security** | 7.5 | UUIDs gut, aber Fallback schwach |
+| **Documentation** | 8.0 | JSDoc vorhanden, aber nicht konsistent |
+
+**Gesamtscore: 7.2/10** ⚠️
+
+---
+
+## 🎯 Next Steps
+
+### Sprint 1 (Type Safety)
+- [ ] Zod-Schemas für alle Test-Fixtures
+- [ ] Non-Null Assertions entfernen
+- [ ] ESLint-Regeln verschärfen (`@typescript-eslint/no-non-null-assertion`)
+
+### Sprint 2 (Code Quality)
+- [ ] `compareDirectMatches` refaktorisieren
+- [ ] ESLint-Disables auf < 5 pro Datei reduzieren
+- [ ] Magic Numbers in Konstanten extrahieren
+
+### Sprint 3 (Tech Debt)
+- [ ] Naming-Konventionen konsistentieren
+- [ ] Dead Code entfernen
+- [ ] Debug-Code aus Production-Code entfernen
+
+---
+
+## 📋 ESLint-Konfigurations-Empfehlung
+
+```json
+{
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "no-console": ["error", { "allow": ["error", "warn"] }],
+    "max-lines-per-function": ["warn", { "max": 50 }],
+    "complexity": ["warn", { "max": 20 }]
+  }
+}
+```
+
+---
+
+**Fazit**: Das Projekt hat eine solide Architektur und gute Testabdeckung, aber Type-Safety und Code-Quality können durch gezielte Refaktorings deutlich verbessert werden. Priorisiere P0-Items für stabile Releases.

--- a/reviews/2026-05-07_2053_SUMMARY.md
+++ b/reviews/2026-05-07_2053_SUMMARY.md
@@ -1,0 +1,2404 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:53  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 186.6s  
+**Agents:** 15  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Architektur & Schichtenmodell | success | 174.4s | 151.3k | 45641 |
+| 2 | Code-Qualitaet & TypeScript-Patterns | success | 0.7s | 147.0k | 45595 |
+| 3 | UI-Komponenten & Design System | error | 185.6s | 147.8k | ? |
+| 4 | PDF-Export, Sharing & Datenausgabe | success | 53.4s | 150.4k | 43248 |
+| 5 | Hooks, State & Context | error | 185.5s | 148.0k | ? |
+| 6 | Internationalisierung & Barrierefreiheit | success | 164.4s | 150.6k | 47567 |
+| 7 | Live-Cockpit & Spielsteuerung | success | 118.4s | 148.8k | 42377 |
+| 8 | Performance, Bundle & PWA | success | 162.8s | 32.5k | 11322 |
+| 9 | Screens, Routing & Navigation | success | 169.7s | 150.7k | 41914 |
+| 10 | Security & Datenschutz | error | 186.0s | 151.3k | ? |
+| 11 | Sport-Konfiguration & Datenmodell | error | 186.5s | 134.3k | ? |
+| 12 | Supabase, Datenbank & Sync | success | 175.9s | 150.3k | 39715 |
+| 13 | Testing & Qualitaetssicherung | success | 120.8s | 99.1k | 32986 |
+| 14 | Turnier-Admin & Playoff-Logik | error | 186.6s | 151.5k | ? |
+| 15 | Turnier-Erstellung (Wizard Flow) | success | 172.8s | 149.2k | 43755 |
+
+---
+
+## Architektur & Schichtenmodell
+
+
+
+# Architektur-Review: hallenfussball-pwa
+
+## 📊 Gesamtbewertung: **7.5/10**
+
+Starke Architektur mit klaren Trennungen, aber einige kritische Design-Entscheidungen erfordern Aufmerksamkeit.
+
+---
+
+## ✅ Stärken
+
+### 1. **Klare Core/Feature-Trennung**
+```
+src/core/          → Pure Business Logic (kein React)
+src/features/      → React-Komponenten & Hooks
+```
+Die `RepositoryContext.tsx` importiert zwar `useAuth` aus Features, aber Core bleibt grundsätzlich unabhängig. Das ermöglicht einfache Tests und Portierung.
+
+### 2. **Exzellentes Error-Hierarchy-Design**
+- Feature/Action-Tagging für Sentry-Integration
+- Spezialisierte Fehlerklassen (`OptimisticLockError`, `NetworkError`)
+- Konsistente `isAbortError()`-Utility
+- **Datei:** `src/core/errors.ts`
+
+### 3. **Robustes Repository-Pattern**
+```typescript
+// Abstraktion erlaubt einfachen Wechsel
+const repo = canUseSupabase 
+  ? new OfflineRepository(localRepo, supabaseRepo)
+  : localRepo;
+```
+- `OfflineRepository` für Offline-First
+- Interface-basiert (`ITournamentRepository`)
+- **Datei:** `src/core/contexts/RepositoryContext.tsx`
+
+### 4. **Zod-Schema-Validierung**
+- Runtime-Validierung für Datenintegrität
+- Type-Safety durch `z.infer<>`
+- `.passthrough()` für Forward-Compatibility
+- **Datei:** `src/core/models/schemas/TournamentSchema.ts`
+
+### 5. **Umfassende Test-Abdeckung**
+- Edge Cases abgedeckt (z.B. `< 2 groups` in Playoff-Generator)
+- Konsistenz-Checks (`assertDependsOnConsistency`)
+- **Datei:** `src/core/generators/__tests__/playoffGenerator.test.ts`
+
+### 6. **Fair Scheduling Algorithmus**
+- Multi-Field-Support
+- Rest-Perioden-Balance
+- Home/Away-Balance
+- **Datei:** `src/core/generators/fairScheduler.ts`
+
+---
+
+## ⚠️ Architektur-Probleme
+
+### 🔴 **Critical**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **useRef für Subscriptions** | `RepositoryContext.tsx` | `supabaseLiveMatchRepoRef` useRef verhindert korrekte Cleanup bei Re-Renders. React-Context sollte nicht für Subscriptions-Lebenszyklus genutzt werden. |
+| **Date-Serialisierung** | `TournamentSchema.ts` | `scheduledTime?: z.union([z.string(), z.date()])` - JSON kann nur Strings speichern. Transform-Logik fehlt. |
+| **Circular Import Risk** | `RepositoryContext.tsx` | Core importiert `useAuth` aus Features. Bei komplexeren Abhängigkeiten entstehen Zirkel. |
+
+### 🟠 **High**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **God Object: fairScheduler** | `fairScheduler.ts` | 23.637 Zeichen, zu viele Verantwortlichkeiten (Pairing, Scheduling, Fairness-Berechnung, Validierung). |
+| **Mixed Concerns: scheduleGenerator** | `scheduleGenerator.ts` | Generiert, scheduliert UND rendert (CSV, Print). Trennung fehlt. |
+| **LiveMatch vs Match Duplikation** | `LiveMatch.ts` vs `MatchSchema` | Zwei Modelle für denselben Use-Case. Sync-Risiko zwischen Runtime und Persistenz. |
+| **Missing Feature Flags** | - | Keine zentrale Konfiguration für Feature-Flags oder Environment-Configs. |
+
+### 🟡 **Medium**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Optimistic Locking Incomplete** | - | `OptimisticLockError` existiert, aber Repository-Implementierung fehlt. |
+| **Barrel Export Chaos** | `core/index.ts` | Zu viele `export *` ohne Dokumentation. |
+| **No Integration Tests** | - | Fokus auf Unit-Tests, keine E2E zwischen Core/Features. |
+
+### 🟢 **Low**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Test File Size** | `playoffGenerator.test.ts` | 14.903 Zeichen - zu groß für Wartbarkeit. |
+| **Hardcoded Timezones** | `scheduleHelpers.ts` | `parseStartTime` nutzt lokale Timezone ohne UTC-Handling. |
+
+---
+
+## 🛠️ Konkrete Verbesserungsvorschläge
+
+### 1. **RepositoryContext Subscriptions Fix** 🔴
+
+**Problem:** `useRef` für Subscriptions funktioniert nicht bei React-StrictMode/Re-Renders.
+
+**Lösung:** Custom Hook mit `useEffect` Cleanup:
+
+```typescript
+// src/core/contexts/useSupabaseSubscriptions.ts
+import { useEffect, useCallback } from 'react';
+
+export function useSupabaseSubscriptions(
+  repo: SupabaseLiveMatchRepository | null,
+  tournamentId: string | null
+) {
+  const unsubscribe = useCallback(() => {
+    repo?.unsubscribeAll();
+  }, [repo]);
+
+  useEffect(() => {
+    return unsubscribe; // Cleanup on unmount
+  }, [unsubscribe]);
+
+  return { unsubscribe };
+}
+
+// RepositoryProvider.tsx
+const { unsubscribe } = useSupabaseSubscriptions(
+  context.supabaseLiveMatchRepo,
+  tournamentId
+);
+```
+
+### 2. **Date Schema Transform** 🔴
+
+**Problem:** JSON speichert Dates als Strings, aber TypeScript erwartet Date-Objekte.
+
+**Lösung:** Zod Transform:
+
+```typescript
+// src/core/models/schemas/TournamentSchema.ts
+const DateTransform = z.preprocess(
+  (arg) => {
+    if (arg instanceof Date) return arg;
+    if (typeof arg === 'string') return new Date(arg);
+    return arg;
+  },
+  z.date().optional()
+);
+
+export const MatchSchema = z.object({
+  // ...
+  scheduledTime: DateTransform, // Statt z.union([z.string(), z.date()])
+});
+```
+
+### 3. **Fair Scheduler Refactoring** 🟠
+
+**Problem:** Zu viele Verantwortlichkeiten in einer Datei.
+
+**Lösung:** Aufteilen nach Single Responsibility:
+
+```
+src/core/generators/
+├── fairScheduler/
+│   ├── index.ts              # Public API
+│   ├── pairing.ts            # Round-robin, DFB patterns
+│   ├── scheduling.ts         # Slot/Feld-Zuweisung
+│   ├── fairness.ts           # Fairness-Berechnung
+│   └── validation.ts         # Constraint-Checks
+```
+
+```typescript
+// src/core/generators/fairScheduler/pairing.ts
+export function generateRoundRobinPairings(teams: Team[]): TeamPairing[] {
+  // Circle Method Logic
+}
+
+// src/core/generators/fairScheduler/scheduling.ts
+export function assignSlotsToMatches(
+  pairings: TeamPairing[],
+  options: SchedulingOptions
+): Match[] {
+  // Slot/Zeit-Zuweisung
+}
+```
+
+### 4. **Feature Flag System** 🟠
+
+**Problem:** Keine zentrale Feature-Flag-Konfiguration.
+
+**Lösung:** Einfaches Feature Flag System:
+
+```typescript
+// src/core/config/featureFlags.ts
+export const FeatureFlags = {
+  ENABLE_PLAYOFF_PRESETS: true,
+  ENABLE_OFFLINE_SYNC: true,
+  ENABLE_MULTI_USER: import.meta.env.VITE_ENABLE_MULTI_USER === 'true',
+} as const;
+
+// src/core/config/index.ts
+export const Config = {
+  featureFlags: FeatureFlags,
+  environment: import.meta.env.MODE,
+  supabaseUrl: import.meta.env.VITE_SUPABASE_URL,
+  // ...
+};
+```
+
+### 5. **LiveMatch/Match Synchronization** 🟠
+
+**Problem:** Zwei Modelle führen zu Inkonsistenzen.
+
+**Lösung:** LiveMatch als View-Only von Match:
+
+```typescript
+// src/core/models/LiveMatch.ts
+export function createLiveMatchFromMatch(
+  match: Match,
+  teamMap: Map<string, Team>
+): LiveMatch {
+  return {
+    id: match.id,
+    homeTeam: teamMap.get(match.teamA),
+    awayTeam: teamMap.get(match.teamB),
+    // ...
+  };
+}
+
+// Repository sollte LiveMatch nicht speichern, nur Match
+```
+
+### 6. **Optimistic Locking Implementierung** 🟡
+
+**Problem:** Error existiert, aber Repository-Implementierung fehlt.
+
+**Lösung:** Version-Check in Repository:
+
+```typescript
+// src/core/repositories/SupabaseRepository.ts
+async function updateTournament(tournament: Tournament) {
+  const { data, error } = await supabase
+    .from('tournaments')
+    .update(tournament)
+    .eq('id', tournament.id)
+    .eq('version', tournament.version); // Optimistic Lock
+
+  if (error?.code === 'PGRST301') { // Conflict
+    throw new OptimisticLockError(
+      tournament.id,
+      tournament.version,
+      (error as any).details?.current_version
+    );
+  }
+}
+```
+
+### 7. **Import-Struktur verbessern** 🟡
+
+**Problem:** `export *` erschwert Nachverfolgung.
+
+**Lösung:** Explizite Exports mit JSDoc:
+
+```typescript
+// src/core/index.ts
+/**
+ * Core Module - Pure Business Logic
+ * @module core
+ */
+
+// Models
+export { TournamentSchema } from './models/schemas/TournamentSchema';
+export { MatchSchema } from './models/schemas/TournamentSchema';
+export { TeamSchema } from './models/schemas/TournamentSchema';
+
+// Repositories
+export { LocalStorageRepository } from './repositories/LocalStorageRepository';
+export { SupabaseRepository } from './repositories/SupabaseRepository';
+export { OfflineRepository } from './repositories/OfflineRepository';
+
+// Generators
+export { generatePlayoffMatches } from './generators/playoffGenerator';
+export { assignReferees } from './generators/refereeAssigner';
+```
+
+---
+
+## 📋 Architektur-Checkliste
+
+| Bereich | Status | Empfehlung |
+|---------|--------|------------|
+| **Dependency Flow** | ✅ Gut | Core → Features vermeiden |
+| **Repository Pattern** | ✅ Gut | Interface-basiert, offline-ready |
+| **Error Handling** | ✅ Exzellent | Feature/Action-Tagging |
+| **Type Safety** | ⚠️ Mittel | Date-Transform fehlt |
+| **Test Coverage** | ✅ Gut | Unit-Tests umfassend |
+| **Code Organization** | ⚠️ Mittel | Fair Scheduler zu groß |
+| **Configuration** | ❌ Fehlend | Feature Flags hinzufügen |
+| **Integration Tests** | ❌ Fehlend | E2E zwischen Schichten |
+
+---
+
+## 🎯 Priorisierte Action Items
+
+### **Sprint 1 (Critical)**
+- [ ] RepositoryContext Subscriptions mit `useEffect` fixen
+- [ ] Date-Transform in Zod-Schemas implementieren
+- [ ] Circular Import Risk analysieren (Core → Features)
+
+### **Sprint 2 (High)**
+- [ ] Fair Scheduler in Module aufteilen
+- [ ] Feature Flag System einführen
+- [ ] LiveMatch/Match Synchronization klären
+
+### **Sprint 3 (Medium)**
+- [ ] Optimistic Locking in Repositories implementieren
+- [ ] Integration Tests für Repository Layer
+- [ ] Barrel Export Dokumentation
+
+---
+
+## 🏁 Fazit
+
+Die Architektur ist **grundsätzlich solide** mit klaren Trennungen und guten Abstraktionen. Die größten Risiken liegen in:
+
+1. **React Lifecycle** (useRef für Subscriptions)
+2. **Date Handling** (JSON vs TypeScript)
+3. **Code Size** (Fair Scheduler als God Object)
+
+Mit den oben genannten Verbesserungen kann die Architektur auf **9/10** skaliert werden. Die Basis für Skalierung (Multi-User, Offline-First, Realtime) ist bereits vorhanden.
+
+---
+
+## Code-Qualitaet & TypeScript-Patterns
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metrik | Wert | Bewertung |
+|--------|------|-----------|
+| **Code Quality Score** | **7.2/10** | ⚠️ Gut mit Verbesserungspotenzial |
+| **Type Safety** | 6.5/10 | ⚠️ Häufige `any`-Casts in Tests |
+| **Test Coverage** | 8.5/10 | ✅ Umfangreiche Tests vorhanden |
+| **Maintainability** | 7.0/10 | ⚠️ ESLint-Disables häufig |
+| **Architecture** | 8.0/10 | ✅ Klare Trennung, gute Abstraktionen |
+
+---
+
+## 🔴 Code Smells (Schweregrad & Referenz)
+
+### Critical (P0)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/calculations.ts` | ~200 | `compareDirectMatches` hat 80+ LOC, tiefe Verschachtelung | Wartbarkeit |
+| `src/utils/scheduleGenerator_finals_bug.test.ts` | ~100 | `console.log` in Tests (Debug-Output) | Test-Clutter |
+| `src/utils/storageCleanup.ts` | ~80 | `cleanupOldLiveMatches` hat 70+ LOC mit komplexer Logik | Wartbarkeit |
+
+### High (P1)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/FairnessCalculator.ts` | 30-40 | `!` Non-Null Assertion (unsafe) | Runtime-Errors möglich |
+| `src/utils/__tests__/ScenarioHMK.test.ts` | 15 | `as ImportedTournament` Cast | Type-Safety verloren |
+| `src/utils/displayNames.ts` | 50 | `eslint-disable` für `prefer-nullish-coalescing` | Code-Style Inkonsistenz |
+| `src/utils/filterMatches.ts` | 40 | `||` statt `??` für Boolean-Checks | Logik-Risiko |
+
+### Medium (P2)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/idGenerator.ts` | 20 | Fallback-UUID ist "weak" | Kollisions-Risiko |
+| `src/utils/knockoutMatchGenerator.ts` | 60 | Dead-Code-Kommentar (nicht entfernt) | Verwirrung |
+| `src/utils/` | alle | Gemischte Deutsch/Englisch Namen | Konsistenz |
+
+---
+
+## ⚠️ TypeScript-Verstöße
+
+### `any`-Verwendung (15+ Vorkommen)
+
+```typescript
+// ❌ src/utils/__tests__/ScenarioHMK.test.ts:15
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+
+// ✅ Besser: Zod-Validation
+import { z } from 'zod';
+const TournamentSchema = z.object({...});
+const importedTournament = TournamentSchema.parse(JSON.parse(fileContent));
+```
+
+### Unsafe Type Assertions
+
+```typescript
+// ❌ src/utils/FairnessCalculator.ts:30
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// ... später
+const newAvg = this.computeAvgRest(state.matchSlots); // state könnte undefined sein!
+
+// ✅ Besser:
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// state ist jetzt sicher im Scope
+```
+
+### Non-Null Assertions (`!`)
+
+```typescript
+// ❌ src/utils/calculations.ts:200
+const teamAStanding = standings.find(...)!; // Kann undefined sein!
+
+// ✅ Besser:
+const teamAStanding = standings.find(...);
+if (!teamAStanding) return;
+```
+
+---
+
+## 📝 Naming-Inkonsistenzen
+
+### Funktion-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `getGroupLabel` (Singular) | `generateGroupLabels` (Plural) |
+| `createDefaultGroups` | `generateGroupLabels` |
+| `generateUniqueId` | `generateTournamentId` |
+| `getGroupDisplayName` | `getFieldDisplayName` |
+
+### Typ-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `TournamentCase` (Schema) | `Tournament` (Runtime) |
+| `ScheduledMatch` | `Match` |
+| `StoredSound` | `Sound` |
+
+### Empfehlung
+- **Singular vs. Plural**: `getGroupLabel` → `generateGroupLabel` (für Einzel)
+- **Verb-Konsistenz**: `generate` für Erzeugung, `get` für Lookup
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Incremental Caching Pattern**
+```typescript
+// ✅ src/utils/FairnessCalculator.ts
+export class FairnessCalculator {
+  private avgRestByTeam = new Map<string, number>();
+  private globalMinAvg = Infinity;
+  private globalMaxAvg = -Infinity;
+  
+  // O(1) Lookups durch Cache
+  recordAssignment(teamId: string): void {
+    // Incremental Update statt Neukalkulation
+    this.globalMinAvg = Math.min(this.globalMinAvg, newAvg);
+    this.globalMaxAvg = Math.max(this.globalMaxAvg, newAvg);
+  }
+}
+```
+
+### 2. **Test-Helper Pattern**
+```typescript
+// ✅ src/utils/__tests__/calculations.test.ts
+const createTournament = (overrides?: Partial<Tournament>): Tournament => ({
+  // Defaults + Overrides
+  ...defaults,
+  ...overrides,
+});
+```
+
+### 3. **Polyfill-Lazy-Loading**
+```typescript
+// ✅ src/utils/polyfills/inert.ts
+export async function initInertPolyfill(): Promise<void> {
+  if ('inert' in HTMLElement.prototype) return; // Native Support check
+  await import('wicg-inert'); // Only load if needed
+}
+```
+
+### 4. **Safe Storage Pattern**
+```typescript
+// ✅ src/utils/storageCleanup.ts
+export function safeLocalStorageSet(key: string, data: string): boolean {
+  try {
+    localStorage.setItem(key, data);
+    return true;
+  } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      cleanupOldLiveMatches(key); // Auto-cleanup
+      return false;
+    }
+  }
+}
+```
+
+---
+
+## 🔧 Refactoring-Empfehlungen (Priorisiert)
+
+### P0 - Critical (Sofort)
+
+1. **Type-Safety in Tests erhöhen**
+   ```bash
+   # Ersetze `as`-Casts durch Zod-Validation
+   # src/utils/__tests__/ScenarioHMK.test.ts
+   ```
+   
+2. **Non-Null Assertions entfernen**
+   ```typescript
+   // src/utils/FairnessCalculator.ts:30
+   // Statt: this.teamStates = teamStates!;
+   // Besser: this.teamStates = teamStates;
+   // Und: if (!state) { return; } statt state!
+   ```
+
+3. **ESLint-Disables reduzieren**
+   ```bash
+   # Ziel: < 10 eslint-disable pro Datei
+   # src/utils/displayNames.ts hat 5+ Disables
+   ```
+
+### P1 - High (Nächste Sprint)
+
+4. **`compareDirectMatches` refaktorisieren**
+   ```typescript
+   // src/utils/calculations.ts
+   // Aufteilen in:
+   // - findDirectMatches()
+   // - calculateMiniTableStats()
+   // - compareMiniTable()
+   ```
+
+5. **Magic Numbers extrahieren**
+   ```typescript
+   // src/utils/soundStorage.ts
+   export const MAX_SOUND_FILE_SIZE = 500 * 1024; // ✅ Gut
+   // src/utils/logoProcessor.ts
+   export const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // ✅ Gut
+   // Aber: 128px, 256, 0.8 - in Konstanten
+   ```
+
+6. **Dead Code entfernen**
+   ```typescript
+   // src/utils/knockoutMatchGenerator.ts
+   // NOTE: updateKnockoutMatchesAfterResult was removed
+   // → Kommentar löschen oder Funktion implementieren
+   ```
+
+### P2 - Medium (Tech Debt Backlog)
+
+7. **Namen konsistentieren**
+   ```bash
+   # getGroupLabel → generateGroupLabel
+   # createDefaultGroups → generateDefaultGroups
+   ```
+
+8. **Debug-Code aus Tests entfernen**
+   ```typescript
+   // src/utils/__tests__/scheduleGenerator_finals_bug.test.ts
+   // eslint-disable no-console → Entfernen
+   // console.log → debugLog() aus debug.ts
+   ```
+
+9. **ID Generator verbessern**
+   ```typescript
+   // src/utils/idGenerator.ts
+   // Fallback entfernen oder robust machen
+   // crypto.randomUUID() ist immer verfügbar in modernen Browsern
+   ```
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Type Safety** | 6.5 | `any` in Tests, Non-Null Assertions |
+| **Test Coverage** | 8.5 | Umfangreiche Tests, Edge Cases abgedeckt |
+| **Code Organization** | 8.0 | Klare Struktur, Utility-Kapselung |
+| **Error Handling** | 7.0 | try/catch vorhanden, aber Custom Errors fehlen |
+| **Performance** | 8.5 | FairnessCalculator mit O(n²) statt O(n³) |
+| **Maintainability** | 7.0 | ESLint-Disables, lange Funktionen |
+| **Security** | 7.5 | UUIDs gut, aber Fallback schwach |
+| **Documentation** | 8.0 | JSDoc vorhanden, aber nicht konsistent |
+
+**Gesamtscore: 7.2/10** ⚠️
+
+---
+
+## 🎯 Next Steps
+
+### Sprint 1 (Type Safety)
+- [ ] Zod-Schemas für alle Test-Fixtures
+- [ ] Non-Null Assertions entfernen
+- [ ] ESLint-Regeln verschärfen (`@typescript-eslint/no-non-null-assertion`)
+
+### Sprint 2 (Code Quality)
+- [ ] `compareDirectMatches` refaktorisieren
+- [ ] ESLint-Disables auf < 5 pro Datei reduzieren
+- [ ] Magic Numbers in Konstanten extrahieren
+
+### Sprint 3 (Tech Debt)
+- [ ] Naming-Konventionen konsistentieren
+- [ ] Dead Code entfernen
+- [ ] Debug-Code aus Production-Code entfernen
+
+---
+
+## 📋 ESLint-Konfigurations-Empfehlung
+
+```json
+{
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "no-console": ["error", { "allow": ["error", "warn"] }],
+    "max-lines-per-function": ["warn", { "max": 50 }],
+    "complexity": ["warn", { "max": 20 }]
+  }
+}
+```
+
+---
+
+**Fazit**: Das Projekt hat eine solide Architektur und gute Testabdeckung, aber Type-Safety und Code-Quality können durch gezielte Refaktorings deutlich verbessert werden. Priorisiere P0-Items für stabile Releases.
+
+---
+
+## UI-Komponenten & Design System
+
+> **FEHLER:** 504 Server Error: Gateway Timeout for url: https://adesso-ai-hub.3asabc.de/v1/chat/completions
+
+---
+
+## PDF-Export, Sharing & Datenausgabe
+
+
+
+# Code Review: hallenfussball-pwa — Export & Sharing
+
+## Export-Bugs (kritisch)
+
+| ID | Problem | Datei | Impact |
+|---|---|---|---|
+| **PDF-001** | **Kein Timeout bei PDF-Generierung** — Bei großen Turnieren (>50 Spiele) kann jsPDF hängen bleiben ohne Feedback | `PDFExportDialog.tsx` | Benutzer sieht "Exportieren..." ewig |
+| **PDF-002** | **Kein Fallback bei jsPDF-Fehlern** — Catch block zeigt nur generische Fehlermeldung, kein Retry | `PDFExportDialog.tsx` | Keine Fehlerdiagnose möglich |
+| **PDF-003** | **Fehlende Schriftart-Embedded** — Umlaute (ä, ö, ü) können in PDF falsch dargestellt werden | `lib/pdfExporter.ts` (nicht im Code) | PDF-Render-Fehler |
+| **SHARE-001** | **Kein Clipboard-Fallback** — Web Share API funktioniert nicht auf Desktop, kein Copy-to-Clipboard | `ShareDialog.tsx` (nicht im Code) | Desktop-Nutzer können Link nicht kopieren |
+| **SHARE-002** | **Kein Deep-Link für geteilte Turniere** — `shareCode` wird nicht in URL codiert | `ShareDialog.tsx` | Geteilter Link zeigt nicht das richtige Turnier |
+| **SHARE-003** | **Monitor-URL ohne Auth-Check** — Öffentliche Monitor-URL könnte sensible Daten zeigen | `MonitorView.tsx` (nicht im Code) | Datenschutz-Problem |
+
+## Fehlende Export-Formate
+
+| Format | Status | Empfehlung |
+|---|---|---|
+| **CSV Export** | ❌ Fehlend | Ergebnisse, Tabellen, Spielplan als CSV |
+| **JSON Backup** | ⚠️ Teilweise (nur Import) | Vollständiges Turnier als JSON exportieren |
+| **Excel/XLSX** | ❌ Fehlend | Für Office-Nutzer wichtig |
+| **Print-Friendly** | ❌ Fehlend | `@media print` Styles für Browser-Print |
+| **QR-Code PDF** | ⚠️ Teilweise (nur QR-Code) | PDF mit QR-Code für Live-Tracking |
+
+## Sharing-UX-Probleme
+
+| Problem | Beschreibung | Lösung |
+|---|---|---|
+| **Kein Link-Vorschau** | Geteilter Link zeigt nur ID, keine Turnier-Info | Open Graph Tags implementieren |
+| **Keine QR-Code Generierung** | QR-Code wird nur im Schedule angezeigt | QR-Code Dialog für Teilen hinzufügen |
+| **Keine Social-Media-Vorschau** | Keine Meta-Tags für Twitter/Facebook | `og:title`, `og:image`, `twitter:card` |
+| **Kein "Live-Status" im Link** | Geteilter Link zeigt immer Vorrunde | URL-Parameter für aktuelle Phase |
+| **Kein "Teilen per E-Mail"** | Nur Web Share API | `mailto:` Link mit Turnier-Info |
+
+## Positive Patterns ✅
+
+| Pattern | Datei | Bewertung |
+|---|---|---|
+| **Error Boundary** | `ErrorBoundary.tsx` | ⭐⭐⭐⭐⭐ Exzellente Fehlerbehandlung mit Sentry |
+| **Dialog-Struktur** | `Dialog.tsx`, `PDFExportDialog.tsx` | ⭐⭐⭐⭐⭐ Konsistent, zugänglich, responsive |
+| **i18n Integration** | Alle Dialogs | ⭐⭐⭐⭐⭐ Vollständige Übersetzungen |
+| **Focus Trap** | `Dialog.tsx`, `ConsentDialog.tsx` | ⭐⭐⭐⭐⭐ WCAG 4.1.3 konform |
+| **Offline-Feedback** | `OfflineBanner.tsx`, `OfflineModeIndicator.tsx` | ⭐⭐⭐⭐⭐ Gute UX bei Netzwerkproblemen |
+| **Import-Validierung** | `ImportDialog.tsx` | ⭐⭐⭐⭐⭐ Mehrstufiger Prozess mit Warnings |
+| **Responsive FAB** | `ScheduleActionButtons.tsx` | ⭐⭐⭐⭐ Mobile-optimierte Action-Buttons |
+
+## Export Score: 6.5/10
+
+### Begründung:
+
+**Stärken (+3 Punkte):**
+- ✅ PDF-Export-Dialog mit Optionen
+- ✅ Import-Funktion mit Validierung
+- ✅ Error Boundary für Fehlerbehandlung
+- ✅ i18n und Accessibility berücksichtigt
+- ✅ Responsive Design für Mobile
+
+**Schwächen (-3.5 Punkte):**
+- ❌ Kein CSV/Excel Export
+- ❌ Kein Print-Friendly Mode
+- ❌ Keine Clipboard-Funktion
+- ❌ Keine Deep-Links für Sharing
+- ❌ Keine QR-Code Generierung für Teilen
+- ❌ Fehlende Meta-Tags für Social Sharing
+- ❌ Keine Timeout/Progress bei PDF-Generierung
+
+## Empfehlungen (Priorisiert)
+
+### 🔴 Kritisch (Sofort)
+1. **PDF Timeout & Progress** — `Promise.race` mit 30s Timeout + Ladebalken
+2. **Clipboard-Fallback** — `navigator.clipboard.writeText()` für Desktop
+3. **Deep-Link für Sharing** — `window.location.href = '/turnier/${shareCode}'`
+
+### 🟡 Wichtig (Nächste Sprint)
+4. **CSV Export** — `exportStandingsToCSV()`, `exportScheduleToCSV()`
+5. **Print Styles** — `@media print` für ScheduleDisplay
+6. **QR-Code Dialog** — QR-Code für Turnier-Link generieren
+
+### 🟢 Nice-to-have
+7. **JSON Backup Export** — `exportTournamentToJSON()`
+8. **Open Graph Meta-Tags** — Für Social Media Vorschau
+9. **PDF mit QR-Code** — QR-Code auf Spielplan-PDF für Live-Tracking
+
+## Code-Beispiel für fehlende Features
+
+```tsx
+// ✅ Clipboard-Fallback für ShareDialog
+const handleCopyLink = async () => {
+  const url = `${window.location.origin}/turnier/${shareCode}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    showSuccess(t('share.copied'));
+  } catch {
+    // Fallback für ältere Browser
+    const textarea = document.createElement('textarea');
+    textarea.value = url;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    showSuccess(t('share.copied'));
+  }
+};
+
+// ✅ CSV Export für Ergebnisse
+const exportStandingsToCSV = (standings: Standing[]) => {
+  const headers = ['Team', 'Spiele', 'Siege', 'Unentschieden', 'Niederlagen', 'Tore', 'Punkte'];
+  const rows = standings.map(s => [
+    s.team.name,
+    s.matchesPlayed,
+    s.wins,
+    s.draws,
+    s.losses,
+    `${s.goalsFor}:${s.goalsAgainst}`,
+    s.points
+  ]);
+  
+  const csv = [headers, ...rows].map(r => r.join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'turnier-ergebnisse.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+// ✅ Print Styles für ScheduleDisplay
+const printStyles = `
+  @media print {
+    .schedule-display {
+      padding: 0 !important;
+      background: white !important;
+      color: black !important;
+    }
+    .schedule-action-buttons,
+    .offline-banner,
+    .toast-container {
+      display: none !important;
+    }
+    .match-card {
+      page-break-inside: avoid;
+      border: 1px solid #ccc !important;
+    }
+  }
+`;
+```
+
+## Fazit
+
+Die App hat eine solide Basis für PDF-Export und Import, aber **fehlende Export-Formate** und **Sharing-Funktionen** sind kritische Lücken. Priorisiere **Clipboard-Fallback** und **CSV Export** für die nächste Iteration. Die **PDF-Generierung** benötigt dringend **Timeout-Handling** und **Progress-Feedback**.
+
+---
+
+## Hooks, State & Context
+
+> **FEHLER:** 504 Server Error: Gateway Timeout for url: https://adesso-ai-hub.3asabc.de/v1/chat/completions
+
+---
+
+## Internationalisierung & Barrierefreiheit
+
+
+
+# i18n & Accessibility Code Review: hallenfussball-pwa
+
+## 📊 Scores
+| Category | Score | Assessment |
+|----------|-------|------------|
+| **i18n** | **8.5/10** | Excellent structure, type-safe, good pluralization support |
+| **Accessibility** | **6.5/10** | Good foundations, critical gaps in live data announcements |
+
+---
+
+## 🔍 i18n-Lücken & Issues
+
+### ❌ Hardcodierte Strings (MEDIUM)
+```tsx
+// ContactForm.tsx - Toggle-Button mit Emoji
+<span>{showExtended ? '▼' : '▶'}</span>
+```
+**Problem**: Icons/Arrows sind nicht übersetzbar, Screenreader lesen "▼" als "down arrow"
+**Lösung**: In i18n verschieben oder SVG mit `aria-hidden="true"`
+
+```tsx
+// ErrorBoundary.tsx - Warning Icon
+<span style={{ fontSize: cssVars.fontSizes.xxl }} aria-hidden="true">
+  ⚠️
+</span>
+```
+**Problem**: Emoji ohne Screenreader-Text-Kontext
+**Lösung**: `aria-label={t('errorBoundary.warning')}` hinzufügen oder SVG-Icon
+
+### ⚠️ Fehlende Plural-Keys (LOW)
+```json
+// admin.json - Missing some plural forms
+"gamesRunning_one": "{{count}} Spiel läuft",
+"gamesRunning_other": "{{count}} Spiele laufen",
+// But missing for:
+"teams" - should have plural support
+"groups" - has plural, good
+```
+
+### ⚠️ Datums-/Zeitformate (LOW)
+```ts
+// dateFormatting.ts - Good, but needs time format consideration
+export function formatTime(date: Date | string | number): string {
+  return new Intl.DateTimeFormat(i18n.language, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+}
+```
+**Problem**: 12h/24h-Formatierung ist browserabhängig, sollte explizit gesetzt werden
+
+### ✅ Positive i18n Patterns
+- **Type-safe i18next** mit TypeScript Module Augmentation
+- **Namespace-Struktur** klar getrennt (cockpit, monitor, wizard, etc.)
+- **Pluralization** korrekt implementiert (`_one`/`_other`)
+- **Language detection** mit localStorage → Browser → Fallback
+- **HTML lang-Attribut** wird automatisch synced
+- **Date/Time formatting** mit Intl.DateTimeFormat
+
+---
+
+## ♿ WCAG 2.1 AA Verstöße
+
+### 🔴 CRITICAL (Must Fix)
+
+#### 1. Live-Daten ohne aria-live (CRITICAL)
+```tsx
+// Cockpit-Komponente - Timer, Score Updates
+<div>{timer}</div>
+<div>{score}</div>
+```
+**Problem**: Screenreader hören keine Änderungen bei laufenden Spielen
+**WCAG**: 4.1.3 Status Messages
+**Lösung**:
+```tsx
+<div aria-live="polite" aria-atomic="true">
+  {t('cockpit.ariaLive.running')} {timer}
+</div>
+```
+
+#### 2. Toggle-Button ohne aria-expanded (HIGH)
+```tsx
+// ContactForm.tsx
+<button
+  type="button"
+  onClick={() => setShowExtended(!showExtended)}
+>
+  {t('contact.toggle')}
+</button>
+```
+**Problem**: Screenreader weiß nicht, ob Bereich expandiert/collapsed ist
+**WCAG**: 4.1.2 Name, Role, Value
+**Lösung**:
+```tsx
+<button
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+>
+```
+
+#### 3. Fehlt: Focus Management in Modals (HIGH)
+**Problem**: Keine sichtbare Focus-Trap-Implementierung in Dialog-Komponenten
+**WCAG**: 2.4.3 Focus Order
+**Lösung**: `react-aria` oder `react-focus-lock` implementieren
+
+### 🟡 MEDIUM Priority
+
+#### 4. Skip Links (MEDIUM)
+**Problem**: Keine Skip-to-content Link für Keyboard-Nutzer
+**WCAG**: 2.4.1 Bypass Blocks
+**Lösung**:
+```tsx
+<a href="#main-content" className="skip-link">
+  {t('common.skipToContent')}
+</a>
+```
+
+#### 5. Form Labels (MEDIUM)
+```tsx
+// Input-Komponente - nicht sichtbar im Code, aber prüfen:
+<Input label={t('contact.name')} />
+```
+**Problem**: `label` prop muss mit `htmlFor`/`id` verknüpft sein
+**WCAG**: 1.3.1 Info and Relationships
+
+#### 6. Touch Targets (MEDIUM)
+**Problem**: Cannot verify sizes from code, but ensure 48x48px minimum
+**WCAG**: 2.5.5 Target Size
+**Lösung**: Design Tokens prüfen (`cssVars.touchTargetSize`)
+
+### 🟢 LOW Priority
+
+#### 7. Color Contrast (LOW)
+**Problem**: Cannot verify from code alone
+**Lösung**: Design Tokens auf 4.5:1 (normal), 3:1 (large text) prüfen
+
+#### 8. Reduced Motion (LOW)
+**Problem**: Animationen bei Timer/Goal-Animationen
+**WCAG**: 2.3.3 Animation from Interactions
+**Lösung**:
+```css
+@media (prefers-reduced-motion: reduce) {
+  .goal-animation {
+    animation: none;
+  }
+}
+```
+
+---
+
+## 🎯 Screenreader-Probleme (Live-Daten)
+
+### ❌ Kritische Lücken
+
+| Feature | Problem | Lösung |
+|---------|---------|--------|
+| **Timer-Updates** | Jede Sekunde ändert sich die Zeit | `aria-live="polite"` mit Intervall-Announcement alle 10s |
+| **Tor-Ankündigungen** | Screenreader hört "Goal" nicht | `aria-live="assertive"` bei Tor |
+| **Spielstatus-Wechsel** | Running → Paused → Finished | Announcements bei Status-Änderung |
+| **Karten/Zeitstrafen** | Keine Ankündigung bei Ereignissen | `aria-live="polite"` im Event-Log |
+
+### ✅ Positive Patterns
+- `role="alert"` im ErrorBoundary (gut!)
+- ARIA-Labels in Übersetzungen (`*_AriaLabel`)
+- `aria-label` für Icons/Buttons in i18n-Keys
+
+---
+
+## 📋 Empfohlene Sofort-Maßnahmen
+
+### Phase 1 (Critical - 1-2 Tage)
+```tsx
+// 1. Live Announcements im Cockpit
+<div aria-live="polite" aria-atomic="true">
+  {t('cockpit.ariaLive.running')} {formatTime(timer)}
+</div>
+
+// 2. Toggle Button fix
+<button
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+>
+  {t('contact.toggle')}
+</button>
+
+// 3. Goal Announcements
+<div aria-live="assertive" className="sr-only">
+  {t('cockpit.toast.goalScored', { teamName })}
+</div>
+```
+
+### Phase 2 (High - 1 Woche)
+- Skip Links implementieren
+- Focus Trap in Modals (react-focus-lock)
+- Reduced Motion Support
+- Touch Target Sizes prüfen
+
+### Phase 3 (Medium - 2 Wochen)
+- RTL-Testing (auch wenn nur DE/EN)
+- Number formatting mit Intl.NumberFormat
+- Color Contrast Audit
+
+---
+
+## 🏆 Zusammenfassung
+
+**Stärken:**
+- ✅ Exzellente i18n-Struktur mit TypeScript-Support
+- ✅ Gute Pluralization-Implementierung
+- ✅ ARIA-Labels in Translation-Files integriert
+- ✅ Error Boundary mit `role="alert"`
+
+**Schwachstellen:**
+- ❌ **Live-Daten ohne aria-live** (kritisch für Cockpit)
+- ❌ Toggle-Buttons ohne aria-expanded
+- ❌ Fehlt: Focus Management in Modals
+- ❌ Fehlt: Skip Links
+
+**Empfehlung:** Live-Daten-Announcements priorisieren (Cockpit ist Kern-Feature), dann Accessibility-Grundlagen abschließen.
+
+---
+
+## 📝 Code-Snippets für Fix
+
+```tsx
+// src/components/Cockpit/MatchTimer.tsx
+export const MatchTimer: React.FC<{ timer: string; status: MatchStatus }> = ({ 
+  timer, 
+  status 
+}) => {
+  const { t } = useTranslation('cockpit');
+  
+  return (
+    <>
+      {/* Screenreader-Announcement (polite) */}
+      <div 
+        aria-live="polite" 
+        aria-atomic="true" 
+        className="sr-only"
+      >
+        {t('ariaLive.running')} {timer}
+      </div>
+      
+      {/* Visuelle Anzeige */}
+      <div className="timer-display">{timer}</div>
+    </>
+  );
+};
+
+// src/components/ContactForm.tsx
+<button
+  type="button"
+  onClick={() => setShowExtended(!showExtended)}
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+  aria-label={`${t('contact.toggle')} ${showExtended ? t('actions.collapse') : t('actions.expand')}`}
+>
+  <span aria-hidden="true">{showExtended ? '▼' : '▶'}</span>
+  {t('contact.toggle')}
+</button>
+```
+
+---
+
+**Gesamtbewertung:** Sehr gute i18n-Basis, Accessibility muss bei Live-Daten dringend nachgebessert werden.
+
+---
+
+## Live-Cockpit & Spielsteuerung
+
+
+
+# QA-Review: Live-Cockpit & Spielsteuerung (Code-Analyse)
+
+## ⚠️ WICHTIGER HINWEIS
+Das bereitgestellte Code-Segment zeigt primär den **Schedule-Editor**, nicht das **Live-Cockpit**. Für eine vollständige Analyse fehlen:
+- Timer-Logik (Start/Stop/Pause/Drift)
+- Live-Score-Erfassung & Sync
+- Realtime-Supabase-Integration für Live-Spiele
+- Monitor/Anzeigetafel-Komponenten
+- Spielstatus-Management (`running`, `finished`, `paused`)
+
+Ich analysiere daher **was vorhanden ist** und identifiziere **kritische Lücken**.
+
+---
+
+## 🚨 Kritische Timing-Bugs
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Kein Live-Timer im Code** | 🔴 Critical | Timer-Logik fehlt komplett. Wie wird Spielzeit gemessen? Client-Date (`setInterval`) oder Server-Time? |
+| **Keine Browser-Tab-Drift-Kompensation** | 🔴 Critical | Wenn Tab im Hintergrund: `setInterval` verlangsamt sich. Keine `requestAnimationFrame` oder `performance.now()`-Synchronisierung erkennbar. |
+| **Keine Race-Condition-Prävention bei Score-Updates** | 🟠 High | Mehrere User können gleichzeitig Tore eintragen? Optimistic UI ohne Conflict-Resolution? |
+| **Undo/Redo im Schedule-Editor** | 🟡 Medium | Lokal mit `useReducer`. Bei Live-Spiel: Was passiert bei Tab-Wechsel? History geht verloren. |
+
+**Code-Beispiel (Schedule-Editor Undo):**
+```typescript
+const undoStackRef = useRef<HistoryState[]>([]);
+// ⚠️ Lokal im Browser! Bei Refresh/Tab-Wechsel verloren.
+```
+
+---
+
+## 🧠 Logik-Fehler
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Keine Punkte-Berechnung im Code** | 🔴 Critical | Tabellenstand, Tordifferenz, Direkter Vergleich nicht implementiert. |
+| **Sortierung bei Punktgleichheit unklar** | 🟠 High | Wie wird bei Gleichstand sortiert? Tordifferenz? Tore? Direkter Vergleich? |
+| **Match-Duration vs. Break-Duration** | 🟡 Medium | `matchDurationMinutes: 10` in Tests, aber `gameDuration` im Tournament-Typ? Inkonsistenz. |
+| **Skip-Match Logik** | 🟡 Medium | `matchStatus: 'skipped'` wird gesetzt, aber wie wirkt sich das auf Tabelle aus? |
+
+**Code-Beispiel (Conflict Detection):**
+```typescript
+// ✅ GUT: Team-Double-Booking wird erkannt
+const conflicts = detectTeamConflicts(matches, matchDuration, teams);
+// ⚠️ ABER: Keine Logik, wie Konflikte im Live-Spiel behandelt werden.
+```
+
+---
+
+## 😫 UX-Probleme unter Zeitdruck (Halle = Stress-Szenario)
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Keine Bestätigung bei Tor-Eingabe** | 🔴 Critical | Ein Tippfehler = falsches Ergebnis. Kein Undo-Zeitfenster für Tore? |
+| **Kein "Spiel läuft"-Indikator** | 🟠 High | Wie weiß der User, ob das Spiel gerade läuft? Timer läuft? |
+| **Keine Offline-Resilienz** | 🟠 High | Bei Netzwerk-Ausfall während des Spiels: Was passiert mit Score-Updates? |
+| **Mobile View für Cockpit?** | 🟡 Medium | `compact`-Mode im Editor, aber Cockpit-Monitor? |
+| **Keine Audio-Feedback** | 🟡 Medium | Kein Sound bei Tor, Spielstart, Spielende? |
+
+**Code-Beispiel (Drag & Drop):**
+```typescript
+// ✅ GUT: Drag-Distance für Touch (200ms delay)
+useSensor(TouchSensor, {
+  activationConstraint: {
+    delay: 200,
+    tolerance: 5,
+  },
+});
+// ⚠️ ABER: Im Live-Cockpit braucht man direkte Eingabe, kein Drag.
+```
+
+---
+
+## ✅ Positive Patterns
+
+| Pattern | Bewertung | Beschreibung |
+|---------|-----------|--------------|
+| **Conflict Detection mit O(1) Lookup** | 🟢 Excellent | `conflictsByMatch: Map<string, ScheduleConflict[]>` für schnelle Abfrage. |
+| **Undo/Redo mit History-Stack** | 🟢 Excellent | `undoStackRef`, `redoStackRef` mit `useReducer`. |
+| **Drag & Drop mit @dnd-kit** | 🟢 Excellent | Accessibility, Touch-Support, Keyboard-Support integriert. |
+| **Zustandsmanagement mit Hooks** | 🟢 Excellent | `useScheduleEditor`, `useMatchConflicts` trennt UI von Logik. |
+| **Typ-Safety mit TypeScript** | 🟢 Excellent | `Match`, `Tournament`, `ScheduleConflict` sind gut definiert. |
+| **Testabdeckung** | 🟢 Excellent | Viele Unit-Tests für Conflict Detection, Auto-Reassign. |
+| **Konflikt-Dialog mit Severity** | 🟢 Excellent | `error` vs. `warning` Unterscheidung, Vorschläge zur Lösung. |
+
+---
+
+## 📊 Live-Cockpit Score
+
+| Kategorie | Score | Kommentar |
+|-----------|-------|-----------|
+| **Timer-Logik** | 0/10 | ❌ Fehlt komplett |
+| **Realtime-Sync** | 0/10 | ❌ Supabase Realtime erwähnt, aber nicht im Code |
+| **Score-Erfassung** | 0/10 | ❌ Keine UI für Tor-Eingabe |
+| **Konflikt-Prävention** | 7/10 | ✅ Schedule-Editor gut, aber nicht für Live |
+| **UX unter Stress** | 3/10 | ⚠️ Editor gut, Cockpit fehlt |
+| **Code-Qualität** | 9/10 | ✅ Exzellente Struktur, Tests, Typ-Safety |
+| **Gesamt** | **3/10** | ⚠️ **Schedule-Editor ist gut, aber Live-Cockpit fehlt** |
+
+---
+
+## 🔧 Empfehlungen für Live-Cockpit
+
+### 1. **Timer-Logik (Critical)**
+```typescript
+// ⚠️ Client-Date vs. Server-Time
+const useGameTimer = (matchId: string) => {
+  const [time, setTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  
+  useEffect(() => {
+    // ⚠️ Drift-Kompensation mit Server-Time
+    const syncWithServer = async () => {
+      const serverTime = await getServerTime();
+      setTime(serverTime);
+    };
+    syncWithServer();
+    
+    const interval = setInterval(() => {
+      setTime(t => t + 1);
+    }, 1000);
+    
+    return () => clearInterval(interval);
+  }, [isRunning]);
+};
+```
+
+### 2. **Score-Update mit Conflict-Resolution**
+```typescript
+// ⚠️ Optimistic UI + Server-Ack
+const updateScore = async (matchId: string, newScore: Score) => {
+  // Optimistic Update
+  setScore(newScore);
+  
+  try {
+    await supabase.from('matches').update({ score: newScore }).eq('id', matchId);
+  } catch (error) {
+    // Rollback bei Conflict
+    setScore(oldScore);
+    showError('Konflikt beim Speichern');
+  }
+};
+```
+
+### 3. **Offline-Resilienz**
+```typescript
+// ⚠️ Queue für Offline-Updates
+const useOfflineScoreQueue = () => {
+  const [queue, setQueue] = useState<ScoreUpdate[]>([]);
+  
+  useEffect(() => {
+    const subscription = supabase.on('matches', 'UPDATE', (payload) => {
+      // Sync queue bei Verbindung wiederhergestellt
+      if (payload.eventType === 'INSERT') {
+        processQueue();
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+};
+```
+
+### 4. **Monitor/Anzeigetafel**
+```typescript
+// ⚠️ Separate View für Zuschauer
+const LiveMonitor = () => {
+  const { data: match } = useSupabaseMatch(matchId);
+  
+  return (
+    <div className="monitor">
+      <Timer time={match.gameTime} isRunning={match.status === 'running'} />
+      <Score home={match.scoreA} away={match.scoreB} />
+      <MatchStatus status={match.status} />
+    </div>
+  );
+};
+```
+
+---
+
+## 🎯 Fazit
+
+**Der Schedule-Editor ist hervorragend implementiert** (9/10 Code-Qualität), aber **das Live-Cockpit fehlt komplett**. Für eine Produktions-Turnierverwaltung müssen folgende Komponenten nachgebaut werden:
+
+1. **Timer-Logik** mit Drift-Kompensation
+2. **Score-Erfassung** mit Undo/Conflict-Resolution
+3. **Realtime-Sync** via Supabase Realtime
+4. **Offline-Queue** für Netzwerk-Ausfälle
+5. **Monitor-Ansicht** für Zuschauer
+
+**Empfohlene nächste Schritte:**
+1. Live-Cockpit-Feature als separates Modul erstellen
+2. Timer-Logik mit `performance.now()` + Server-Sync implementieren
+3. Score-Update mit Optimistic UI + Server-Ack
+4. Monitor/Anzeigetafel als separate PWA-Route
+5. Integrationstests für Live-Szenarien (mehrere User, Offline)
+
+**Gesamt-Bewertung: 3/10** (wegen fehlendem Live-Cockpit, nicht wegen schlechtem Code)
+
+---
+
+## Performance, Bundle & PWA
+
+
+
+# 🔍 Performance & PWA Audit: hallenfussball-pwa
+
+## Executive Summary
+
+| Kategorie | Bewertung | Status |
+|-----------|-----------|--------|
+| **Bundle Size** | 6/10 | ⚠️ Keine Code-Splitting-Strategie sichtbar |
+| **PWA-Fähigkeit** | 4/10 | ❌ Service Worker & Manifest nicht im Code |
+| **Offline-Storage** | 9/10 | ✅ Excellent IndexedDB-Implementierung |
+| **Runtime Performance** | 7/10 | ✅ Async Storage, aber Migration blockiert |
+| **Overall Score** | **6.5/10** | 🟡 Gut, aber PWA-Lücken kritisch |
+
+---
+
+## 🚨 Critical Issues
+
+### 1. **Fehlender Service Worker (PWA-Kern)**
+```ts
+// ❌ Nicht im Code gefunden:
+// - sw.ts / service-worker.ts
+// - Vite PWA Plugin (vite-plugin-pwa)
+// - Cache-Strategien (Stale-While-Revalidate, Network-First)
+// - Precache-Manifest
+```
+**Impact:** App ist **nicht installierbar**, keine Offline-Funktion, keine Push-Notifications.
+
+### 2. **Blockierende Storage-Migration bei App-Start**
+```ts
+// src/core/storage/StorageFactory.ts
+await autoMigrate(); // ⚠️ Blockiert Initialisierung
+```
+**Problem:**
+- `autoMigrate()` wird bei jedem Start geprüft
+- Bei großen localStorage-Daten (Turniere, Spielpläne) → **LCP verzögert**
+- Keine Progress-Indikation für User
+
+**Schätzung:** +500ms bis +3s LCP bei ersten Nutzern mit Migration
+
+### 3. **Kein Code-Splitting sichtbar**
+```ts
+// 626 Dateien → wahrscheinlich ein großer Bundle
+// ❌ Keine dynamic imports für:
+// - PDF-Export (jsPDF ist groß: ~300KB)
+// - Turnier-Wizard
+// - Live-Cockpit (Timer, Realtime)
+// - Playoff-Bracket
+```
+
+---
+
+## 📦 Bundle-Optimierungen
+
+### Current State (Geschätzt)
+| Chunk | Größe (geschätzt) | Problem |
+|-------|-------------------|---------|
+| `main.js` | ~400-600KB | Alle Features gebündelt |
+| `jsPDF` | ~300KB | Wird nur bei Export benötigt |
+| `i18next` | ~50KB | Alle Locale-Dateien gebündelt |
+| `Supabase Client` | ~100KB | Könnte lazy geladen werden |
+
+### Optimierungs-Potenzial
+
+#### 1. **Lazy Loading für schwere Features**
+```ts
+// ✅ jsPDF nur bei Bedarf laden
+const exportPDF = async () => {
+  const { jsPDF } = await import('jspdf');
+  // ... PDF erstellen
+};
+
+// ✅ Turnier-Wizard lazy laden
+const TournamentWizard = lazy(() => import('@/features/tournament/Wizard'));
+
+// ✅ Live-Cockpit lazy laden
+const LiveCockpit = lazy(() => import('@/features/live/Cockpit'));
+```
+**Size Impact:** -300KB initial, +200KB lazy
+
+#### 2. **Vite Config Optimierungen**
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor': ['react', 'react-dom'],
+          'supabase': ['@supabase/supabase-js'],
+          'pdf': ['jspdf'],
+          'i18n': ['i18next', 'react-i18next'],
+        },
+      },
+    },
+    chunkSizeWarningLimit: 500, // Warnung bei >500KB
+  },
+  // Code Splitting für Routes
+  optimizeDeps: {
+    include: ['@supabase/supabase-js'],
+  },
+});
+```
+**Size Impact:** -150KB initial, bessere Caching durch Chunk-Hashing
+
+#### 3. **Tree Shaking für i18next**
+```ts
+// ❌ Alle Lokales gebündelt
+import i18n from 'i18next';
+
+// ✅ Nur benötigte Locale lazy laden
+const loadLocale = async (lng: string) => {
+  const module = await import(`./locales/${lng}.json`);
+  return module.default;
+};
+```
+**Size Impact:** -100KB (bei 5 Lokales à 20KB)
+
+---
+
+## 📱 PWA-Lücken
+
+### Fehlende Komponenten
+| Feature | Status | Impact |
+|---------|--------|--------|
+| `manifest.json` | ❌ | Keine Installation |
+| `vite-plugin-pwa` | ❌ | Kein Service Worker |
+| Offline-Page | ❌ | Keine UX bei Netzausfall |
+| Install-Prompt | ❌ | Keine User-Conversion |
+| Splash Screen | ❌ | Keine native App-Feeling |
+| Background Sync | ❌ | Keine Offline-Updates |
+
+### Empfohlene PWA-Config
+```ts
+// vite.config.ts
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  plugins: [
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
+      manifest: {
+        name: 'Hallenfußball Turnier',
+        short_name: 'Hallenfußball',
+        description: 'Turnierverwaltung für Hallenfußball',
+        theme_color: '#1a1a1a',
+        background_color: '#ffffff',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        icons: [
+          {
+            src: 'pwa-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: 'pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+        ],
+      },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/api\.supabase\.co.*/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-cache',
+              networkTimeoutSeconds: 10,
+            },
+          },
+          {
+            urlPattern: /\.(?:png|jpg|jpeg|svg|gif)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'images-cache',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Tage
+              },
+            },
+          },
+        ],
+      },
+    }),
+  ],
+});
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Exzellente Storage-Abstraktion**
+```ts
+// IStorageAdapter Interface
+// ✅ Testbar, erweiterbar, fallback-fähig
+```
+**Score:** 9/10
+
+### 2. **IndexedDB mit Fallback**
+```ts
+// ✅ Safari Private Mode erkannt
+// ✅ Quota-Monitoring
+// ✅ Migration-Utilities
+```
+
+### 3. **Comprehensive Testing**
+```ts
+// ✅ Unit Tests für StorageFactory
+// ✅ E2E Tests für IndexedDB
+// ✅ Fallback-Szenarien getestet
+```
+
+### 4. **Type-Safe Storage**
+```ts
+// ✅ Generics für Typ-Sicherheit
+// ✅ Error-Handling mit StorageError
+```
+
+---
+
+## 🚀 Performance-Verbesserungen (Priorisiert)
+
+### Phase 1: PWA-Fundament (Wichtigste)
+1. **Vite PWA Plugin hinzufügen** (1-2h)
+   - `npm install vite-plugin-pwa workbox-window`
+   - Manifest.json erstellen
+   - Service Worker konfigurieren
+
+2. **Offline-Page erstellen** (2-4h)
+   - "Keine Verbindung"-UI
+   - Retry-Button mit Status-Indikator
+   - Local-Data-Anzeige
+
+3. **Install-Prompt implementieren** (1h)
+   - `beforeinstallprompt` Event
+   - Custom Install-Button
+
+### Phase 2: Bundle-Optimierung (Hoher Impact)
+1. **Code-Splitting für Features** (4-8h)
+   - `React.lazy()` für alle Routes
+   - Dynamic imports für jsPDF, i18n
+
+2. **Vite Config optimieren** (2-4h)
+   - Manual chunks konfigurieren
+   - Brotli/Gzip aktivieren
+
+3. **Asset-Optimierung** (2-4h)
+   - Bilder komprimieren (WebP)
+   - Fonts als WOFF2
+   - SVG-Icons statt PNG
+
+### Phase 3: Runtime Performance (Optional)
+1. **Virtualisierte Listen** (2-4h)
+   - `react-window` für Spieler-Listen
+   - `react-virtual` für Tabellen
+
+2. **Memoization für Heavy Components** (2-4h)
+   - `useMemo` für Berechnungen
+   - `React.memo` für Render-Optimierung
+
+3. **Web Workers für PDF-Export** (4-6h)
+   - UI blockiert nicht während Export
+
+---
+
+## 📊 Performance Score Breakdown
+
+| Metric | Score | Gewichtung | Weighted |
+|--------|-------|------------|----------|
+| **Initial Load (LCP)** | 5/10 | 25% | 1.25 |
+| **Bundle Size** | 6/10 | 20% | 1.20 |
+| **PWA Capability** | 4/10 | 25% | 1.00 |
+| **Offline Function** | 9/10 | 15% | 1.35 |
+| **Runtime Performance** | 7/10 | 15% | 1.05 |
+| **TOTAL** | | 100% | **5.85/10** |
+
+---
+
+## 🎯 Next Steps (Sofort)
+
+1. **`vite-plugin-pwa` installieren** (Priorität: 🔴 Kritisch)
+2. **Manifest.json erstellen** (Priorität: 🔴 Kritisch)
+3. **Code-Splitting für jsPDF** (Priorität: 🟠 Hoch)
+4. **Lazy Loading für Routes** (Priorität: 🟠 Hoch)
+5. **Migration-Progress-Indikator** (Priorität: 🟡 Mittel)
+
+---
+
+**Fazit:** Die Storage-Architektur ist exzellent, aber die PWA-Implementierung fehlt vollständig. Ohne Service Worker ist die App nicht als PWA nutzbar. Priorisiere PWA-Setup vor weiteren Optimierungen.
+
+---
+
+## Screens, Routing & Navigation
+
+
+
+Hier ist das strukturierte Review basierend auf dem bereitgestellten Code.
+
+# 📱 React Router & UX Review: hallenfussball-pwa
+
+## 1. Routing-Probleme
+
+### 🔴 Fehlende zentrale Route Guards
+**Status:** Kritisch
+**Problem:** Es gibt keine zentrale `ProtectedRoute`-Komponente im Code. Auth-Checks und Limits werden in den Screens selbst gehandhabt (z.B. `useTournamentLimit` im Dashboard, `onNavigateToLogin` Props).
+**Risiko:** Ein User kann per URL direkt zu `/tournament/:id/management` navigieren, ohne eingeloggt zu sein. Die Auth-Logik ist über die Screens verstreut und schwer zu warten.
+**Lösung:** Erstelle einen `ProtectedRoute` Wrapper in `src/components/routing/ProtectedRoute.tsx`.
+```tsx
+// Beispiel
+const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  return children;
+};
+```
+
+### 🟠 Redundante Public Screens
+**Status:** Mittel
+**Problem:** `LiveViewScreen` und `PublicTournamentViewScreen` haben fast identische Logik (Laden, Privacy-Filter, Schedule-Anzeige). `LiveViewScreen` nutzt `shareCode`, `PublicTournamentViewScreen` nutzt `tournamentId`.
+**Risiko:** Wartungsaufwand verdoppelt, Inkonsistenzen bei Bugfixes.
+**Lösung:** Vereine beide zu einem `PublicTournamentScreen`, der beide ID-Formate (UUID oder Share-Code) akzeptiert.
+
+### 🟠 Fehlendes 404-Handling
+**Status:** Mittel
+**Problem:** Kein `*` Catch-All Route für unbekannte URLs sichtbar.
+**Risiko:** User landen auf einer leeren Seite bei Tippfehlern.
+**Lösung:** Füge `<Route path="*" element={<NotFoundScreen />} />` am Ende der Route-Liste hinzu.
+
+## 2. Navigation-UX-Probleme
+
+### 🟠 "Prop Drilling" für Navigation
+**Status:** Mittel
+**Problem:** Fast jeder Screen (Legal, Dashboard, TournamentManagement) bekommt `onBack` als Prop. Das erzwingt eine starre Parent-Child-Hierarchie für die Navigation.
+**Risiko:** Wenn ein Screen später in einem Modal oder einem anderen Kontext genutzt wird, bricht die Navigation.
+**Lösung:** Nutze `useNavigate()` direkt in den Screens, wo immer möglich. `onBack` sollte nur für spezielle Fälle (z.B. Wizard-Abbruch) übrig bleiben.
+
+### 🟡 Inkonsequente Mobile-Navigation
+**Status:** Klein
+**Problem:** `TournamentManagementScreen` nutzt ein `BottomNavigation` (Tab-Bar), `DashboardScreen` nutzt `DashboardNav` (Tabs im Content).
+**Risiko:** Nutzererwartung auf Mobile wird nicht ganz konsistent erfüllt (Bottom Bar vs. Top Tabs).
+**Lösung:** Prüfe, ob `DashboardScreen` auch eine Bottom Tab Bar für Mobile erhalten sollte, um Konsistenz mit dem Management Screen zu gewährleisten.
+
+### 🟡 History-Stack bei Wizard
+**Status:** Klein
+**Problem:** Im `TournamentCreationScreen` wird `navigate(..., { replace: true })` genutzt. Das ist gut für Performance, verhindert aber, dass der Browser-Back-Button den Wizard Schritt für Schritt zurückspult.
+**Risiko:** User fühlen sich "gefangen", wenn sie versehentlich einen Schritt weitergehen.
+**Lösung:** Nutze `replace: true` nur, wenn der Schritt nicht relevant für die History ist. Alternativ: Ein "Schritt-zurück"-Button im Wizard selbst anbieten.
+
+## 3. Deep-Link-Lücken
+
+### ✅ Starke Punkte
+*   **Wizard Steps:** `/create?step=3` funktioniert durch `getStepFromSearchParams`.
+*   **Tournament Tabs:** `/tournament/:id/schedule` wird durch `getTabFromPath` gelöst.
+*   **Live Filters:** `?g=1&p=groupStage` in `LiveViewScreen` sind exzellent für teilbare Ansichten.
+
+### 🔴 Fehlende Deep Links
+*   **Settings:** Es gibt keine URL für Einstellungen (z.B. `/settings/theme`). Das erfordert `onBack` und verhindert, dass man Einstellungen direkt teilen kann.
+*   **Legal Pages:** Datenschutz/Impressum sind statisch. `/privacy` URL sollte direkt funktionieren (nicht nur via Link im Footer).
+
+## 4. Positive Patterns
+
+### 🟢 Exzellentes URL-Syncing
+Fast alle komplexen UI-States (Tabs, Wizard Steps, Filter) werden mit der URL synchronisiert.
+*   **Code:** `updateUrlParams` in `LiveViewScreen`.
+*   **Vorteil:** Bookmarks funktionieren, Browser-Back-Button ist vorhersagbar, Sharing ist möglich.
+
+### 🟢 Dirty-State-Warnung
+*   **Code:** `TournamentManagementScreen` -> `handleTabChange` mit `isSettingsDirty`.
+*   **Vorteil:** Verhindert Datenverlust, wenn User Settings ändern und dann den Tab wechseln. Sehr UX-freundlich.
+
+### 🟢 Lazy Loading für Performance
+*   **Code:** `TournamentCreationScreen` (Wizard Steps), `SettingsScreen`.
+*   **Vorteil:** Initial Bundle Size bleibt klein, nur benötigte Komponenten werden geladen.
+
+### 🟢 Accessibility (A11y)
+*   **Code:** `LegalPageLayout` nutzt `aria-label` für Back-Button, `role="radiogroup"` in `BaseThemeSelector`.
+*   **Vorteil:** Screenreader-kompatibel, Tastaturnavigation unterstützt.
+
+## 5. Navigation Score
+
+| Kategorie | Score | Kommentar |
+| :--- | :--- | :--- |
+| **Routing-Struktur** | 8/10 | Gute URL-Syncing, aber fehlende Guards und Redundanz. |
+| **Navigation UX** | 9/10 | Dirty-States und URL-Sync sind hervorragend. |
+| **Deep Linking** | 9/10 | Fast alle wichtigen Views sind tief verlinkbar. |
+| **Mobile Experience** | 8/10 | Bottom Nav ist gut, aber Inkonsistenzen zwischen Screens. |
+| **Zustand & History** | 7/10 | `replace: true` im Wizard kann verwirrend sein. |
+| **Gesamt** | **8.2/10** | **Starkes Fundament, braucht zentrale Auth-Logik.** |
+
+## 🛠 Empfohlene Sofortmaßnahmen
+
+1.  **Auth Guards:** Erstelle `ProtectedRoute` und umschließe alle geschützten Routen (`/tournament/:id/*`, `/create`).
+2.  **Public View Vereinen:** Refaktorisiere `LiveViewScreen` und `PublicTournamentViewScreen` zu einer einzigen Komponente.
+3.  **404 Screen:** Implementiere einen Fehler-Screen für unbekannte Routen.
+4.  **Navigation Hooks:** Ersetze `onBack` Props durch `useNavigate()` in den Screens, wo es sinnvoll ist.
+5.  **Settings URL:** Erweitere das Routing, um `/settings` direkt aufrufbar zu machen.
+
+---
+
+## Security & Datenschutz
+
+> **FEHLER:** 504 Server Error: Gateway Timeout for url: https://adesso-ai-hub.3asabc.de/v1/chat/completions
+
+---
+
+## Sport-Konfiguration & Datenmodell
+
+> **FEHLER:** 504 Server Error: Gateway Timeout for url: https://adesso-ai-hub.3asabc.de/v1/chat/completions
+
+---
+
+## Supabase, Datenbank & Sync
+
+
+
+Hier ist das strukturierte Review der Supabase/PostgreSQL-Architektur für das **hallenfussball-pwa** Projekt.
+
+### 1. Kritische DB/Auth-Probleme
+
+**🔴 RLS Recursion & Performance in `tournament_collaborators`**
+*   **Problem:** In `20260128_002_consolidate_rls_v3.sql` wird `user_owns_tournament()` als `SECURITY DEFINER` Funktion genutzt, um RLS-Recursion zu vermeiden (da `tournaments_select_v3` auf `collaborators` zugreift und umgekehrt).
+*   **Risiko:** Wenn die Funktion `user_owns_tournament` selbst RLS auf `tournaments` auslösen würde (was sie durch `SECURITY DEFINER` umgeht), käme es zu einem Stack-Overflow.
+*   **Empfehlung:** Stelle sicher, dass `user_owns_tournament` **keine** RLS-Checks auf `tournaments` ausführt (z.B. durch explizites `SET search_path` oder Nutzung von `pg_temp`), oder füge einen expliziten Test hinzu, der eine rekursive Abfrage simuliert.
+*   **Anonym-User:** Die Funktion `is_anonymous_user()` prüft `auth.jwt()`. Wenn ein Anonymer User eingeladen wird (z.B. via Link), ist `auth.uid()` null. Die RLS-Policy `collaborators_select_v3` prüft `user_id = (SELECT auth.uid())`. Das funktioniert für Anonyme, die sich *einloggen*, aber nicht für *unauthentifizierte* Einladungen. Das ist wahrscheinlich gewollt (Einladungen nur für Auth-User), sollte aber dokumentiert sein.
+
+**🟡 Migration Order Dependency (Critical)**
+*   **Problem:** Die Migrationen `002_denormalize_owner`, `003_backfill_owner` und `004_optimized_rls` sind strikt sequenziell abhängig.
+*   **Risiko:** Wenn `004` auf einer Datenbank läuft, die `003` nicht ausgeführt hat, haben die `owner_id` Spalten in Kind-Tabellen NULL-Werte. Die RLS-Policy `owner_id = auth.uid()` würde dann **niemanden** erlauben (da `NULL != UUID`).
+*   **Empfehlung:** Füge in Migration `004` einen `ASSERT` oder eine Prüfung hinzu, die abbricht, wenn `owner_id` noch NULL ist, bevor die Policies erstellt werden.
+    ```sql
+    -- Beispiel für Safety-Check in Migration 004
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM matches WHERE owner_id IS NULL) THEN
+        RAISE EXCEPTION 'Migration 003 (Backfill) not completed. owner_id is NULL in matches table.';
+      END IF;
+    END $$;
+    ```
+
+**🟡 `is_public` Denormalisierung**
+*   **Problem:** Die `is_public` Spalte wird auf Kind-Tabellen (`teams`, `matches`) denormalisiert und via Trigger (`cascade_tournament_visibility`) synchronisiert.
+*   **Risiko:** Wenn ein `tournament` gelöscht wird (`ON DELETE CASCADE`), werden die Kinder gelöscht. Der Trigger feuert nicht. Das ist in Ordnung. Aber wenn ein `tournament` **deaktiviert** wird (Soft Delete), müssen die Trigger auch `is_public = false` setzen.
+*   **Empfehlung:** Erweitere `cascade_tournament_visibility` um den Fall `OLD.status != NEW.status` (falls Soft Delete über Status läuft), oder stelle sicher, dass `is_public` explizit beim Soft Delete gesetzt wird.
+
+### 2. Sync-Probleme (Konflikte, Datenverlust)
+
+**🟢 Offline-First Strategie (Stark)**
+*   **Positiv:** `OfflineRepository` und `HybridRepository` trennen klar zwischen "Local First" (Sofortige UI) und "Cloud Sync" (Hintergrund).
+*   **Positiv:** `MutationQueue` persistiert Änderungen lokal, auch wenn das Gerät offline ist.
+*   **Risiko:** Bei `save()` wird `localRepo.save()` zuerst ausgeführt. Wenn der Cloud-Upload später fehlschlägt (z.B. Token abgelaufen), bleibt die lokale Version "frischer" als die Cloud.
+*   **Empfehlung:** Implementiere ein "Sync Status" Flag auf dem lokalen Objekt (z.B. `syncStatus: 'pending' | 'synced' | 'error'`), damit das UI dem User anzeigen kann, ob Änderungen wirklich in der Cloud sind.
+
+**🟡 Optimistic Locking im Live-Cockpit**
+*   **Positiv:** `SupabaseLiveMatchRepository` nutzt `.eq('version', match.version)` für CAS (Compare-And-Swap).
+*   **Problem:** Wenn zwei Trainer gleichzeitig ein Tor eintragen, wird einer mit `OptimisticLockError` abgewiesen.
+*   **Risiko:** Das UI muss diesen Fehler fangen und einen **Retry-Mechanismus** haben (aktuelle Version laden, Merge, erneut speichern). Aktuell wirft der Code die Exception (`throw new OptimisticLockError`), aber es ist unklar, ob das UI das robust handhabt (z.B. bei schnellem Tippen).
+*   **Empfehlung:** Füge im UI (z.B. in `LiveMatchView`) ein `useRetry` Hook hinzu, das bei `OptimisticLockError` automatisch den Refresh- und Retry-Flow triggert.
+
+**🟡 Stale Match Recovery**
+*   **Positiv:** `LocalStorageLiveMatchRepository.recoverStaleMatch()` erkennt Matches, die nach 30 Min. noch "RUNNING" sind (Browser-Crash), und setzt sie auf "PAUSED".
+*   **Risiko:** Wenn der Browser-Crash passiert, während der Timer läuft, wird die Zeit "verloren" (auf `maxElapsed` geklemmt). Das ist akzeptabel, aber nicht perfekt.
+*   **Empfehlung:** Speichere `timerStartTime` und `timerPausedAt` auch in der DB (`live_state` JSONB), damit der Server den Stale-Check auch für Remote-User machen kann (nicht nur lokal).
+
+### 3. Optimierungspotenzial
+
+**🔵 RLS Performance (Indexierung)**
+*   **Status:** `20260121_002_denormalize_owner.sql` hat Indizes für `owner_id` und `is_public` erstellt. Das ist exzellent.
+*   **Verbesserung:** Die `EXISTS` Subqueries in `teams_select_v3` (für `tournament_collaborators`) können teuer werden, wenn ein User an **vielen** Turnieren mitwirkt (z.B. 100+).
+*   **Empfehlung:** Erstelle einen Index auf `tournament_collaborators(user_id, accepted_at IS NOT NULL)`.
+    ```sql
+    CREATE INDEX IF NOT EXISTS idx_collaborators_user_active 
+    ON tournament_collaborators(user_id) 
+    WHERE accepted_at IS NOT NULL;
+    ```
+
+**🔵 Realtime Subscriptions**
+*   **Status:** `SupabaseLiveMatchRepository` nutzt Realtime für `matches` und `match_events`.
+*   **Verbesserung:** Wenn viele Matches gleichzeitig laufen, können viele Channels offen sein.
+*   **Empfehlung:** Nutze **Broadcast** Channels für den Timer (nur Status-Updates) und **Presence** Channels für "Wer ist gerade im Cockpit?", statt alles über DB-Realtime zu lösen. Das reduziert die DB-Last.
+
+**🔵 Edge Function Performance**
+*   **Status:** `merge-accounts` Edge Function ist gut.
+*   **Verbesserung:** Die Funktion `merge_user_data` nutzt `ARRAY_AGG` für `v_tournament_ids`. Bei sehr großen Turnieren (1000+ Teams) kann das Speicher-Overhead haben.
+*   **Empfehlung:** Wenn das Limit von 3 Turnieren für Anonyme gilt, ist das kein Problem. Für Admins (die alles mergen können) sollte man prüfen, ob `ARRAY_AGG` bei >10k Zeilen skaliert. Besser: Iteratives Update in Schleifen (Batch Processing).
+
+### 4. Positive Patterns
+
+1.  **Denormalisierung für RLS:** Das Pattern, `owner_id` und `is_public` auf Kind-Tabellen zu kopieren (`002_denormalize_owner`), ist **Goldstandard** für Supabase. Es eliminiert teure JOINs in RLS Policies und macht die Sicherheit skalierbar.
+2.  **Versionierung (Optimistic Locking):** Die `version` Spalte auf `matches` und `teams` mit automatischem Trigger-Update ist die beste Praxis für Concurrent Editing.
+3.  **Edge Functions für Auth-Logik:** `merge-accounts` und `validate-registration-code` kapseln sensible Logik sicher vom Client fern (keine Secrets im Bundle).
+4.  **Local Storage Cleanup:** `LocalStorageLiveMatchRepository.cleanupOldMatches()` verhindert, dass der Browser-Speicher voll läuft. Sehr wichtig für PWAs.
+5.  **Web Locks API:** Nutzung von `navigator.locks` in `LocalStorageLiveMatchRepository` verhindert Race Conditions bei Multi-Tab-Nutzung (z.B. zwei Tabs mit demselben Turnier).
+6.  **Migration Safety:** `IF NOT EXISTS` und `DROP IF EXISTS` in allen Migrations machen sie idempotent und sicher für wiederholte Ausführung.
+
+### 5. Supabase Score
+
+**Score: 8.5 / 10**
+
+**Begründung:**
+*   **Architektur (9/10):** Die Trennung von Offline/Online, die Denormalisierung für RLS und die Versionierung sind hervorragend durchdacht.
+*   **Sicherheit (8/10):** RLS ist komplex aber robust. Die `SECURITY DEFINER` Funktionen sind gut geschützt. Ein kleiner Punkt für die `tournament_collaborators` Recursion.
+*   **Performance (8/10):** Indexe sind da, aber `EXISTS` Subqueries in RLS können bei großen Datenmengen (viele Kollaboratoren) langsam werden.
+*   **UX (9/10):** Offline-First, Stale-Recovery und Web Locks sorgen für eine sehr flüssige Nutzererfahrung.
+
+**Nächste Schritte (Priorität):**
+1.  **RLS Testing:** Füge Unit-Tests hinzu, die prüfen, ob ein User A *nicht* auf die Daten von User B zugreifen kann, selbst wenn er die IDs kennt.
+2.  **Migration Safety:** Füge den `ASSERT` Check in Migration `004` ein, um NULL `owner_id` zu verhindern.
+3.  **UI Retry:** Stelle sicher, dass `OptimisticLockError` im UI sauber behandelt wird (Auto-Retry).
+4.  **Indexierung:** Erstelle den Index `idx_collaborators_user_active` für Performance bei vielen Kollaboratoren.
+
+Das ist ein sehr professionell aufgebautes System für eine PWA mit Multi-User-Kollaboration. Die Architektur ist skalierbar und sicher.
+
+---
+
+## Testing & Qualitaetssicherung
+
+
+
+# 📊 Testing-Strategie Analyse: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt **starke Unit-Test-Abdeckung** für Kern-Logik (Schedule-Generierung, Tabellenberechnung, Playoffs), aber **kritische Lücken** in E2E-, Integration- und PWA-spezifischen Tests. Die Test-Infrastruktur ist solide aufgebaut (Vitest, Factories, Mocking), aber nicht vollständig für Produktions-Ready-Qualität.
+
+---
+
+## 1. Testlücken (Ungetestete Kritische Pfade)
+
+| Bereich | Lücke | Risiko |
+|---------|-------|--------|
+| **E2E-Tests** | ❌ Keine Playwright/Cypress Tests | Benutzer-Flows nicht validiert |
+| **Supabase Integration** | ❌ Auth, DB, Realtime nur gemockt | Live-System kann anders funktionieren |
+| **PWA-Features** | ❌ Service Worker, Offline-Mode, Install-Flow | Kern-PWA-Features ungetestet |
+| **PDF-Export** | ❌ jsPDF-Integration nicht getestet | Export-Funktion kritisch für Turnier-Verwaltung |
+| **Realtime-Konflikte** | ❌ Gleichzeitige Updates, Race Conditions | Datenkorruption möglich |
+| **Auth-Flow** | ❌ Login, Session, Permission-Checks | Sicherheitsrisiko |
+| **Error-Handling** | ⚠️ Nur teilweise getestet | Fehlerzustände nicht robust |
+| **Mobile Responsiveness** | ❌ Keine Viewport-Tests | PWA auf Mobile nicht validiert |
+
+---
+
+## 2. Test-Qualitätsprobleme
+
+### 2.1 Fragile Tests
+
+```ts
+// ❌ Problem: Time-based assertions können flaky sein
+expect(match8?.scheduledTime).toContain('09:54:00');
+
+// ✅ Besser: Relative Zeitberechnung prüfen
+const expectedTime = new Date('2026-01-10T09:54:00.000Z');
+expect(new Date(match8.scheduledTime).getTime())
+  .toBeCloseTo(expectedTime.getTime(), -3);
+```
+
+### 2.2 Zu starke Mocking
+
+```ts
+// ❌ i18next Mock zu simpel - Interpolationen nicht vollständig
+vi.mock('i18next', () => ({
+  t: (key: string, opts?: Record<string, unknown>) => String(key)
+}))
+
+// ✅ Besser: Echte i18next-Instanz mit Test-Namespaces
+import i18next from 'i18next';
+await i18next.init({ lng: 'de', resources: { de: { translation: {} } } });
+```
+
+### 2.3 Schwache Assertions
+
+```ts
+// ❌ Zu allgemein
+expect(standings.length).toBe(3);
+
+// ✅ Besser: Spezifischer
+expect(standings[0].team.name).toBe('Team 1');
+expect(standings[0].points).toBe(6);
+expect(standings[0].goalDifference).toBe(2);
+```
+
+### 2.4 Fehlende Cleanup-Strategien
+
+```ts
+// ⚠️ localStorage Mock wird nicht zwischen Tests zurückgesetzt
+// Kann zu State-Lecks führen
+afterEach(() => {
+  cleanup();
+  // localStorageMock.clear(); // FEHLT!
+});
+```
+
+### 2.5 Performance-Tests mit zu großzügigen Timeouts
+
+```ts
+// ❌ 60s Timeout für 64 Teams ist zu großzügig (O(n²) Algorithmus)
+// ✅ Besser: Performance-Baseline mit Alert bei Regression
+expect(duration).toBeLessThan(5000); // 5s realistischer
+```
+
+---
+
+## 3. Fehlende Test-Typen
+
+| Test-Typ | Status | Priorität |
+|----------|--------|-----------|
+| **E2E Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Integration Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Accessibility Tests** | ❌ Fehlend | 🟡 Mittel |
+| **Performance Tests** | ⚠️ Teilweise | 🟡 Mittel |
+| **Security Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Visual Regression** | ❌ Fehlend | 🟢 Niedrig |
+| **Load Tests** | ❌ Fehlend | 🟢 Niedrig |
+| **Contract Tests** | ❌ Fehlend | 🟡 Mittel |
+
+---
+
+## 4. Priorisierte Empfehlungen
+
+### 🔴 **P1 - Kritisch (sofort umsetzen)**
+
+1. **E2E-Tests für Kern-Flows**
+   ```ts
+   // Playwright Setup für:
+   - Turnier-Erstellung (Wizard)
+   - Spielplan-Generierung
+   - Live-Cockpit (Timer, Tore)
+   - PDF-Export
+   ```
+
+2. **Supabase Integration Tests**
+   ```ts
+   // Test-Container oder Supabase Dev-DB
+   - Auth Flow (Login, Session)
+   - Realtime Updates
+   - DB Constraints
+   ```
+
+3. **PWA-Spezifische Tests**
+   ```ts
+   // Service Worker Testing
+   - Offline-Mode
+   - Install-Flow
+   - Background Sync
+   ```
+
+4. **Error-Handling Coverage**
+   ```ts
+   // Teste alle Error-Zustände
+   - Network Failures
+   - Validation Errors
+   - Permission Denied
+   - Timeout Handling
+   ```
+
+### 🟡 **P2 - Hoch (nächste Sprint-Iteration)**
+
+5. **Accessibility Tests**
+   ```ts
+   // axe-core Integration
+   - WCAG 2.1 AA Compliance
+   - Screen Reader Tests
+   - Keyboard Navigation
+   ```
+
+6. **Performance Budgets**
+   ```ts
+   // CI-Integration
+   - Lighthouse Scores
+   - Bundle Size Limits
+   - Time-to-Interactive
+   ```
+
+7. **Contract Tests für API**
+   ```ts
+   // Supabase API Contract
+   - Response Schemas
+   - Error Formats
+   - Realtime Events
+   ```
+
+### 🟢 **P3 - Mittel (langfristig)**
+
+8. **Visual Regression Tests**
+   ```ts
+   // Percy/Chromatic
+   - UI Component Changes
+   - Responsive Layouts
+   - Theme Switching
+   ```
+
+9. **Load Tests für Realtime**
+   ```ts
+   // Concurrent Users
+   - 10+ gleichzeitige Live-Updates
+   - Broadcast Performance
+   ```
+
+10. **Mutation Testing**
+    ```ts
+    // Stryker/Mutant
+    - Test-Qualität validieren
+    - Ungetestete Code-Pfade finden
+    ```
+
+---
+
+## 5. Testing Score
+
+| Kategorie | Score | Kommentar |
+|-----------|-------|-----------|
+| **Unit Test Coverage** | 8/10 | Sehr gut für Kern-Logik |
+| **Test-Infrastructure** | 7/10 | Solide, aber Verbesserungspotential |
+| **E2E Coverage** | 1/10 | Fehlend |
+| **Integration Testing** | 2/10 | Nur Mocks |
+| **Accessibility** | 0/10 | Fehlend |
+| **Performance Testing** | 3/10 | Nur Baseline-Tests |
+| **Error Handling** | 4/10 | Teilweise abgedeckt |
+| **CI/CD Integration** | 5/10 | Unklar aus Code |
+| **Test-Maintainability** | 6/10 | Gute Factories, aber Fragility |
+| **Overall Score** | **4.6/10** | **Bedingt production-ready** |
+
+---
+
+## 6. Konkrete nächste Schritte
+
+```yaml
+# Sprint 1-2 (P1)
+- [ ] Playwright Setup + 5 Kern-E2E-Tests
+- [ ] Supabase Integration Test Suite
+- [ ] PWA Service Worker Tests
+- [ ] Error Boundary Coverage
+
+# Sprint 3-4 (P2)
+- [ ] Accessibility Audit (axe-core)
+- [ ] Performance Budgets in CI
+- [ ] Contract Tests für API
+- [ ] Test Coverage Report (80%+ Target)
+
+# Sprint 5-6 (P3)
+- [ ] Visual Regression Setup
+- [ ] Load Testing für Realtime
+- [ ] Mutation Testing Pilot
+- [ ] Flaky Test Detection
+```
+
+---
+
+## 7. Risikobewertung
+
+| Risiko | Wahrscheinlichkeit | Impact | Mitigation |
+|--------|-------------------|--------|------------|
+| **Datenkorruption durch Race Conditions** | Mittel | Hoch | Integration Tests + Realtime Mocks |
+| **PWA-Features funktionieren nicht** | Hoch | Hoch | E2E-Tests auf echten Devices |
+| **Performance-Degradation** | Mittel | Mittel | Performance Budgets + Monitoring |
+| **Accessibility Issues** | Hoch | Mittel | axe-core + Manual Testing |
+| **Supabase Integration Fehler** | Mittel | Hoch | Contract Tests + Staging Environment |
+
+---
+
+## Fazit
+
+Die Test-Strategie ist für **Unit-Tests stark**, aber für **Production-Ready-Qualität unvollständig**. Priorisiere **E2E-Tests** und **Integration-Tests**, um kritische Pfade zu validieren. Die bestehende Test-Infrastruktur (Vitest, Factories, Mocking) bietet eine solide Basis für Erweiterung.
+
+**Empfohlener nächster Schritt:** Playwright Setup mit 3-5 Kern-E2E-Tests für Turnier-Erstellungs-Flow.
+
+---
+
+## Turnier-Admin & Playoff-Logik
+
+> **FEHLER:** 504 Server Error: Gateway Timeout for url: https://adesso-ai-hub.3asabc.de/v1/chat/completions
+
+---
+
+## Turnier-Erstellung (Wizard Flow)
+
+
+
+# 🏆 Tournament Creation Wizard - QA & UX Review
+
+## Executive Summary
+
+Der Wizard ist **technisch ausgereift** mit guter Struktur und vielen Features, hat aber **kritische UX-Lücken** und **Validierungsprobleme** die zu fehlerhaften Turnieren führen können.
+
+---
+
+## 🚨 Logik-Fehler im Wizard/Generator
+
+### 1. **Team-Count vs. numberOfTeams Inkonsistenz**
+```typescript
+// Problem: numberOfTeams ist separate Konfiguration
+const numberOfTeams = formData.numberOfTeams ?? 4;
+// Aber teams.length wird nicht validiert
+```
+**Impact:** User kann 4 Teams konfigurieren aber nur 3 eingeben → Schedule-Generation schlägt fehl
+
+**Fix:**
+```typescript
+// In Step4_Teams.tsx
+const isTeamCountValid = teams.length === numberOfTeams;
+// Disable "Weiter" button wenn false
+```
+
+### 2. **Gruppenverteilung bei ungerader Teamzahl**
+```typescript
+// Bei 5 Teams, 2 Gruppen: 3+2 oder 2+3?
+const teamsPerGroup = Math.ceil(teams / numberOfGroups);
+// Math.ceil(5/2) = 3 → Gruppe 1: 3 Teams, Gruppe 2: 2 Teams
+```
+**Impact:** Ungleichgewicht, eine Gruppe hat mehr Spiele
+
+**Fix:**
+```typescript
+// Balanced distribution
+const baseTeams = Math.floor(teams / numberOfGroups);
+const extraTeams = teams % numberOfGroups;
+// Gruppe 1: baseTeams + 1, Gruppe 2: baseTeams
+```
+
+### 3. **DFB Pattern mit BYE nicht vollständig validiert**
+```typescript
+// DFBKeySystem.tsx
+const hasBye = pattern.rounds.some(round =>
+  round.some(match => match.includes('BYE'))
+);
+```
+**Problem:** BYE wird angezeigt aber nicht im Schedule korrekt gehandled
+
+**Fix:**
+```typescript
+// In Schedule Generator
+if (match.includes('BYE')) {
+  // Skip match generation oder als "Free Pass" markieren
+  continue;
+}
+```
+
+### 4. **Schedule-Generation ohne Fehlerbehandlung**
+```typescript
+// TournamentPreview.tsx
+const newSchedule = generateFullSchedule(updatedTournament);
+// Keine try-catch, keine Error-Handling
+```
+**Impact:** Bei ungültigen Parametern crasht die App
+
+**Fix:**
+```typescript
+try {
+  const newSchedule = generateFullSchedule(updatedTournament);
+  setSchedule(newSchedule);
+} catch (error) {
+  setError(t('scheduleGenerationFailed', { error: error.message }));
+}
+```
+
+---
+
+## ⚠️ Fehlende Validierungen
+
+### Pflichtfelder & Grenzwerte
+
+| Feld | Current | Missing |
+|------|---------|---------|
+| `title` | `required` | Max 100 Zeichen, No Special Chars |
+| `date` | `required` | Must be >= today |
+| `startTime` | `required` | Format validation (HH:MM) |
+| `numberOfTeams` | `min: 2, max: 24` | Must match `teams.length` |
+| `numberOfGroups` | `min: 2, max: 8` | Must divide teams evenly or warn |
+| `teams[].name` | No validation | No duplicates, min 2 chars |
+| `location.name` | `required` | No validation |
+
+### Missing Zod-Schema im Wizard
+
+```typescript
+// Missing: src/features/tournament-creation/wizardSchema.ts
+export const wizardSchema = z.object({
+  title: z.string().min(3).max(100),
+  date: z.string().refine(date => new Date(date) >= new Date(), "Date must be in future"),
+  numberOfTeams: z.number().min(2).max(24),
+  teams: z.array(z.object({
+    name: z.string().min(2).max(50),
+  })).refine(teams => teams.length > 0, "At least one team required")
+  // ... more validations
+});
+```
+
+---
+
+## 🎨 UX-Probleme im Wizard-Flow
+
+### 1. **Keine Fortschrittsanzeige**
+```tsx
+// Missing: Progress bar or step indicator
+<div className="wizard-progress">
+  <StepIndicator step={1} active={currentStep === 1} />
+  <StepIndicator step={2} active={currentStep === 2} />
+  ...
+</div>
+```
+
+### 2. **Keine Auto-Save / Persistierung**
+```typescript
+// Problem: Browser-Crash = Datenverlust
+// Missing: localStorage or Supabase draft save
+useEffect(() => {
+  localStorage.setItem('tournamentDraft', JSON.stringify(formData));
+}, [formData]);
+```
+
+### 3. **Keine "Zurück"-Navigation mit Warnung**
+```typescript
+// Problem: User verliert Daten bei "Zurück"
+const handleBack = () => {
+  if (hasUnsavedChanges && !confirm('Ungespeicherte Änderungen gehen verloren')) {
+    return;
+  }
+  setCurrentStep(prev => prev - 1);
+};
+```
+
+### 4. **Kein Bulk-Import für Teams**
+```typescript
+// Missing: CSV/Excel import
+<Button onClick={handleImportTeams} icon={<Icons.Upload />}>
+  Teams importieren (CSV)
+</Button>
+```
+
+### 5. **Keine Vorlagen / Copy from existing**
+```typescript
+// Missing: Template selection
+<Select
+  label="Vorlage verwenden"
+  options={existingTournaments.map(t => ({ value: t.id, label: t.title }))}
+/>
+```
+
+### 6. **Mobile UX: Zu viele Eingaben auf einem Screen**
+```css
+/* Mobile: Steps sollten gestaffelt werden */
+@media (max-width: 768px) {
+  .configGrid {
+    grid-template-columns: 1fr !important;
+  }
+  .teamRow {
+    flex-direction: column !important;
+  }
+}
+```
+
+---
+
+## 🎯 Edge Cases nicht abgedeckt
+
+| Scenario | Current Behavior | Risk |
+|----------|-----------------|------|
+| Browser schließt während Wizard | Datenverlust | 🔴 High |
+| Supabase-Connection abbricht | Keine Error-Message | 🔴 High |
+| Team-Name enthält HTML | XSS möglich | 🟡 Medium |
+| Datum in Vergangenheit | Keine Warnung | 🟡 Medium |
+| 24 Teams, 1 Feld | Schedule > 24h | 🟡 Medium |
+| Duplicate Team-Namen (Case-insensitive) | Error vorhanden | 🟢 Low |
+| Empty Group bei Gruppen-Modus | Error vorhanden | 🟢 Low |
+| Schiedsrichter-Duplicate-Namen | Error vorhanden | 🟢 Low |
+| Field-Name-Duplicate | Error vorhanden | 🟢 Low |
+| Ungültige Point-System-Werte | No validation | 🟡 Medium |
+
+### Critical: LiveMatch Optimistic Locking
+```typescript
+// LiveMatch.ts
+version: number; // ✅ Good
+// But missing: Conflict resolution in LiveMatch component
+```
+**Fix:**
+```typescript
+const handleScoreUpdate = async (newScore: number) => {
+  const currentMatch = await fetchMatch(matchId);
+  if (currentMatch.version !== match.version) {
+    // Conflict detected
+    showConflictResolutionDialog();
+    return;
+  }
+  // Proceed with update
+};
+```
+
+---
+
+## 📊 Tournament Creation Score
+
+| Kategorie | Score | Comments |
+|-----------|-------|----------|
+| **Funktionalität** | 8/10 | Alle Features vorhanden |
+| **Validierung** | 5/10 | Viele fehlende Checks |
+| **UX/Usability** | 6/10 | Keine Progress-Bar, Auto-Save |
+| **Edge Cases** | 4/10 | Viele nicht abgedeckt |
+| **Performance** | 7/10 | Virtualisierung fehlt |
+| **Accessibility** | 6/10 | ARIA vorhanden, aber unvollständig |
+| **Security** | 5/10 | XSS, Input-Sanitization fehlt |
+| **Maintainability** | 8/10 | Gut strukturiert, viele Components |
+
+## **Gesamt: 6.1/10** ⭐⭐⭐
+
+---
+
+## 🛠️ Priority Fixes
+
+### 🔴 **P0 - Critical (Sofort)**
+1. **Zod-Validierung im Wizard** hinzufügen
+2. **Auto-Save** via localStorage implementieren
+3. **Schedule-Generation Error-Handling**
+4. **Team-Count Validierung** (numberOfTeams === teams.length)
+
+### 🟡 **P1 - High (2 Wochen)**
+1. **Fortschrittsanzeige** im Wizard
+2. **Bulk-Import** für Teams (CSV)
+3. **Browser-Close Warning** (beforeunload)
+4. **Input-Sanitization** für Team-Namen
+
+### 🟢 **P2 - Medium (1 Monat)**
+1. **Vorlagen-System** (Copy from existing)
+2. **Virtualisierung** bei Team-Liste
+3. **E2E-Tests** für Wizard-Flow
+4. **Accessibility Audit** (WCAG 2.1)
+
+---
+
+## 💡 UX-Verbesserungen
+
+### 1. **Smart Defaults**
+```typescript
+// Auto-select based on team count
+if (numberOfTeams <= 8) {
+  setGroupSystem('roundRobin');
+} else if (numberOfTeams <= 16) {
+  setGroupSystem('groupsAndFinals');
+  setNumberOfGroups(2);
+}
+```
+
+### 2. **Real-time Schedule Preview**
+```tsx
+// In Step2: Live preview of estimated duration
+<LiveScheduleEstimate
+  teams={teams}
+  fields={numberOfFields}
+  gameDuration={groupPhaseGameDuration}
+/>
+```
+
+### 3. **Undo/Redo**
+```typescript
+// Use undoable state management
+const [history, setHistory] = useUndoable(formData);
+```
+
+### 4. **Tour-Guide für Erstnutzer**
+```tsx
+// First-time user onboarding
+if (isFirstTime) {
+  <TourGuide steps={wizardSteps} />;
+}
+```
+
+---
+
+## ✅ What's Done Well
+
+1. ✅ **TypeScript-Strict** mit `Partial<Tournament>`
+2. ✅ **i18n** für alle Labels
+3. ✅ **Responsive Design** mit CSS Modules
+4. ✅ **Duplicate Detection** für Teams, Gruppen, SR
+5. ✅ **Accessibility** mit `aria-*` Attributes
+6. ✅ **Modular Components** (NameGrid, DFBKeySystem, etc.)
+7. ✅ **LiveMatch Model** mit Optimistic Locking
+8. ✅ **Bambini-Mode** mit speziellen Settings
+
+---
+
+## 📝 Next Steps
+
+1. **Implement P0 Fixes** (Validierung, Auto-Save, Error-Handling)
+2. **Add Unit Tests** für Schedule-Generator
+3. **Add E2E Tests** für Wizard-Flow (Cypress/Playwright)
+4. **Performance Audit** mit Lighthouse
+5. **Accessibility Audit** mit axe-core
+6. **Security Review** (XSS, Input Validation)
+
+**Gesamturteil:** Solide Basis, aber Validierung und UX müssen verbessert werden für Production-Readiness.
+
+---
+

--- a/reviews/2026-05-07_2053_architecture.md
+++ b/reviews/2026-05-07_2053_architecture.md
@@ -1,0 +1,405 @@
+# Code Review: Architektur & Schichtenmodell
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 174.4s  
+**Status:** success  
+**Code-Kontext:** 151,308 Zeichen  
+
+<details><summary>Thinking Process (4,088 Zeichen)</summary>
+
+The user wants me to analyze the architecture of a React/TypeScript PWA for hallenfussball (indoor soccer) tournament management. They've provided a large amount of code including:
+
+1. RepositoryContext.tsx - Context for managing repositories
+2. Error hierarchy (errors.ts, errors.test.ts)
+3. Generators (playoffGenerator, refereeAssigner, scheduleHelpers, fairScheduler, playoffScheduler, scheduleGenerator)
+4. Models and Schemas (LiveMatch, TournamentSchema, etc.)
+
+Let me analyze this systematically across the dimensions they requested:
+
+1. **Schichtenarchitektur (Layer Architecture)** - Core vs Features vs Components
+2. **Dependency Flow** - Does Core import from Features/Components? Circular imports?
+3. **Repository Pattern** - LocalStorage vs Supabase repositories, abstraction quality
+4. **Type System** - Zod schemas + TypeScript types, consistency, duplication
+5. **Configuration** - Sport configs, feature flags, environments
+6. **Error Handling** - Consistent pattern or ad-hoc?
+7. **Dependencies** - God objects? Too many responsibilities?
+8. **Barrel Exports** - Clean or chaotic?
+
+Let me go through each section:
+
+## Strengths I can identify:
+
+1. **Clear Core/Feature Separation**: The `src/core` directory contains business logic without React dependencies. This is good for testability and portability.
+
+2. **Repository Pattern**: There's a clear abstraction with `ITournamentRepository` and `ILiveMatchRepository` interfaces, with implementations for LocalStorage and Supabase.
+
+3. **Error Hierarchy**: Well-structured error classes (`AppError`, `RepositoryError`, `AuthenticationError`, `NetworkError`, `SyncError`, `OptimisticLockError`) with feature/action tagging for Sentry integration.
+
+4. **Comprehensive Testing**: The code shows extensive test coverage with Vitest, including edge cases.
+
+5. **Zod Schemas**: Runtime validation with Zod schemas for data integrity, especially for Tournament, Match, Team, and related entities.
+   
+6. **Offline-First Design**: The `OfflineRepository` wrapper demonstrates offline capability with local-first sync strategy.
+
+7. **Playoff Generation**: Sophisticated bracket generation with presets (top-4, top-8, top-16, all-places) and dependency tracking.
+
+8. **Fair Scheduling**: Advanced algorithm for fair match distribution across teams and fields.
+
+## Problems I can identify:
+
+1. **RepositoryContext Complexity**: The context mixes too many concerns - auth checking, repo selection, cleanup, and provides multiple exports. The `supabaseLiveMatchRepoRef` useRef pattern is problematic for React.
+
+2. **Circular Import Risk**: Need to check if Core imports from Features (the RepositoryContext imports from `../../features/auth/hooks/useAuth`).
+
+3. **Date Handling**: Inconsistent Date serialization (TournamentSchema has `scheduledTime?: z.union([z.string(), z.date()])` but JSON only stores strings).
+
+4. **Type Duplication**: Some types exist in both `types/tournament.ts` and `core/models/` - need to verify consistency.
+
+5. **God Objects**: Some generator files are very large (fairScheduler.ts has 23,637 characters).
+
+6. **Mixed Concerns in Generators**: ScheduleGenerator mixes generation, scheduling, and rendering logic.
+
+7. **Missing Feature Flag System**: No clear configuration for feature flags or environment-based configs.
+
+8. **Optimistic Locking**: The `OptimisticLockError` exists but I don't see clear implementation in the repositories.
+
+9. **LiveMatch Model**: Separate from Match model - could cause synchronization issues between runtime and persisted state.
+
+10. **Barrel Exports**: Need to verify if there are too many re-exports creating confusion.
+
+11. **Test Files**: Tests are well-structured but some are quite large.
+
+12. **Missing Integration Tests**: Focus on unit tests, less on integration between layers.
+
+13. **Supabase Realtime**: The `supabaseLiveMatchRepoRef` useRef pattern means subscriptions might not clean up properly on re-renders.
+
+I should now organize this into a structured review with strengths, problems (with severity levels), and concrete improvement suggestions.
+
+
+</details>
+
+---
+
+
+
+# Architektur-Review: hallenfussball-pwa
+
+## 📊 Gesamtbewertung: **7.5/10**
+
+Starke Architektur mit klaren Trennungen, aber einige kritische Design-Entscheidungen erfordern Aufmerksamkeit.
+
+---
+
+## ✅ Stärken
+
+### 1. **Klare Core/Feature-Trennung**
+```
+src/core/          → Pure Business Logic (kein React)
+src/features/      → React-Komponenten & Hooks
+```
+Die `RepositoryContext.tsx` importiert zwar `useAuth` aus Features, aber Core bleibt grundsätzlich unabhängig. Das ermöglicht einfache Tests und Portierung.
+
+### 2. **Exzellentes Error-Hierarchy-Design**
+- Feature/Action-Tagging für Sentry-Integration
+- Spezialisierte Fehlerklassen (`OptimisticLockError`, `NetworkError`)
+- Konsistente `isAbortError()`-Utility
+- **Datei:** `src/core/errors.ts`
+
+### 3. **Robustes Repository-Pattern**
+```typescript
+// Abstraktion erlaubt einfachen Wechsel
+const repo = canUseSupabase 
+  ? new OfflineRepository(localRepo, supabaseRepo)
+  : localRepo;
+```
+- `OfflineRepository` für Offline-First
+- Interface-basiert (`ITournamentRepository`)
+- **Datei:** `src/core/contexts/RepositoryContext.tsx`
+
+### 4. **Zod-Schema-Validierung**
+- Runtime-Validierung für Datenintegrität
+- Type-Safety durch `z.infer<>`
+- `.passthrough()` für Forward-Compatibility
+- **Datei:** `src/core/models/schemas/TournamentSchema.ts`
+
+### 5. **Umfassende Test-Abdeckung**
+- Edge Cases abgedeckt (z.B. `< 2 groups` in Playoff-Generator)
+- Konsistenz-Checks (`assertDependsOnConsistency`)
+- **Datei:** `src/core/generators/__tests__/playoffGenerator.test.ts`
+
+### 6. **Fair Scheduling Algorithmus**
+- Multi-Field-Support
+- Rest-Perioden-Balance
+- Home/Away-Balance
+- **Datei:** `src/core/generators/fairScheduler.ts`
+
+---
+
+## ⚠️ Architektur-Probleme
+
+### 🔴 **Critical**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **useRef für Subscriptions** | `RepositoryContext.tsx` | `supabaseLiveMatchRepoRef` useRef verhindert korrekte Cleanup bei Re-Renders. React-Context sollte nicht für Subscriptions-Lebenszyklus genutzt werden. |
+| **Date-Serialisierung** | `TournamentSchema.ts` | `scheduledTime?: z.union([z.string(), z.date()])` - JSON kann nur Strings speichern. Transform-Logik fehlt. |
+| **Circular Import Risk** | `RepositoryContext.tsx` | Core importiert `useAuth` aus Features. Bei komplexeren Abhängigkeiten entstehen Zirkel. |
+
+### 🟠 **High**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **God Object: fairScheduler** | `fairScheduler.ts` | 23.637 Zeichen, zu viele Verantwortlichkeiten (Pairing, Scheduling, Fairness-Berechnung, Validierung). |
+| **Mixed Concerns: scheduleGenerator** | `scheduleGenerator.ts` | Generiert, scheduliert UND rendert (CSV, Print). Trennung fehlt. |
+| **LiveMatch vs Match Duplikation** | `LiveMatch.ts` vs `MatchSchema` | Zwei Modelle für denselben Use-Case. Sync-Risiko zwischen Runtime und Persistenz. |
+| **Missing Feature Flags** | - | Keine zentrale Konfiguration für Feature-Flags oder Environment-Configs. |
+
+### 🟡 **Medium**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Optimistic Locking Incomplete** | - | `OptimisticLockError` existiert, aber Repository-Implementierung fehlt. |
+| **Barrel Export Chaos** | `core/index.ts` | Zu viele `export *` ohne Dokumentation. |
+| **No Integration Tests** | - | Fokus auf Unit-Tests, keine E2E zwischen Core/Features. |
+
+### 🟢 **Low**
+
+| Problem | Datei | Beschreibung |
+|---------|-------|--------------|
+| **Test File Size** | `playoffGenerator.test.ts` | 14.903 Zeichen - zu groß für Wartbarkeit. |
+| **Hardcoded Timezones** | `scheduleHelpers.ts` | `parseStartTime` nutzt lokale Timezone ohne UTC-Handling. |
+
+---
+
+## 🛠️ Konkrete Verbesserungsvorschläge
+
+### 1. **RepositoryContext Subscriptions Fix** 🔴
+
+**Problem:** `useRef` für Subscriptions funktioniert nicht bei React-StrictMode/Re-Renders.
+
+**Lösung:** Custom Hook mit `useEffect` Cleanup:
+
+```typescript
+// src/core/contexts/useSupabaseSubscriptions.ts
+import { useEffect, useCallback } from 'react';
+
+export function useSupabaseSubscriptions(
+  repo: SupabaseLiveMatchRepository | null,
+  tournamentId: string | null
+) {
+  const unsubscribe = useCallback(() => {
+    repo?.unsubscribeAll();
+  }, [repo]);
+
+  useEffect(() => {
+    return unsubscribe; // Cleanup on unmount
+  }, [unsubscribe]);
+
+  return { unsubscribe };
+}
+
+// RepositoryProvider.tsx
+const { unsubscribe } = useSupabaseSubscriptions(
+  context.supabaseLiveMatchRepo,
+  tournamentId
+);
+```
+
+### 2. **Date Schema Transform** 🔴
+
+**Problem:** JSON speichert Dates als Strings, aber TypeScript erwartet Date-Objekte.
+
+**Lösung:** Zod Transform:
+
+```typescript
+// src/core/models/schemas/TournamentSchema.ts
+const DateTransform = z.preprocess(
+  (arg) => {
+    if (arg instanceof Date) return arg;
+    if (typeof arg === 'string') return new Date(arg);
+    return arg;
+  },
+  z.date().optional()
+);
+
+export const MatchSchema = z.object({
+  // ...
+  scheduledTime: DateTransform, // Statt z.union([z.string(), z.date()])
+});
+```
+
+### 3. **Fair Scheduler Refactoring** 🟠
+
+**Problem:** Zu viele Verantwortlichkeiten in einer Datei.
+
+**Lösung:** Aufteilen nach Single Responsibility:
+
+```
+src/core/generators/
+├── fairScheduler/
+│   ├── index.ts              # Public API
+│   ├── pairing.ts            # Round-robin, DFB patterns
+│   ├── scheduling.ts         # Slot/Feld-Zuweisung
+│   ├── fairness.ts           # Fairness-Berechnung
+│   └── validation.ts         # Constraint-Checks
+```
+
+```typescript
+// src/core/generators/fairScheduler/pairing.ts
+export function generateRoundRobinPairings(teams: Team[]): TeamPairing[] {
+  // Circle Method Logic
+}
+
+// src/core/generators/fairScheduler/scheduling.ts
+export function assignSlotsToMatches(
+  pairings: TeamPairing[],
+  options: SchedulingOptions
+): Match[] {
+  // Slot/Zeit-Zuweisung
+}
+```
+
+### 4. **Feature Flag System** 🟠
+
+**Problem:** Keine zentrale Feature-Flag-Konfiguration.
+
+**Lösung:** Einfaches Feature Flag System:
+
+```typescript
+// src/core/config/featureFlags.ts
+export const FeatureFlags = {
+  ENABLE_PLAYOFF_PRESETS: true,
+  ENABLE_OFFLINE_SYNC: true,
+  ENABLE_MULTI_USER: import.meta.env.VITE_ENABLE_MULTI_USER === 'true',
+} as const;
+
+// src/core/config/index.ts
+export const Config = {
+  featureFlags: FeatureFlags,
+  environment: import.meta.env.MODE,
+  supabaseUrl: import.meta.env.VITE_SUPABASE_URL,
+  // ...
+};
+```
+
+### 5. **LiveMatch/Match Synchronization** 🟠
+
+**Problem:** Zwei Modelle führen zu Inkonsistenzen.
+
+**Lösung:** LiveMatch als View-Only von Match:
+
+```typescript
+// src/core/models/LiveMatch.ts
+export function createLiveMatchFromMatch(
+  match: Match,
+  teamMap: Map<string, Team>
+): LiveMatch {
+  return {
+    id: match.id,
+    homeTeam: teamMap.get(match.teamA),
+    awayTeam: teamMap.get(match.teamB),
+    // ...
+  };
+}
+
+// Repository sollte LiveMatch nicht speichern, nur Match
+```
+
+### 6. **Optimistic Locking Implementierung** 🟡
+
+**Problem:** Error existiert, aber Repository-Implementierung fehlt.
+
+**Lösung:** Version-Check in Repository:
+
+```typescript
+// src/core/repositories/SupabaseRepository.ts
+async function updateTournament(tournament: Tournament) {
+  const { data, error } = await supabase
+    .from('tournaments')
+    .update(tournament)
+    .eq('id', tournament.id)
+    .eq('version', tournament.version); // Optimistic Lock
+
+  if (error?.code === 'PGRST301') { // Conflict
+    throw new OptimisticLockError(
+      tournament.id,
+      tournament.version,
+      (error as any).details?.current_version
+    );
+  }
+}
+```
+
+### 7. **Import-Struktur verbessern** 🟡
+
+**Problem:** `export *` erschwert Nachverfolgung.
+
+**Lösung:** Explizite Exports mit JSDoc:
+
+```typescript
+// src/core/index.ts
+/**
+ * Core Module - Pure Business Logic
+ * @module core
+ */
+
+// Models
+export { TournamentSchema } from './models/schemas/TournamentSchema';
+export { MatchSchema } from './models/schemas/TournamentSchema';
+export { TeamSchema } from './models/schemas/TournamentSchema';
+
+// Repositories
+export { LocalStorageRepository } from './repositories/LocalStorageRepository';
+export { SupabaseRepository } from './repositories/SupabaseRepository';
+export { OfflineRepository } from './repositories/OfflineRepository';
+
+// Generators
+export { generatePlayoffMatches } from './generators/playoffGenerator';
+export { assignReferees } from './generators/refereeAssigner';
+```
+
+---
+
+## 📋 Architektur-Checkliste
+
+| Bereich | Status | Empfehlung |
+|---------|--------|------------|
+| **Dependency Flow** | ✅ Gut | Core → Features vermeiden |
+| **Repository Pattern** | ✅ Gut | Interface-basiert, offline-ready |
+| **Error Handling** | ✅ Exzellent | Feature/Action-Tagging |
+| **Type Safety** | ⚠️ Mittel | Date-Transform fehlt |
+| **Test Coverage** | ✅ Gut | Unit-Tests umfassend |
+| **Code Organization** | ⚠️ Mittel | Fair Scheduler zu groß |
+| **Configuration** | ❌ Fehlend | Feature Flags hinzufügen |
+| **Integration Tests** | ❌ Fehlend | E2E zwischen Schichten |
+
+---
+
+## 🎯 Priorisierte Action Items
+
+### **Sprint 1 (Critical)**
+- [ ] RepositoryContext Subscriptions mit `useEffect` fixen
+- [ ] Date-Transform in Zod-Schemas implementieren
+- [ ] Circular Import Risk analysieren (Core → Features)
+
+### **Sprint 2 (High)**
+- [ ] Fair Scheduler in Module aufteilen
+- [ ] Feature Flag System einführen
+- [ ] LiveMatch/Match Synchronization klären
+
+### **Sprint 3 (Medium)**
+- [ ] Optimistic Locking in Repositories implementieren
+- [ ] Integration Tests für Repository Layer
+- [ ] Barrel Export Dokumentation
+
+---
+
+## 🏁 Fazit
+
+Die Architektur ist **grundsätzlich solide** mit klaren Trennungen und guten Abstraktionen. Die größten Risiken liegen in:
+
+1. **React Lifecycle** (useRef für Subscriptions)
+2. **Date Handling** (JSON vs TypeScript)
+3. **Code Size** (Fair Scheduler als God Object)
+
+Mit den oben genannten Verbesserungen kann die Architektur auf **9/10** skaliert werden. Die Basis für Skalierung (Multi-User, Offline-First, Realtime) ist bereits vorhanden.

--- a/reviews/2026-05-07_2053_code_quality.md
+++ b/reviews/2026-05-07_2053_code_quality.md
@@ -1,0 +1,364 @@
+# Code Review: Code-Qualitaet & TypeScript-Patterns
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 0.7s  
+**Status:** success  
+**Code-Kontext:** 146,980 Zeichen  
+
+<details><summary>Thinking Process (1,609 Zeichen)</summary>
+
+Der Code ist umfangreich und detailliert. Ich muss eine strukturierte Qualitätsanalyse erstellen, die Code Smells, TypeScript-Verstöße, Naming-Inkonsistenzen, positive Patterns, Refactoring-Empfehlungen und einen Code Quality Score enthält.
+
+Lass mich systematisch durchgehen:
+
+1. **TypeScript Strict Mode**
+   - Ich sehe `any`-Verwendung in Tests (ImportedMatch, ImportedTeam, etc.)
+   - `as`-Casts sind vorhanden
+   - Non-Null Assertions (`!`) werden verwendet
+   - `eslint-disable` Kommentare sind häufig
+
+2. **Type Definitions**
+   - Types sind gut strukturiert in `types/` Verzeichnis
+   - Union Types werden verwendet
+   - Branded Types fehlen teilweise
+
+3. **Utility Functions**
+   - DRY-Prinzip wird weitgehend eingehalten
+   - Abstraktionen sind angemessen
+   - Over-Engineering ist minimal
+
+4. **Constants**
+   - Magic Numbers sind vorhanden (z.B. 5MB, 128px)
+   - Konstanten sind definiert
+
+5. **Error Handling**
+   - try/catch ist konsistent
+   - Custom Error Types fehlen teilweise
+   - Error Boundaries nicht im Code sichtbar
+
+6. **Naming Conventions**
+   - Gemischt Deutsch/Englisch
+   - Generell konsistent
+   - Manche Inkonsistenzen (z.B. `getGroupLabel` vs `generateGroupLabels`)
+
+7. **Code Smells**
+   - Lange Funktionen (>50 LOC)
+   - Deep Nesting
+   - Switch-Ketten
+
+8. **DRY-Verstöße**
+   - Copy-Paste-Code in Tests
+   - Fehlende Abstraktionen
+
+9. **ESLint-Config**
+   - Viele eslint-disable Kommentare
+   - Regeln scheinen vorhanden
+
+10. **Dead Code**
+    - Kommentare erwähnen entfernte Funktionen
+    - Unbenutzte Exports möglich
+
+Ich werde jetzt eine detaillierte Analyse erstellen.
+
+
+</details>
+
+---
+
+
+
+# 📊 Code Quality Report: hallenfussball-pwa
+
+## Executive Summary
+
+| Metrik | Wert | Bewertung |
+|--------|------|-----------|
+| **Code Quality Score** | **7.2/10** | ⚠️ Gut mit Verbesserungspotenzial |
+| **Type Safety** | 6.5/10 | ⚠️ Häufige `any`-Casts in Tests |
+| **Test Coverage** | 8.5/10 | ✅ Umfangreiche Tests vorhanden |
+| **Maintainability** | 7.0/10 | ⚠️ ESLint-Disables häufig |
+| **Architecture** | 8.0/10 | ✅ Klare Trennung, gute Abstraktionen |
+
+---
+
+## 🔴 Code Smells (Schweregrad & Referenz)
+
+### Critical (P0)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/calculations.ts` | ~200 | `compareDirectMatches` hat 80+ LOC, tiefe Verschachtelung | Wartbarkeit |
+| `src/utils/scheduleGenerator_finals_bug.test.ts` | ~100 | `console.log` in Tests (Debug-Output) | Test-Clutter |
+| `src/utils/storageCleanup.ts` | ~80 | `cleanupOldLiveMatches` hat 70+ LOC mit komplexer Logik | Wartbarkeit |
+
+### High (P1)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/FairnessCalculator.ts` | 30-40 | `!` Non-Null Assertion (unsafe) | Runtime-Errors möglich |
+| `src/utils/__tests__/ScenarioHMK.test.ts` | 15 | `as ImportedTournament` Cast | Type-Safety verloren |
+| `src/utils/displayNames.ts` | 50 | `eslint-disable` für `prefer-nullish-coalescing` | Code-Style Inkonsistenz |
+| `src/utils/filterMatches.ts` | 40 | `||` statt `??` für Boolean-Checks | Logik-Risiko |
+
+### Medium (P2)
+
+| Datei | Zeile | Problem | Impact |
+|-------|-------|---------|--------|
+| `src/utils/idGenerator.ts` | 20 | Fallback-UUID ist "weak" | Kollisions-Risiko |
+| `src/utils/knockoutMatchGenerator.ts` | 60 | Dead-Code-Kommentar (nicht entfernt) | Verwirrung |
+| `src/utils/` | alle | Gemischte Deutsch/Englisch Namen | Konsistenz |
+
+---
+
+## ⚠️ TypeScript-Verstöße
+
+### `any`-Verwendung (15+ Vorkommen)
+
+```typescript
+// ❌ src/utils/__tests__/ScenarioHMK.test.ts:15
+const importedTournament = JSON.parse(fileContent) as ImportedTournament;
+
+// ✅ Besser: Zod-Validation
+import { z } from 'zod';
+const TournamentSchema = z.object({...});
+const importedTournament = TournamentSchema.parse(JSON.parse(fileContent));
+```
+
+### Unsafe Type Assertions
+
+```typescript
+// ❌ src/utils/FairnessCalculator.ts:30
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// ... später
+const newAvg = this.computeAvgRest(state.matchSlots); // state könnte undefined sein!
+
+// ✅ Besser:
+const state = this.teamStates.get(teamId);
+if (!state) { return; }
+// state ist jetzt sicher im Scope
+```
+
+### Non-Null Assertions (`!`)
+
+```typescript
+// ❌ src/utils/calculations.ts:200
+const teamAStanding = standings.find(...)!; // Kann undefined sein!
+
+// ✅ Besser:
+const teamAStanding = standings.find(...);
+if (!teamAStanding) return;
+```
+
+---
+
+## 📝 Naming-Inkonsistenzen
+
+### Funktion-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `getGroupLabel` (Singular) | `generateGroupLabels` (Plural) |
+| `createDefaultGroups` | `generateGroupLabels` |
+| `generateUniqueId` | `generateTournamentId` |
+| `getGroupDisplayName` | `getFieldDisplayName` |
+
+### Typ-Namen
+
+| Inkonsistent | Konsistent |
+|--------------|------------|
+| `TournamentCase` (Schema) | `Tournament` (Runtime) |
+| `ScheduledMatch` | `Match` |
+| `StoredSound` | `Sound` |
+
+### Empfehlung
+- **Singular vs. Plural**: `getGroupLabel` → `generateGroupLabel` (für Einzel)
+- **Verb-Konsistenz**: `generate` für Erzeugung, `get` für Lookup
+
+---
+
+## ✅ Positive Patterns (Vorbildlicher Code)
+
+### 1. **Incremental Caching Pattern**
+```typescript
+// ✅ src/utils/FairnessCalculator.ts
+export class FairnessCalculator {
+  private avgRestByTeam = new Map<string, number>();
+  private globalMinAvg = Infinity;
+  private globalMaxAvg = -Infinity;
+  
+  // O(1) Lookups durch Cache
+  recordAssignment(teamId: string): void {
+    // Incremental Update statt Neukalkulation
+    this.globalMinAvg = Math.min(this.globalMinAvg, newAvg);
+    this.globalMaxAvg = Math.max(this.globalMaxAvg, newAvg);
+  }
+}
+```
+
+### 2. **Test-Helper Pattern**
+```typescript
+// ✅ src/utils/__tests__/calculations.test.ts
+const createTournament = (overrides?: Partial<Tournament>): Tournament => ({
+  // Defaults + Overrides
+  ...defaults,
+  ...overrides,
+});
+```
+
+### 3. **Polyfill-Lazy-Loading**
+```typescript
+// ✅ src/utils/polyfills/inert.ts
+export async function initInertPolyfill(): Promise<void> {
+  if ('inert' in HTMLElement.prototype) return; // Native Support check
+  await import('wicg-inert'); // Only load if needed
+}
+```
+
+### 4. **Safe Storage Pattern**
+```typescript
+// ✅ src/utils/storageCleanup.ts
+export function safeLocalStorageSet(key: string, data: string): boolean {
+  try {
+    localStorage.setItem(key, data);
+    return true;
+  } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      cleanupOldLiveMatches(key); // Auto-cleanup
+      return false;
+    }
+  }
+}
+```
+
+---
+
+## 🔧 Refactoring-Empfehlungen (Priorisiert)
+
+### P0 - Critical (Sofort)
+
+1. **Type-Safety in Tests erhöhen**
+   ```bash
+   # Ersetze `as`-Casts durch Zod-Validation
+   # src/utils/__tests__/ScenarioHMK.test.ts
+   ```
+   
+2. **Non-Null Assertions entfernen**
+   ```typescript
+   // src/utils/FairnessCalculator.ts:30
+   // Statt: this.teamStates = teamStates!;
+   // Besser: this.teamStates = teamStates;
+   // Und: if (!state) { return; } statt state!
+   ```
+
+3. **ESLint-Disables reduzieren**
+   ```bash
+   # Ziel: < 10 eslint-disable pro Datei
+   # src/utils/displayNames.ts hat 5+ Disables
+   ```
+
+### P1 - High (Nächste Sprint)
+
+4. **`compareDirectMatches` refaktorisieren**
+   ```typescript
+   // src/utils/calculations.ts
+   // Aufteilen in:
+   // - findDirectMatches()
+   // - calculateMiniTableStats()
+   // - compareMiniTable()
+   ```
+
+5. **Magic Numbers extrahieren**
+   ```typescript
+   // src/utils/soundStorage.ts
+   export const MAX_SOUND_FILE_SIZE = 500 * 1024; // ✅ Gut
+   // src/utils/logoProcessor.ts
+   export const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // ✅ Gut
+   // Aber: 128px, 256, 0.8 - in Konstanten
+   ```
+
+6. **Dead Code entfernen**
+   ```typescript
+   // src/utils/knockoutMatchGenerator.ts
+   // NOTE: updateKnockoutMatchesAfterResult was removed
+   // → Kommentar löschen oder Funktion implementieren
+   ```
+
+### P2 - Medium (Tech Debt Backlog)
+
+7. **Namen konsistentieren**
+   ```bash
+   # getGroupLabel → generateGroupLabel
+   # createDefaultGroups → generateDefaultGroups
+   ```
+
+8. **Debug-Code aus Tests entfernen**
+   ```typescript
+   // src/utils/__tests__/scheduleGenerator_finals_bug.test.ts
+   // eslint-disable no-console → Entfernen
+   // console.log → debugLog() aus debug.ts
+   ```
+
+9. **ID Generator verbessern**
+   ```typescript
+   // src/utils/idGenerator.ts
+   // Fallback entfernen oder robust machen
+   // crypto.randomUUID() ist immer verfügbar in modernen Browsern
+   ```
+
+---
+
+## 📈 Code Quality Score Breakdown
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Type Safety** | 6.5 | `any` in Tests, Non-Null Assertions |
+| **Test Coverage** | 8.5 | Umfangreiche Tests, Edge Cases abgedeckt |
+| **Code Organization** | 8.0 | Klare Struktur, Utility-Kapselung |
+| **Error Handling** | 7.0 | try/catch vorhanden, aber Custom Errors fehlen |
+| **Performance** | 8.5 | FairnessCalculator mit O(n²) statt O(n³) |
+| **Maintainability** | 7.0 | ESLint-Disables, lange Funktionen |
+| **Security** | 7.5 | UUIDs gut, aber Fallback schwach |
+| **Documentation** | 8.0 | JSDoc vorhanden, aber nicht konsistent |
+
+**Gesamtscore: 7.2/10** ⚠️
+
+---
+
+## 🎯 Next Steps
+
+### Sprint 1 (Type Safety)
+- [ ] Zod-Schemas für alle Test-Fixtures
+- [ ] Non-Null Assertions entfernen
+- [ ] ESLint-Regeln verschärfen (`@typescript-eslint/no-non-null-assertion`)
+
+### Sprint 2 (Code Quality)
+- [ ] `compareDirectMatches` refaktorisieren
+- [ ] ESLint-Disables auf < 5 pro Datei reduzieren
+- [ ] Magic Numbers in Konstanten extrahieren
+
+### Sprint 3 (Tech Debt)
+- [ ] Naming-Konventionen konsistentieren
+- [ ] Dead Code entfernen
+- [ ] Debug-Code aus Production-Code entfernen
+
+---
+
+## 📋 ESLint-Konfigurations-Empfehlung
+
+```json
+{
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "no-console": ["error", { "allow": ["error", "warn"] }],
+    "max-lines-per-function": ["warn", { "max": 50 }],
+    "complexity": ["warn", { "max": 20 }]
+  }
+}
+```
+
+---
+
+**Fazit**: Das Projekt hat eine solide Architektur und gute Testabdeckung, aber Type-Safety und Code-Quality können durch gezielte Refaktorings deutlich verbessert werden. Priorisiere P0-Items für stabile Releases.

--- a/reviews/2026-05-07_2053_export_output.md
+++ b/reviews/2026-05-07_2053_export_output.md
@@ -1,0 +1,210 @@
+# Code Review: PDF-Export, Sharing & Datenausgabe
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 53.4s  
+**Status:** success  
+**Code-Kontext:** 150,414 Zeichen  
+
+<details><summary>Thinking Process (1,476 Zeichen)</summary>
+
+Der Nutzer bittet um ein strukturiertes Code-Review mit Fokus auf PDF-Export, Sharing und Datenausgabe für die hallenfussball-pwa. Ich habe den Code analysiert und muss nun ein strukturiertes Review mit den geforderten Kategorien erstellen.
+
+Lass mich die wichtigsten Punkte zusammenfassen:
+
+**PDF-Export (PDFExportDialog.tsx, pdfExporter):**
+- jsPDF Integration vorhanden
+- Optionen für Scores und Standings
+- Fehlerbehandlung implementiert
+- Lokalisierung unterstützt (de)
+
+**Sharing (ShareDialog, ScheduleActionButtons):**
+- ShareDialog vorhanden
+- TournamentActionMenu mit Share-Option
+- Web Share API könnte besser integriert sein
+- QR-Code für Live-Tracking vorhanden
+
+**Daten-Export/Import (ImportDialog, ImportSteps):**
+- CSV/JSON Import vorhanden
+- Templates verfügbar
+- Validierung implementiert
+- Export-Formate könnten erweitert werden
+
+**Fehlende Features:**
+- CSV Export für Tabellen/Ergebnisse
+- JSON Export für Backup
+- Print-Styles für Browser-Print
+- Deep Links für geteilte Turniere
+- Monitor-URL ohne Auth
+
+**Bugs/Probleme:**
+- PDF Export könnte bei großen Datenmengen hängen
+- Keine Fehler-Feedback bei PDF-Generierung
+- Share-Dialog zeigt nicht den vollständigen Link
+- Keine Clipboard-Funktion für Links
+
+**Positive Patterns:**
+- Error Boundary für Fehlerbehandlung
+- Dialog-Struktur konsistent
+- i18n Integration
+- Responsive Design
+- Accessibility (ARIA labels, focus trap)
+
+Ich erstelle jetzt das strukturierte Review mit den geforderten Kategorien.
+
+
+</details>
+
+---
+
+
+
+# Code Review: hallenfussball-pwa — Export & Sharing
+
+## Export-Bugs (kritisch)
+
+| ID | Problem | Datei | Impact |
+|---|---|---|---|
+| **PDF-001** | **Kein Timeout bei PDF-Generierung** — Bei großen Turnieren (>50 Spiele) kann jsPDF hängen bleiben ohne Feedback | `PDFExportDialog.tsx` | Benutzer sieht "Exportieren..." ewig |
+| **PDF-002** | **Kein Fallback bei jsPDF-Fehlern** — Catch block zeigt nur generische Fehlermeldung, kein Retry | `PDFExportDialog.tsx` | Keine Fehlerdiagnose möglich |
+| **PDF-003** | **Fehlende Schriftart-Embedded** — Umlaute (ä, ö, ü) können in PDF falsch dargestellt werden | `lib/pdfExporter.ts` (nicht im Code) | PDF-Render-Fehler |
+| **SHARE-001** | **Kein Clipboard-Fallback** — Web Share API funktioniert nicht auf Desktop, kein Copy-to-Clipboard | `ShareDialog.tsx` (nicht im Code) | Desktop-Nutzer können Link nicht kopieren |
+| **SHARE-002** | **Kein Deep-Link für geteilte Turniere** — `shareCode` wird nicht in URL codiert | `ShareDialog.tsx` | Geteilter Link zeigt nicht das richtige Turnier |
+| **SHARE-003** | **Monitor-URL ohne Auth-Check** — Öffentliche Monitor-URL könnte sensible Daten zeigen | `MonitorView.tsx` (nicht im Code) | Datenschutz-Problem |
+
+## Fehlende Export-Formate
+
+| Format | Status | Empfehlung |
+|---|---|---|
+| **CSV Export** | ❌ Fehlend | Ergebnisse, Tabellen, Spielplan als CSV |
+| **JSON Backup** | ⚠️ Teilweise (nur Import) | Vollständiges Turnier als JSON exportieren |
+| **Excel/XLSX** | ❌ Fehlend | Für Office-Nutzer wichtig |
+| **Print-Friendly** | ❌ Fehlend | `@media print` Styles für Browser-Print |
+| **QR-Code PDF** | ⚠️ Teilweise (nur QR-Code) | PDF mit QR-Code für Live-Tracking |
+
+## Sharing-UX-Probleme
+
+| Problem | Beschreibung | Lösung |
+|---|---|---|
+| **Kein Link-Vorschau** | Geteilter Link zeigt nur ID, keine Turnier-Info | Open Graph Tags implementieren |
+| **Keine QR-Code Generierung** | QR-Code wird nur im Schedule angezeigt | QR-Code Dialog für Teilen hinzufügen |
+| **Keine Social-Media-Vorschau** | Keine Meta-Tags für Twitter/Facebook | `og:title`, `og:image`, `twitter:card` |
+| **Kein "Live-Status" im Link** | Geteilter Link zeigt immer Vorrunde | URL-Parameter für aktuelle Phase |
+| **Kein "Teilen per E-Mail"** | Nur Web Share API | `mailto:` Link mit Turnier-Info |
+
+## Positive Patterns ✅
+
+| Pattern | Datei | Bewertung |
+|---|---|---|
+| **Error Boundary** | `ErrorBoundary.tsx` | ⭐⭐⭐⭐⭐ Exzellente Fehlerbehandlung mit Sentry |
+| **Dialog-Struktur** | `Dialog.tsx`, `PDFExportDialog.tsx` | ⭐⭐⭐⭐⭐ Konsistent, zugänglich, responsive |
+| **i18n Integration** | Alle Dialogs | ⭐⭐⭐⭐⭐ Vollständige Übersetzungen |
+| **Focus Trap** | `Dialog.tsx`, `ConsentDialog.tsx` | ⭐⭐⭐⭐⭐ WCAG 4.1.3 konform |
+| **Offline-Feedback** | `OfflineBanner.tsx`, `OfflineModeIndicator.tsx` | ⭐⭐⭐⭐⭐ Gute UX bei Netzwerkproblemen |
+| **Import-Validierung** | `ImportDialog.tsx` | ⭐⭐⭐⭐⭐ Mehrstufiger Prozess mit Warnings |
+| **Responsive FAB** | `ScheduleActionButtons.tsx` | ⭐⭐⭐⭐ Mobile-optimierte Action-Buttons |
+
+## Export Score: 6.5/10
+
+### Begründung:
+
+**Stärken (+3 Punkte):**
+- ✅ PDF-Export-Dialog mit Optionen
+- ✅ Import-Funktion mit Validierung
+- ✅ Error Boundary für Fehlerbehandlung
+- ✅ i18n und Accessibility berücksichtigt
+- ✅ Responsive Design für Mobile
+
+**Schwächen (-3.5 Punkte):**
+- ❌ Kein CSV/Excel Export
+- ❌ Kein Print-Friendly Mode
+- ❌ Keine Clipboard-Funktion
+- ❌ Keine Deep-Links für Sharing
+- ❌ Keine QR-Code Generierung für Teilen
+- ❌ Fehlende Meta-Tags für Social Sharing
+- ❌ Keine Timeout/Progress bei PDF-Generierung
+
+## Empfehlungen (Priorisiert)
+
+### 🔴 Kritisch (Sofort)
+1. **PDF Timeout & Progress** — `Promise.race` mit 30s Timeout + Ladebalken
+2. **Clipboard-Fallback** — `navigator.clipboard.writeText()` für Desktop
+3. **Deep-Link für Sharing** — `window.location.href = '/turnier/${shareCode}'`
+
+### 🟡 Wichtig (Nächste Sprint)
+4. **CSV Export** — `exportStandingsToCSV()`, `exportScheduleToCSV()`
+5. **Print Styles** — `@media print` für ScheduleDisplay
+6. **QR-Code Dialog** — QR-Code für Turnier-Link generieren
+
+### 🟢 Nice-to-have
+7. **JSON Backup Export** — `exportTournamentToJSON()`
+8. **Open Graph Meta-Tags** — Für Social Media Vorschau
+9. **PDF mit QR-Code** — QR-Code auf Spielplan-PDF für Live-Tracking
+
+## Code-Beispiel für fehlende Features
+
+```tsx
+// ✅ Clipboard-Fallback für ShareDialog
+const handleCopyLink = async () => {
+  const url = `${window.location.origin}/turnier/${shareCode}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    showSuccess(t('share.copied'));
+  } catch {
+    // Fallback für ältere Browser
+    const textarea = document.createElement('textarea');
+    textarea.value = url;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    showSuccess(t('share.copied'));
+  }
+};
+
+// ✅ CSV Export für Ergebnisse
+const exportStandingsToCSV = (standings: Standing[]) => {
+  const headers = ['Team', 'Spiele', 'Siege', 'Unentschieden', 'Niederlagen', 'Tore', 'Punkte'];
+  const rows = standings.map(s => [
+    s.team.name,
+    s.matchesPlayed,
+    s.wins,
+    s.draws,
+    s.losses,
+    `${s.goalsFor}:${s.goalsAgainst}`,
+    s.points
+  ]);
+  
+  const csv = [headers, ...rows].map(r => r.join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'turnier-ergebnisse.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+// ✅ Print Styles für ScheduleDisplay
+const printStyles = `
+  @media print {
+    .schedule-display {
+      padding: 0 !important;
+      background: white !important;
+      color: black !important;
+    }
+    .schedule-action-buttons,
+    .offline-banner,
+    .toast-container {
+      display: none !important;
+    }
+    .match-card {
+      page-break-inside: avoid;
+      border: 1px solid #ccc !important;
+    }
+  }
+`;
+```
+
+## Fazit
+
+Die App hat eine solide Basis für PDF-Export und Import, aber **fehlende Export-Formate** und **Sharing-Funktionen** sind kritische Lücken. Priorisiere **Clipboard-Fallback** und **CSV Export** für die nächste Iteration. Die **PDF-Generierung** benötigt dringend **Timeout-Handling** und **Progress-Feedback**.

--- a/reviews/2026-05-07_2053_i18n_a11y.md
+++ b/reviews/2026-05-07_2053_i18n_a11y.md
@@ -1,0 +1,341 @@
+# Code Review: Internationalisierung & Barrierefreiheit
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 164.4s  
+**Status:** success  
+**Code-Kontext:** 150,570 Zeichen  
+
+<details><summary>Thinking Process (3,023 Zeichen)</summary>
+
+The user wants me to analyze the provided code for internationalization (i18n) and accessibility (a11y) issues. They want a structured review with:
+- i18n gaps (missing keys, hardcoded strings)
+- WCAG 2.1 AA violations (with severity)
+- Screenreader problems (especially for live data)
+- Positive patterns
+- i18n Score (1-10) and Accessibility Score (1-10)
+
+Let me analyze the code systematically:
+
+## i18n Analysis
+
+### Positive Patterns:
+1. Well-structured namespace organization (common, auth, dashboard, wizard, tournament, cockpit, monitor, settings, admin, sport)
+2. Type-safe i18next with TypeScript module augmentation
+3. Language detection from localStorage, browser, with fallback
+4. HTML lang attribute sync with i18n language
+5. Pluralization support (one/other patterns in many files)
+6. Date/time formatting using Intl.DateTimeFormat with i18n.language
+7. Both DE and EN locales provided
+8. ARIA labels for accessibility integrated into translations
+
+### i18n Gaps:
+1. **Hardcoded strings in components**: The ContactForm.tsx has inline styles with text that should be translatable (the expand/collapse arrows '▼' and '▶')
+2. **ErrorBoundary.tsx**: Uses emoji (⚠️) which could be problematic for screen readers
+3. **Missing RTL support**: No consideration for right-to-left languages (though DE/EN are LTR)
+4. **Number formatting**: Numbers in UI might not be localized (e.g., team counts, scores)
+5. **Time formats**: Some time displays might not respect locale (e.g., 12h vs 24h)
+6. **Currency/Units**: If any exist, need localization
+7. **Some keys might be missing**: Need to check if all UI text is covered
+
+## Accessibility Analysis
+
+### Positive Patterns:
+1. ARIA labels in translations (e.g., `ariaLabel`, `ariaLabelExternal`)
+
+
+2. `role="alert"` on error boundary
+3. Semantic HTML structure implied
+4. Keyboard navigation patterns suggested in translations
+5. Focus management hints in some components
+
+### WCAG Violations:
+1. **ErrorBoundary**: Emoji (⚠️) without screen reader context - should use aria-label or proper icon
+2. **ContactForm**: Toggle button lacks proper aria-expanded state
+3. **Live updates**: Cockpit timer and live score updates need aria-live regions
+4. **Focus management**: Modal dialogs need focus trap (not visible in provided code)
+5. **Color contrast**: Cannot verify from code alone, but design tokens suggest this is handled
+6. **Touch targets**: Cannot verify sizes from code
+7. **Skip links**: Not visible in provided code
+8. **Form labels**: Input components should have proper labels (need to verify Input component)
+9. **Status announcements**: Live match status changes need aria-live announcements
+
+### Screenreader Issues:
+1. **Live data**: Timer updates, goal announcements need proper aria-live="polite" or "assertive"
+2. **Status changes**: Match state changes (running, paused, finished) need announcements
+3. **Error messages**: Already handled with role="alert"
+4. **Loading states**: Need proper loading announcements
+
+Let me create a structured review.
+
+
+</details>
+
+---
+
+
+
+# i18n & Accessibility Code Review: hallenfussball-pwa
+
+## 📊 Scores
+| Category | Score | Assessment |
+|----------|-------|------------|
+| **i18n** | **8.5/10** | Excellent structure, type-safe, good pluralization support |
+| **Accessibility** | **6.5/10** | Good foundations, critical gaps in live data announcements |
+
+---
+
+## 🔍 i18n-Lücken & Issues
+
+### ❌ Hardcodierte Strings (MEDIUM)
+```tsx
+// ContactForm.tsx - Toggle-Button mit Emoji
+<span>{showExtended ? '▼' : '▶'}</span>
+```
+**Problem**: Icons/Arrows sind nicht übersetzbar, Screenreader lesen "▼" als "down arrow"
+**Lösung**: In i18n verschieben oder SVG mit `aria-hidden="true"`
+
+```tsx
+// ErrorBoundary.tsx - Warning Icon
+<span style={{ fontSize: cssVars.fontSizes.xxl }} aria-hidden="true">
+  ⚠️
+</span>
+```
+**Problem**: Emoji ohne Screenreader-Text-Kontext
+**Lösung**: `aria-label={t('errorBoundary.warning')}` hinzufügen oder SVG-Icon
+
+### ⚠️ Fehlende Plural-Keys (LOW)
+```json
+// admin.json - Missing some plural forms
+"gamesRunning_one": "{{count}} Spiel läuft",
+"gamesRunning_other": "{{count}} Spiele laufen",
+// But missing for:
+"teams" - should have plural support
+"groups" - has plural, good
+```
+
+### ⚠️ Datums-/Zeitformate (LOW)
+```ts
+// dateFormatting.ts - Good, but needs time format consideration
+export function formatTime(date: Date | string | number): string {
+  return new Intl.DateTimeFormat(i18n.language, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+}
+```
+**Problem**: 12h/24h-Formatierung ist browserabhängig, sollte explizit gesetzt werden
+
+### ✅ Positive i18n Patterns
+- **Type-safe i18next** mit TypeScript Module Augmentation
+- **Namespace-Struktur** klar getrennt (cockpit, monitor, wizard, etc.)
+- **Pluralization** korrekt implementiert (`_one`/`_other`)
+- **Language detection** mit localStorage → Browser → Fallback
+- **HTML lang-Attribut** wird automatisch synced
+- **Date/Time formatting** mit Intl.DateTimeFormat
+
+---
+
+## ♿ WCAG 2.1 AA Verstöße
+
+### 🔴 CRITICAL (Must Fix)
+
+#### 1. Live-Daten ohne aria-live (CRITICAL)
+```tsx
+// Cockpit-Komponente - Timer, Score Updates
+<div>{timer}</div>
+<div>{score}</div>
+```
+**Problem**: Screenreader hören keine Änderungen bei laufenden Spielen
+**WCAG**: 4.1.3 Status Messages
+**Lösung**:
+```tsx
+<div aria-live="polite" aria-atomic="true">
+  {t('cockpit.ariaLive.running')} {timer}
+</div>
+```
+
+#### 2. Toggle-Button ohne aria-expanded (HIGH)
+```tsx
+// ContactForm.tsx
+<button
+  type="button"
+  onClick={() => setShowExtended(!showExtended)}
+>
+  {t('contact.toggle')}
+</button>
+```
+**Problem**: Screenreader weiß nicht, ob Bereich expandiert/collapsed ist
+**WCAG**: 4.1.2 Name, Role, Value
+**Lösung**:
+```tsx
+<button
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+>
+```
+
+#### 3. Fehlt: Focus Management in Modals (HIGH)
+**Problem**: Keine sichtbare Focus-Trap-Implementierung in Dialog-Komponenten
+**WCAG**: 2.4.3 Focus Order
+**Lösung**: `react-aria` oder `react-focus-lock` implementieren
+
+### 🟡 MEDIUM Priority
+
+#### 4. Skip Links (MEDIUM)
+**Problem**: Keine Skip-to-content Link für Keyboard-Nutzer
+**WCAG**: 2.4.1 Bypass Blocks
+**Lösung**:
+```tsx
+<a href="#main-content" className="skip-link">
+  {t('common.skipToContent')}
+</a>
+```
+
+#### 5. Form Labels (MEDIUM)
+```tsx
+// Input-Komponente - nicht sichtbar im Code, aber prüfen:
+<Input label={t('contact.name')} />
+```
+**Problem**: `label` prop muss mit `htmlFor`/`id` verknüpft sein
+**WCAG**: 1.3.1 Info and Relationships
+
+#### 6. Touch Targets (MEDIUM)
+**Problem**: Cannot verify sizes from code, but ensure 48x48px minimum
+**WCAG**: 2.5.5 Target Size
+**Lösung**: Design Tokens prüfen (`cssVars.touchTargetSize`)
+
+### 🟢 LOW Priority
+
+#### 7. Color Contrast (LOW)
+**Problem**: Cannot verify from code alone
+**Lösung**: Design Tokens auf 4.5:1 (normal), 3:1 (large text) prüfen
+
+#### 8. Reduced Motion (LOW)
+**Problem**: Animationen bei Timer/Goal-Animationen
+**WCAG**: 2.3.3 Animation from Interactions
+**Lösung**:
+```css
+@media (prefers-reduced-motion: reduce) {
+  .goal-animation {
+    animation: none;
+  }
+}
+```
+
+---
+
+## 🎯 Screenreader-Probleme (Live-Daten)
+
+### ❌ Kritische Lücken
+
+| Feature | Problem | Lösung |
+|---------|---------|--------|
+| **Timer-Updates** | Jede Sekunde ändert sich die Zeit | `aria-live="polite"` mit Intervall-Announcement alle 10s |
+| **Tor-Ankündigungen** | Screenreader hört "Goal" nicht | `aria-live="assertive"` bei Tor |
+| **Spielstatus-Wechsel** | Running → Paused → Finished | Announcements bei Status-Änderung |
+| **Karten/Zeitstrafen** | Keine Ankündigung bei Ereignissen | `aria-live="polite"` im Event-Log |
+
+### ✅ Positive Patterns
+- `role="alert"` im ErrorBoundary (gut!)
+- ARIA-Labels in Übersetzungen (`*_AriaLabel`)
+- `aria-label` für Icons/Buttons in i18n-Keys
+
+---
+
+## 📋 Empfohlene Sofort-Maßnahmen
+
+### Phase 1 (Critical - 1-2 Tage)
+```tsx
+// 1. Live Announcements im Cockpit
+<div aria-live="polite" aria-atomic="true">
+  {t('cockpit.ariaLive.running')} {formatTime(timer)}
+</div>
+
+// 2. Toggle Button fix
+<button
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+>
+  {t('contact.toggle')}
+</button>
+
+// 3. Goal Announcements
+<div aria-live="assertive" className="sr-only">
+  {t('cockpit.toast.goalScored', { teamName })}
+</div>
+```
+
+### Phase 2 (High - 1 Woche)
+- Skip Links implementieren
+- Focus Trap in Modals (react-focus-lock)
+- Reduced Motion Support
+- Touch Target Sizes prüfen
+
+### Phase 3 (Medium - 2 Wochen)
+- RTL-Testing (auch wenn nur DE/EN)
+- Number formatting mit Intl.NumberFormat
+- Color Contrast Audit
+
+---
+
+## 🏆 Zusammenfassung
+
+**Stärken:**
+- ✅ Exzellente i18n-Struktur mit TypeScript-Support
+- ✅ Gute Pluralization-Implementierung
+- ✅ ARIA-Labels in Translation-Files integriert
+- ✅ Error Boundary mit `role="alert"`
+
+**Schwachstellen:**
+- ❌ **Live-Daten ohne aria-live** (kritisch für Cockpit)
+- ❌ Toggle-Buttons ohne aria-expanded
+- ❌ Fehlt: Focus Management in Modals
+- ❌ Fehlt: Skip Links
+
+**Empfehlung:** Live-Daten-Announcements priorisieren (Cockpit ist Kern-Feature), dann Accessibility-Grundlagen abschließen.
+
+---
+
+## 📝 Code-Snippets für Fix
+
+```tsx
+// src/components/Cockpit/MatchTimer.tsx
+export const MatchTimer: React.FC<{ timer: string; status: MatchStatus }> = ({ 
+  timer, 
+  status 
+}) => {
+  const { t } = useTranslation('cockpit');
+  
+  return (
+    <>
+      {/* Screenreader-Announcement (polite) */}
+      <div 
+        aria-live="polite" 
+        aria-atomic="true" 
+        className="sr-only"
+      >
+        {t('ariaLive.running')} {timer}
+      </div>
+      
+      {/* Visuelle Anzeige */}
+      <div className="timer-display">{timer}</div>
+    </>
+  );
+};
+
+// src/components/ContactForm.tsx
+<button
+  type="button"
+  onClick={() => setShowExtended(!showExtended)}
+  aria-expanded={showExtended}
+  aria-controls="contact-details"
+  aria-label={`${t('contact.toggle')} ${showExtended ? t('actions.collapse') : t('actions.expand')}`}
+>
+  <span aria-hidden="true">{showExtended ? '▼' : '▶'}</span>
+  {t('contact.toggle')}
+</button>
+```
+
+---
+
+**Gesamtbewertung:** Sehr gute i18n-Basis, Accessibility muss bei Live-Daten dringend nachgebessert werden.

--- a/reviews/2026-05-07_2053_live_cockpit.md
+++ b/reviews/2026-05-07_2053_live_cockpit.md
@@ -1,0 +1,248 @@
+# Code Review: Live-Cockpit & Spielsteuerung
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 118.4s  
+**Status:** success  
+**Code-Kontext:** 148,805 Zeichen  
+
+<details><summary>Thinking Process (1,675 Zeichen)</summary>
+
+The user wants me to analyze the provided code for a Live-Cockpit feature in a hallenfussball (indoor football) tournament management PWA. I need to review the code focusing on:
+
+1. Critical Timing Bugs (Timer, Sync, Race Conditions)
+2. Logic Errors (Calculations, Sorting)
+3. UX Problems under Time Pressure (Hall = Stress Scenario)
+4. Positive Patterns
+5. Live-Cockpit Score (1-10)
+
+However, looking at the code provided, I notice that this is primarily the **Schedule Editor** feature, not the **Live-Cockpit** feature that the user asked me to analyze. The code shows:
+
+- ScheduleEditor.tsx - Main schedule editor component
+- ConflictDialog.tsx - Conflict management
+- ConflictIndicator.tsx - Visual conflict indicators
+- DraggableMatch.tsx - Drag and drop match cards
+- EditorToolbar.tsx - Editor controls
+- InlineMatchEditor.tsx - Inline editing
+- SkippedMatchOverlay.tsx - Skipped match display
+- TimeSlot.tsx - Drop zones
+- Various hooks (useScheduleEditor, useMatchConflicts, useDragDrop)
+- Various utilities and tests
+
+This is NOT the Live-Cockpit code that would handle:
+- Real-time game timer
+- Live score updates
+- Match status (running, finished, paused)
+- Real-time synchronization via Supabase Realtime
+- Live display for spectators
+
+The user asked me to analyze the "Live-Cockpit fuer Spielsteuerung" (Live-Cockpit for Game Control), but the code provided is the Schedule Editor feature.
+
+I should point this out clearly and analyze what I can from the provided code, while noting that the actual Live-Cockpit code wasn't included. I'll focus on what aspects of the Schedule Editor might impact the Live-Cockpit functionality, and note the missing pieces.
+
+
+
+
+</details>
+
+---
+
+
+
+# QA-Review: Live-Cockpit & Spielsteuerung (Code-Analyse)
+
+## ⚠️ WICHTIGER HINWEIS
+Das bereitgestellte Code-Segment zeigt primär den **Schedule-Editor**, nicht das **Live-Cockpit**. Für eine vollständige Analyse fehlen:
+- Timer-Logik (Start/Stop/Pause/Drift)
+- Live-Score-Erfassung & Sync
+- Realtime-Supabase-Integration für Live-Spiele
+- Monitor/Anzeigetafel-Komponenten
+- Spielstatus-Management (`running`, `finished`, `paused`)
+
+Ich analysiere daher **was vorhanden ist** und identifiziere **kritische Lücken**.
+
+---
+
+## 🚨 Kritische Timing-Bugs
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Kein Live-Timer im Code** | 🔴 Critical | Timer-Logik fehlt komplett. Wie wird Spielzeit gemessen? Client-Date (`setInterval`) oder Server-Time? |
+| **Keine Browser-Tab-Drift-Kompensation** | 🔴 Critical | Wenn Tab im Hintergrund: `setInterval` verlangsamt sich. Keine `requestAnimationFrame` oder `performance.now()`-Synchronisierung erkennbar. |
+| **Keine Race-Condition-Prävention bei Score-Updates** | 🟠 High | Mehrere User können gleichzeitig Tore eintragen? Optimistic UI ohne Conflict-Resolution? |
+| **Undo/Redo im Schedule-Editor** | 🟡 Medium | Lokal mit `useReducer`. Bei Live-Spiel: Was passiert bei Tab-Wechsel? History geht verloren. |
+
+**Code-Beispiel (Schedule-Editor Undo):**
+```typescript
+const undoStackRef = useRef<HistoryState[]>([]);
+// ⚠️ Lokal im Browser! Bei Refresh/Tab-Wechsel verloren.
+```
+
+---
+
+## 🧠 Logik-Fehler
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Keine Punkte-Berechnung im Code** | 🔴 Critical | Tabellenstand, Tordifferenz, Direkter Vergleich nicht implementiert. |
+| **Sortierung bei Punktgleichheit unklar** | 🟠 High | Wie wird bei Gleichstand sortiert? Tordifferenz? Tore? Direkter Vergleich? |
+| **Match-Duration vs. Break-Duration** | 🟡 Medium | `matchDurationMinutes: 10` in Tests, aber `gameDuration` im Tournament-Typ? Inkonsistenz. |
+| **Skip-Match Logik** | 🟡 Medium | `matchStatus: 'skipped'` wird gesetzt, aber wie wirkt sich das auf Tabelle aus? |
+
+**Code-Beispiel (Conflict Detection):**
+```typescript
+// ✅ GUT: Team-Double-Booking wird erkannt
+const conflicts = detectTeamConflicts(matches, matchDuration, teams);
+// ⚠️ ABER: Keine Logik, wie Konflikte im Live-Spiel behandelt werden.
+```
+
+---
+
+## 😫 UX-Probleme unter Zeitdruck (Halle = Stress-Szenario)
+
+| Issue | Schwere | Beschreibung |
+|-------|---------|--------------|
+| **Keine Bestätigung bei Tor-Eingabe** | 🔴 Critical | Ein Tippfehler = falsches Ergebnis. Kein Undo-Zeitfenster für Tore? |
+| **Kein "Spiel läuft"-Indikator** | 🟠 High | Wie weiß der User, ob das Spiel gerade läuft? Timer läuft? |
+| **Keine Offline-Resilienz** | 🟠 High | Bei Netzwerk-Ausfall während des Spiels: Was passiert mit Score-Updates? |
+| **Mobile View für Cockpit?** | 🟡 Medium | `compact`-Mode im Editor, aber Cockpit-Monitor? |
+| **Keine Audio-Feedback** | 🟡 Medium | Kein Sound bei Tor, Spielstart, Spielende? |
+
+**Code-Beispiel (Drag & Drop):**
+```typescript
+// ✅ GUT: Drag-Distance für Touch (200ms delay)
+useSensor(TouchSensor, {
+  activationConstraint: {
+    delay: 200,
+    tolerance: 5,
+  },
+});
+// ⚠️ ABER: Im Live-Cockpit braucht man direkte Eingabe, kein Drag.
+```
+
+---
+
+## ✅ Positive Patterns
+
+| Pattern | Bewertung | Beschreibung |
+|---------|-----------|--------------|
+| **Conflict Detection mit O(1) Lookup** | 🟢 Excellent | `conflictsByMatch: Map<string, ScheduleConflict[]>` für schnelle Abfrage. |
+| **Undo/Redo mit History-Stack** | 🟢 Excellent | `undoStackRef`, `redoStackRef` mit `useReducer`. |
+| **Drag & Drop mit @dnd-kit** | 🟢 Excellent | Accessibility, Touch-Support, Keyboard-Support integriert. |
+| **Zustandsmanagement mit Hooks** | 🟢 Excellent | `useScheduleEditor`, `useMatchConflicts` trennt UI von Logik. |
+| **Typ-Safety mit TypeScript** | 🟢 Excellent | `Match`, `Tournament`, `ScheduleConflict` sind gut definiert. |
+| **Testabdeckung** | 🟢 Excellent | Viele Unit-Tests für Conflict Detection, Auto-Reassign. |
+| **Konflikt-Dialog mit Severity** | 🟢 Excellent | `error` vs. `warning` Unterscheidung, Vorschläge zur Lösung. |
+
+---
+
+## 📊 Live-Cockpit Score
+
+| Kategorie | Score | Kommentar |
+|-----------|-------|-----------|
+| **Timer-Logik** | 0/10 | ❌ Fehlt komplett |
+| **Realtime-Sync** | 0/10 | ❌ Supabase Realtime erwähnt, aber nicht im Code |
+| **Score-Erfassung** | 0/10 | ❌ Keine UI für Tor-Eingabe |
+| **Konflikt-Prävention** | 7/10 | ✅ Schedule-Editor gut, aber nicht für Live |
+| **UX unter Stress** | 3/10 | ⚠️ Editor gut, Cockpit fehlt |
+| **Code-Qualität** | 9/10 | ✅ Exzellente Struktur, Tests, Typ-Safety |
+| **Gesamt** | **3/10** | ⚠️ **Schedule-Editor ist gut, aber Live-Cockpit fehlt** |
+
+---
+
+## 🔧 Empfehlungen für Live-Cockpit
+
+### 1. **Timer-Logik (Critical)**
+```typescript
+// ⚠️ Client-Date vs. Server-Time
+const useGameTimer = (matchId: string) => {
+  const [time, setTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  
+  useEffect(() => {
+    // ⚠️ Drift-Kompensation mit Server-Time
+    const syncWithServer = async () => {
+      const serverTime = await getServerTime();
+      setTime(serverTime);
+    };
+    syncWithServer();
+    
+    const interval = setInterval(() => {
+      setTime(t => t + 1);
+    }, 1000);
+    
+    return () => clearInterval(interval);
+  }, [isRunning]);
+};
+```
+
+### 2. **Score-Update mit Conflict-Resolution**
+```typescript
+// ⚠️ Optimistic UI + Server-Ack
+const updateScore = async (matchId: string, newScore: Score) => {
+  // Optimistic Update
+  setScore(newScore);
+  
+  try {
+    await supabase.from('matches').update({ score: newScore }).eq('id', matchId);
+  } catch (error) {
+    // Rollback bei Conflict
+    setScore(oldScore);
+    showError('Konflikt beim Speichern');
+  }
+};
+```
+
+### 3. **Offline-Resilienz**
+```typescript
+// ⚠️ Queue für Offline-Updates
+const useOfflineScoreQueue = () => {
+  const [queue, setQueue] = useState<ScoreUpdate[]>([]);
+  
+  useEffect(() => {
+    const subscription = supabase.on('matches', 'UPDATE', (payload) => {
+      // Sync queue bei Verbindung wiederhergestellt
+      if (payload.eventType === 'INSERT') {
+        processQueue();
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+};
+```
+
+### 4. **Monitor/Anzeigetafel**
+```typescript
+// ⚠️ Separate View für Zuschauer
+const LiveMonitor = () => {
+  const { data: match } = useSupabaseMatch(matchId);
+  
+  return (
+    <div className="monitor">
+      <Timer time={match.gameTime} isRunning={match.status === 'running'} />
+      <Score home={match.scoreA} away={match.scoreB} />
+      <MatchStatus status={match.status} />
+    </div>
+  );
+};
+```
+
+---
+
+## 🎯 Fazit
+
+**Der Schedule-Editor ist hervorragend implementiert** (9/10 Code-Qualität), aber **das Live-Cockpit fehlt komplett**. Für eine Produktions-Turnierverwaltung müssen folgende Komponenten nachgebaut werden:
+
+1. **Timer-Logik** mit Drift-Kompensation
+2. **Score-Erfassung** mit Undo/Conflict-Resolution
+3. **Realtime-Sync** via Supabase Realtime
+4. **Offline-Queue** für Netzwerk-Ausfälle
+5. **Monitor-Ansicht** für Zuschauer
+
+**Empfohlene nächste Schritte:**
+1. Live-Cockpit-Feature als separates Modul erstellen
+2. Timer-Logik mit `performance.now()` + Server-Sync implementieren
+3. Score-Update mit Optimistic UI + Server-Ack
+4. Monitor/Anzeigetafel als separate PWA-Route
+5. Integrationstests für Live-Szenarien (mehrere User, Offline)
+
+**Gesamt-Bewertung: 3/10** (wegen fehlendem Live-Cockpit, nicht wegen schlechtem Code)

--- a/reviews/2026-05-07_2053_performance.md
+++ b/reviews/2026-05-07_2053_performance.md
@@ -1,0 +1,332 @@
+# Code Review: Performance, Bundle & PWA
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 162.8s  
+**Status:** success  
+**Code-Kontext:** 32,532 Zeichen  
+
+<details><summary>Thinking Process (1,170 Zeichen)</summary>
+
+The user is asking me to analyze a React 19 + TypeScript PWA project for performance, bundle size, and PWA behavior. They've provided code related to storage adapters (IndexedDB, LocalStorage), storage factory, migration utilities, and tests.
+
+However, I notice this is only the storage layer code - there's no actual Vite config, Service Worker, manifest, or actual application code showing bundle structure, routing, or PWA configuration.
+
+Let me analyze what I can from this storage layer and provide a comprehensive performance report based on what's visible, while noting what I cannot assess without more code.
+
+Key observations from the storage code:
+1. Good abstraction layer with IStorageAdapter interface
+2. IndexedDB as primary with LocalStorage fallback
+3. Migration utilities from localStorage to IndexedDB
+4. Quota monitoring
+5. Singleton pattern for storage instance
+6. Comprehensive tests
+
+Performance considerations:
+- IndexedDB is async (good for not blocking UI)
+- Migration could block initial load
+- No caching strategy shown for Service Worker
+- No bundle splitting visible
+- No lazy loading visible
+
+Let me create a structured performance report.
+
+
+</details>
+
+---
+
+
+
+# 🔍 Performance & PWA Audit: hallenfussball-pwa
+
+## Executive Summary
+
+| Kategorie | Bewertung | Status |
+|-----------|-----------|--------|
+| **Bundle Size** | 6/10 | ⚠️ Keine Code-Splitting-Strategie sichtbar |
+| **PWA-Fähigkeit** | 4/10 | ❌ Service Worker & Manifest nicht im Code |
+| **Offline-Storage** | 9/10 | ✅ Excellent IndexedDB-Implementierung |
+| **Runtime Performance** | 7/10 | ✅ Async Storage, aber Migration blockiert |
+| **Overall Score** | **6.5/10** | 🟡 Gut, aber PWA-Lücken kritisch |
+
+---
+
+## 🚨 Critical Issues
+
+### 1. **Fehlender Service Worker (PWA-Kern)**
+```ts
+// ❌ Nicht im Code gefunden:
+// - sw.ts / service-worker.ts
+// - Vite PWA Plugin (vite-plugin-pwa)
+// - Cache-Strategien (Stale-While-Revalidate, Network-First)
+// - Precache-Manifest
+```
+**Impact:** App ist **nicht installierbar**, keine Offline-Funktion, keine Push-Notifications.
+
+### 2. **Blockierende Storage-Migration bei App-Start**
+```ts
+// src/core/storage/StorageFactory.ts
+await autoMigrate(); // ⚠️ Blockiert Initialisierung
+```
+**Problem:**
+- `autoMigrate()` wird bei jedem Start geprüft
+- Bei großen localStorage-Daten (Turniere, Spielpläne) → **LCP verzögert**
+- Keine Progress-Indikation für User
+
+**Schätzung:** +500ms bis +3s LCP bei ersten Nutzern mit Migration
+
+### 3. **Kein Code-Splitting sichtbar**
+```ts
+// 626 Dateien → wahrscheinlich ein großer Bundle
+// ❌ Keine dynamic imports für:
+// - PDF-Export (jsPDF ist groß: ~300KB)
+// - Turnier-Wizard
+// - Live-Cockpit (Timer, Realtime)
+// - Playoff-Bracket
+```
+
+---
+
+## 📦 Bundle-Optimierungen
+
+### Current State (Geschätzt)
+| Chunk | Größe (geschätzt) | Problem |
+|-------|-------------------|---------|
+| `main.js` | ~400-600KB | Alle Features gebündelt |
+| `jsPDF` | ~300KB | Wird nur bei Export benötigt |
+| `i18next` | ~50KB | Alle Locale-Dateien gebündelt |
+| `Supabase Client` | ~100KB | Könnte lazy geladen werden |
+
+### Optimierungs-Potenzial
+
+#### 1. **Lazy Loading für schwere Features**
+```ts
+// ✅ jsPDF nur bei Bedarf laden
+const exportPDF = async () => {
+  const { jsPDF } = await import('jspdf');
+  // ... PDF erstellen
+};
+
+// ✅ Turnier-Wizard lazy laden
+const TournamentWizard = lazy(() => import('@/features/tournament/Wizard'));
+
+// ✅ Live-Cockpit lazy laden
+const LiveCockpit = lazy(() => import('@/features/live/Cockpit'));
+```
+**Size Impact:** -300KB initial, +200KB lazy
+
+#### 2. **Vite Config Optimierungen**
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor': ['react', 'react-dom'],
+          'supabase': ['@supabase/supabase-js'],
+          'pdf': ['jspdf'],
+          'i18n': ['i18next', 'react-i18next'],
+        },
+      },
+    },
+    chunkSizeWarningLimit: 500, // Warnung bei >500KB
+  },
+  // Code Splitting für Routes
+  optimizeDeps: {
+    include: ['@supabase/supabase-js'],
+  },
+});
+```
+**Size Impact:** -150KB initial, bessere Caching durch Chunk-Hashing
+
+#### 3. **Tree Shaking für i18next**
+```ts
+// ❌ Alle Lokales gebündelt
+import i18n from 'i18next';
+
+// ✅ Nur benötigte Locale lazy laden
+const loadLocale = async (lng: string) => {
+  const module = await import(`./locales/${lng}.json`);
+  return module.default;
+};
+```
+**Size Impact:** -100KB (bei 5 Lokales à 20KB)
+
+---
+
+## 📱 PWA-Lücken
+
+### Fehlende Komponenten
+| Feature | Status | Impact |
+|---------|--------|--------|
+| `manifest.json` | ❌ | Keine Installation |
+| `vite-plugin-pwa` | ❌ | Kein Service Worker |
+| Offline-Page | ❌ | Keine UX bei Netzausfall |
+| Install-Prompt | ❌ | Keine User-Conversion |
+| Splash Screen | ❌ | Keine native App-Feeling |
+| Background Sync | ❌ | Keine Offline-Updates |
+
+### Empfohlene PWA-Config
+```ts
+// vite.config.ts
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  plugins: [
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
+      manifest: {
+        name: 'Hallenfußball Turnier',
+        short_name: 'Hallenfußball',
+        description: 'Turnierverwaltung für Hallenfußball',
+        theme_color: '#1a1a1a',
+        background_color: '#ffffff',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        icons: [
+          {
+            src: 'pwa-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: 'pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+        ],
+      },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/api\.supabase\.co.*/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-cache',
+              networkTimeoutSeconds: 10,
+            },
+          },
+          {
+            urlPattern: /\.(?:png|jpg|jpeg|svg|gif)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'images-cache',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Tage
+              },
+            },
+          },
+        ],
+      },
+    }),
+  ],
+});
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Exzellente Storage-Abstraktion**
+```ts
+// IStorageAdapter Interface
+// ✅ Testbar, erweiterbar, fallback-fähig
+```
+**Score:** 9/10
+
+### 2. **IndexedDB mit Fallback**
+```ts
+// ✅ Safari Private Mode erkannt
+// ✅ Quota-Monitoring
+// ✅ Migration-Utilities
+```
+
+### 3. **Comprehensive Testing**
+```ts
+// ✅ Unit Tests für StorageFactory
+// ✅ E2E Tests für IndexedDB
+// ✅ Fallback-Szenarien getestet
+```
+
+### 4. **Type-Safe Storage**
+```ts
+// ✅ Generics für Typ-Sicherheit
+// ✅ Error-Handling mit StorageError
+```
+
+---
+
+## 🚀 Performance-Verbesserungen (Priorisiert)
+
+### Phase 1: PWA-Fundament (Wichtigste)
+1. **Vite PWA Plugin hinzufügen** (1-2h)
+   - `npm install vite-plugin-pwa workbox-window`
+   - Manifest.json erstellen
+   - Service Worker konfigurieren
+
+2. **Offline-Page erstellen** (2-4h)
+   - "Keine Verbindung"-UI
+   - Retry-Button mit Status-Indikator
+   - Local-Data-Anzeige
+
+3. **Install-Prompt implementieren** (1h)
+   - `beforeinstallprompt` Event
+   - Custom Install-Button
+
+### Phase 2: Bundle-Optimierung (Hoher Impact)
+1. **Code-Splitting für Features** (4-8h)
+   - `React.lazy()` für alle Routes
+   - Dynamic imports für jsPDF, i18n
+
+2. **Vite Config optimieren** (2-4h)
+   - Manual chunks konfigurieren
+   - Brotli/Gzip aktivieren
+
+3. **Asset-Optimierung** (2-4h)
+   - Bilder komprimieren (WebP)
+   - Fonts als WOFF2
+   - SVG-Icons statt PNG
+
+### Phase 3: Runtime Performance (Optional)
+1. **Virtualisierte Listen** (2-4h)
+   - `react-window` für Spieler-Listen
+   - `react-virtual` für Tabellen
+
+2. **Memoization für Heavy Components** (2-4h)
+   - `useMemo` für Berechnungen
+   - `React.memo` für Render-Optimierung
+
+3. **Web Workers für PDF-Export** (4-6h)
+   - UI blockiert nicht während Export
+
+---
+
+## 📊 Performance Score Breakdown
+
+| Metric | Score | Gewichtung | Weighted |
+|--------|-------|------------|----------|
+| **Initial Load (LCP)** | 5/10 | 25% | 1.25 |
+| **Bundle Size** | 6/10 | 20% | 1.20 |
+| **PWA Capability** | 4/10 | 25% | 1.00 |
+| **Offline Function** | 9/10 | 15% | 1.35 |
+| **Runtime Performance** | 7/10 | 15% | 1.05 |
+| **TOTAL** | | 100% | **5.85/10** |
+
+---
+
+## 🎯 Next Steps (Sofort)
+
+1. **`vite-plugin-pwa` installieren** (Priorität: 🔴 Kritisch)
+2. **Manifest.json erstellen** (Priorität: 🔴 Kritisch)
+3. **Code-Splitting für jsPDF** (Priorität: 🟠 Hoch)
+4. **Lazy Loading für Routes** (Priorität: 🟠 Hoch)
+5. **Migration-Progress-Indikator** (Priorität: 🟡 Mittel)
+
+---
+
+**Fazit:** Die Storage-Architektur ist exzellent, aber die PWA-Implementierung fehlt vollständig. Ohne Service Worker ist die App nicht als PWA nutzbar. Priorisiere PWA-Setup vor weiteren Optimierungen.

--- a/reviews/2026-05-07_2053_screens_navigation.md
+++ b/reviews/2026-05-07_2053_screens_navigation.md
@@ -1,0 +1,201 @@
+# Code Review: Screens, Routing & Navigation
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 169.7s  
+**Status:** success  
+**Code-Kontext:** 150,737 Zeichen  
+
+<details><summary>Thinking Process (5,981 Zeichen)</summary>
+
+Der Nutzer möchte eine detaillierte Analyse der React Router-Struktur und UX basierend auf den bereitgestellten Code-Snippets.
+Ich muss die Screens, Routing-Logik und Navigation durchgehen und bewerten.
+
+**Analyse der Screens:**
+
+1.  **DashboardScreen**:
+    *   **Navigation**: Hat Tabs (Turniere, Archiv, Papierkorb). `getTabFromPath(location.pathname)` wird verwendet, um den aktiven Tab basierend auf der URL zu bestimmen. Das ist gut für Deep-Linking.
+    *   **Auth**: `AuthSection` ist eingebunden.
+    *   **Probleme**: Keine expliziten Route Guards sichtbar (z.B. `ProtectedRoute` Wrapper), aber `useTournamentLimit` prüft Limits. Die Navigation zwischen Tabs scheint client-seitig über State (`activeTab`) und URL-Sync zu laufen.
+
+2.  **DatenschutzScreen / ImpressumScreen**:
+    *   **Layout**: Nutzen `LegalPageLayout` mit `onBack`.
+    *   **Routing**: Werden wahrscheinlich statisch geroutet. `onBack` ist ein Prop, was auf eine manuelle History-Navigation hindeutet (`window.history.back()` oder `navigate(-1)`).
+    *   **Accessibility**: `onBack` Button ist gut.
+
+3.  **LiveViewScreen / PublicTournamentViewScreen**:
+    *   **Deep Linking**: `useSearchParams` für Filter (`g`, `p`, `s`, `tab`, `my`). Sehr gut für teilbare Ansichten.
+    *   **Share Code**: `shareCode` als URL-Parameter oder Pfadsegment.
+    *   **Offline**: Fallback auf LocalStorage.
+    *   **Probleme**: `LiveViewScreen` und `PublicTournamentViewScreen` scheinen fast identische Funktionalität zu haben (Public View). Mögliche Redundanz. `LiveViewScreen` hat `shareCode`, `PublicTournamentViewScreen` hat `tournamentId`. Die Logik für "Public View" ist dupliziert (Filter, Privacy Settings).
+
+4.  **TournamentCreationScreen**:
+    *   **Wizard**: `useTournamentWizard` Hook.
+    *   **Routing**: `buildWizardStepPath` für URL-Sync der Schritte.
+    *   **Auto-Save**: Periodisch und auf `beforeunload`.
+    *   **Lazy Loading**: Steps werden lazy geladen. Gut für Performance.
+    *   **Probleme**: `existingTournament?.lastVisitedStep` Logik beim Sync. Wenn ein User den Wizard verlässt und zurückkommt, sollte er am gleichen Schritt sein. Das wird adressiert, aber `navigate` mit `replace: true` verhindert History-Bloat.
+
+5.  **TournamentManagementScreen**:
+    *   **Tabs**: `ScheduleTab`, `ManagementTab`, etc.
+    *   **Routing**: `buildTournamentTabPath` für URL-Sync der Tabs.
+    *   **Dirty State**: `isSettingsDirty` Warnung beim Tab-Wechsel. Sehr gut für UX.
+    *   **Deep Linking**: `matchId` als Query-Param für Cockpit.
+    *   **Probleme**: `initialMatchId` State wird verwendet, aber die Navigation zum Cockpit passiert über `navigate` mit Query-Param. Das ist konsistent.
+
+6.  **SettingsScreen**:
+    *   **Lazy Load**: Wird lazy geladen (`lazy(() => import(...))`).
+    *   **Navigation**: `onBack` Prop.
+    *   **Settings**: Persistiert in LocalStorage.
+
+**Routing-Struktur (Implizit):**
+*   `/` -> Dashboard
+*   `/tournament/:id` -> TournamentManagementScreen (Tabs via Sub-Routes oder Query Params?) -> Code zeigt `buildTournamentTabPath` und `getTabFromPath` basierend auf `location.pathname`. Vermutlich `/tournament/:id/schedule`, `/tournament/:id/management`, etc.
+*   `/tournament/create` -> TournamentCreationScreen
+*   `/tournament/edit/:id` -> TournamentCreationScreen (mit `existingTournament`)
+*   `/live/:shareCode` -> LiveViewScreen
+*   `/privacy`, `/imprint` -> Legal Screens
+*   `/settings` -> SettingsScreen
+
+**UX-Probleme:**
+1.  **Redundanz**: `LiveViewScreen` vs `PublicTournamentViewScreen`. Beide tun fast das Gleiche (Public View, Privacy Filters). `LiveViewScreen` nutzt `shareCode`, `PublicTournamentViewScreen` nutzt `tournamentId`. Das sollte vereinheitlicht werden.
+2.  **Navigation Guards**: Keine sichtbaren `ProtectedRoute` Komponenten im Code. Auth-Checks scheinen in den Screens selbst zu passieren (`AuthSection`, `useTournamentLimit`). Besser wäre ein Wrapper.
+3.  **Back-Button**: `onBack` Props sind überall. Das erfordert, dass der Parent die History-Logik kennt. Besser wäre ein `useNavigate` Hook in den Screens selbst, wenn möglich, oder ein globaler Back-Handler.
+4.  **404 Handling**: Nicht im Code sichtbar, aber kritisch für Routing.
+5.  **Loading States**: `TournamentManagementScreen` hat Loading/Error States. `DashboardScreen` hat keine expliziten Loading States für die Initialisierung (vermutlich Props).
+6.  **Mobile Navigation**: `TournamentManagementScreen` hat `BottomNavigation`. `DashboardScreen` hat `DashboardNav`. Konsistenz prüfen.
+
+**Positive Patterns:**
+1.  **URL-Sync**: Fast alle Tabs und Steps synchronisieren ihren State mit der URL (Query Params oder Path Segments). Das ermöglicht Deep Linking und "Back"-Button-Unterstützung.
+2.  **Lazy Loading**: Wizard Steps und Settings Screen werden lazy geladen.
+3.  **Dirty State**: Warnung bei ungespeicherten Änderungen im Settings Tab.
+4.  **Offline Support**: `LiveViewScreen` nutzt LocalStorage Fallback.
+5.  **Accessibility**: `aria-label`, `role` Attribute in `LegalPageLayout` und `SettingItem`.
+
+**Bewertung:**
+*   **Routing Score**: 8/10. Gute URL-Sync, Lazy Loading. Aber Redundanz bei Public Screens und fehlende zentrale Auth Guards.
+*   **Navigation UX**: 9/10. Back-Button funktioniert durch URL-Sync. Dirty-State Warnungen sind exzellent.
+*   **Deep Linking**: 9/10. Fast alles ist tief verlinkbar (Tabs, Steps, Filter).
+
+**Zusammenfassung der Kritikpunkte:**
+1.  **Redundanz**: `LiveViewScreen` vs `PublicTournamentViewScreen`.
+2.  **Auth Guards**: Fehlende zentrale Route Guards.
+3.  **404**: Nicht implementiert/sichtbar.
+4.  **Navigation**: `onBack` Props sind "Prop Drilling" für Navigation. Besser: `useNavigate` in Child Screens nutzen.
+5.  **Error Boundaries**: `TournamentCreationScreen` hat `ErrorBoundary`, aber nicht alle Screens.
+
+**Struktur des Reviews:**
+1.  Routing-Probleme
+2.  Navigation-UX-Probleme
+3.  Deep-Link-Lücken
+4.  Positive Patterns
+5.  Navigation Score
+
+Ich werde das Review auf Deutsch verfassen, wie angefordert.
+
+
+</details>
+
+---
+
+
+
+Hier ist das strukturierte Review basierend auf dem bereitgestellten Code.
+
+# 📱 React Router & UX Review: hallenfussball-pwa
+
+## 1. Routing-Probleme
+
+### 🔴 Fehlende zentrale Route Guards
+**Status:** Kritisch
+**Problem:** Es gibt keine zentrale `ProtectedRoute`-Komponente im Code. Auth-Checks und Limits werden in den Screens selbst gehandhabt (z.B. `useTournamentLimit` im Dashboard, `onNavigateToLogin` Props).
+**Risiko:** Ein User kann per URL direkt zu `/tournament/:id/management` navigieren, ohne eingeloggt zu sein. Die Auth-Logik ist über die Screens verstreut und schwer zu warten.
+**Lösung:** Erstelle einen `ProtectedRoute` Wrapper in `src/components/routing/ProtectedRoute.tsx`.
+```tsx
+// Beispiel
+const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  return children;
+};
+```
+
+### 🟠 Redundante Public Screens
+**Status:** Mittel
+**Problem:** `LiveViewScreen` und `PublicTournamentViewScreen` haben fast identische Logik (Laden, Privacy-Filter, Schedule-Anzeige). `LiveViewScreen` nutzt `shareCode`, `PublicTournamentViewScreen` nutzt `tournamentId`.
+**Risiko:** Wartungsaufwand verdoppelt, Inkonsistenzen bei Bugfixes.
+**Lösung:** Vereine beide zu einem `PublicTournamentScreen`, der beide ID-Formate (UUID oder Share-Code) akzeptiert.
+
+### 🟠 Fehlendes 404-Handling
+**Status:** Mittel
+**Problem:** Kein `*` Catch-All Route für unbekannte URLs sichtbar.
+**Risiko:** User landen auf einer leeren Seite bei Tippfehlern.
+**Lösung:** Füge `<Route path="*" element={<NotFoundScreen />} />` am Ende der Route-Liste hinzu.
+
+## 2. Navigation-UX-Probleme
+
+### 🟠 "Prop Drilling" für Navigation
+**Status:** Mittel
+**Problem:** Fast jeder Screen (Legal, Dashboard, TournamentManagement) bekommt `onBack` als Prop. Das erzwingt eine starre Parent-Child-Hierarchie für die Navigation.
+**Risiko:** Wenn ein Screen später in einem Modal oder einem anderen Kontext genutzt wird, bricht die Navigation.
+**Lösung:** Nutze `useNavigate()` direkt in den Screens, wo immer möglich. `onBack` sollte nur für spezielle Fälle (z.B. Wizard-Abbruch) übrig bleiben.
+
+### 🟡 Inkonsequente Mobile-Navigation
+**Status:** Klein
+**Problem:** `TournamentManagementScreen` nutzt ein `BottomNavigation` (Tab-Bar), `DashboardScreen` nutzt `DashboardNav` (Tabs im Content).
+**Risiko:** Nutzererwartung auf Mobile wird nicht ganz konsistent erfüllt (Bottom Bar vs. Top Tabs).
+**Lösung:** Prüfe, ob `DashboardScreen` auch eine Bottom Tab Bar für Mobile erhalten sollte, um Konsistenz mit dem Management Screen zu gewährleisten.
+
+### 🟡 History-Stack bei Wizard
+**Status:** Klein
+**Problem:** Im `TournamentCreationScreen` wird `navigate(..., { replace: true })` genutzt. Das ist gut für Performance, verhindert aber, dass der Browser-Back-Button den Wizard Schritt für Schritt zurückspult.
+**Risiko:** User fühlen sich "gefangen", wenn sie versehentlich einen Schritt weitergehen.
+**Lösung:** Nutze `replace: true` nur, wenn der Schritt nicht relevant für die History ist. Alternativ: Ein "Schritt-zurück"-Button im Wizard selbst anbieten.
+
+## 3. Deep-Link-Lücken
+
+### ✅ Starke Punkte
+*   **Wizard Steps:** `/create?step=3` funktioniert durch `getStepFromSearchParams`.
+*   **Tournament Tabs:** `/tournament/:id/schedule` wird durch `getTabFromPath` gelöst.
+*   **Live Filters:** `?g=1&p=groupStage` in `LiveViewScreen` sind exzellent für teilbare Ansichten.
+
+### 🔴 Fehlende Deep Links
+*   **Settings:** Es gibt keine URL für Einstellungen (z.B. `/settings/theme`). Das erfordert `onBack` und verhindert, dass man Einstellungen direkt teilen kann.
+*   **Legal Pages:** Datenschutz/Impressum sind statisch. `/privacy` URL sollte direkt funktionieren (nicht nur via Link im Footer).
+
+## 4. Positive Patterns
+
+### 🟢 Exzellentes URL-Syncing
+Fast alle komplexen UI-States (Tabs, Wizard Steps, Filter) werden mit der URL synchronisiert.
+*   **Code:** `updateUrlParams` in `LiveViewScreen`.
+*   **Vorteil:** Bookmarks funktionieren, Browser-Back-Button ist vorhersagbar, Sharing ist möglich.
+
+### 🟢 Dirty-State-Warnung
+*   **Code:** `TournamentManagementScreen` -> `handleTabChange` mit `isSettingsDirty`.
+*   **Vorteil:** Verhindert Datenverlust, wenn User Settings ändern und dann den Tab wechseln. Sehr UX-freundlich.
+
+### 🟢 Lazy Loading für Performance
+*   **Code:** `TournamentCreationScreen` (Wizard Steps), `SettingsScreen`.
+*   **Vorteil:** Initial Bundle Size bleibt klein, nur benötigte Komponenten werden geladen.
+
+### 🟢 Accessibility (A11y)
+*   **Code:** `LegalPageLayout` nutzt `aria-label` für Back-Button, `role="radiogroup"` in `BaseThemeSelector`.
+*   **Vorteil:** Screenreader-kompatibel, Tastaturnavigation unterstützt.
+
+## 5. Navigation Score
+
+| Kategorie | Score | Kommentar |
+| :--- | :--- | :--- |
+| **Routing-Struktur** | 8/10 | Gute URL-Syncing, aber fehlende Guards und Redundanz. |
+| **Navigation UX** | 9/10 | Dirty-States und URL-Sync sind hervorragend. |
+| **Deep Linking** | 9/10 | Fast alle wichtigen Views sind tief verlinkbar. |
+| **Mobile Experience** | 8/10 | Bottom Nav ist gut, aber Inkonsistenzen zwischen Screens. |
+| **Zustand & History** | 7/10 | `replace: true` im Wizard kann verwirrend sein. |
+| **Gesamt** | **8.2/10** | **Starkes Fundament, braucht zentrale Auth-Logik.** |
+
+## 🛠 Empfohlene Sofortmaßnahmen
+
+1.  **Auth Guards:** Erstelle `ProtectedRoute` und umschließe alle geschützten Routen (`/tournament/:id/*`, `/create`).
+2.  **Public View Vereinen:** Refaktorisiere `LiveViewScreen` und `PublicTournamentViewScreen` zu einer einzigen Komponente.
+3.  **404 Screen:** Implementiere einen Fehler-Screen für unbekannte Routen.
+4.  **Navigation Hooks:** Ersetze `onBack` Props durch `useNavigate()` in den Screens, wo es sinnvoll ist.
+5.  **Settings URL:** Erweitere das Routing, um `/settings` direkt aufrufbar zu machen.

--- a/reviews/2026-05-07_2053_supabase_data.md
+++ b/reviews/2026-05-07_2053_supabase_data.md
@@ -1,0 +1,161 @@
+# Code Review: Supabase, Datenbank & Sync
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 175.9s  
+**Status:** success  
+**Code-Kontext:** 150,340 Zeichen  
+
+<details><summary>Thinking Process (4,850 Zeichen)</summary>
+
+Der Benutzer bittet um eine strukturierte Analyse der Supabase/PostgreSQL-Architektur, Auth und Realtime-Integration für das Projekt "hallenfussball-pwa". Ich habe den Code (Migrations, Edge Functions, Repository-Implementierungen) analysiert.
+
+**Zusammenfassung der Analyse:**
+
+1.  **Database Schema & Migrations:**
+    *   **RLS (Row Level Security):** Sehr detailliert. Es gab eine Evolution von einfachen Policies (`public read`) zu komplexeren (`owner_id`, `is_public`, `collaborator`). Die Denormalisierung von `owner_id` und `is_public` auf Kind-Tabellen (`teams`, `matches`, etc.) ist ein starkes Optimierungs-Pattern für RLS-Performance.
+    *   **Optimistic Locking:** `version` Spalten auf kritischen Tabellen (`matches`, `teams`, `match_events`) mit Triggers. Dies ist entscheidend für Live-Cockpits.
+    *   **Foreign Keys & Indexes:** Gute Praxis mit `idx_` Indexen für FKs, um JOIN-Performance zu sichern.
+    *   **Edge Functions:** `merge-accounts` und `validate-registration-code` sind sauber implementiert (Auth-Check, Admin-API Nutzung).
+    *   **Denormalisierung:** `20260121_002_denormalize_owner.sql` ist ein Highlight. Es vermeidet teure `EXISTS` Subqueries in RLS Policies.
+
+2.  **Auth & Security:**
+    *   **Anonym vs. Auth:** Gut durchdacht. `is_anonymous_user()` Funktion in SQL. Limitierung auf 3 Turniere für Anonyme.
+    *   **Merge:** Edge Function `merge-accounts` nutzt eine atomare SQL-Funktion `merge_user_data`. Sehr sicher.
+    *   **RLS Lücken:** Es gibt eine kritische Lücke in `20260128_002_consolidate_rls_v3.sql`. Die `tournament_collaborators` Policy nutzt `user_owns_tournament`, die `auth.uid()` nutzt. Aber `tournament_collaborators` selbst hat auch `user_id`. Die Logik `user_id = (SELECT auth.uid())` ist in Ordnung, aber die Kombination mit `invite_email` könnte Probleme machen, wenn `auth.email()` nicht gesetzt ist (z.B. bei Anonym-Usern, die eingeladen werden - das ist aber ein Edge Case).
+    *   **Public Access:** `is_public` Logik ist konsistent.
+
+3.  **Realtime & Sync:**
+    *   **Repositories:** `HybridRepository`, `OfflineRepository`, `SupabaseLiveMatchRepository`.
+    *   **Live Match:** `SupabaseLiveMatchRepository` nutzt `live_state` JSONB und `match_events`.
+    *   **Optimistic Locking im Repo:** `SupabaseLiveMatchRepository.save` nutzt `.eq('version', match.version)`. Das ist korrekt implementiert (CAS).
+    *   **Offline-First:** `OfflineRepository` queue-mechanismus. `HybridRepository` blendet LocalStorage und Cloud.
+    *   **Stale Data:** `LocalStorageLiveMatchRepository` hat Logik für `recoverStaleMatch` (Timer-Reset bei Browser-Crash). Das ist sehr gut für UX.
+    *   **Locking:** `Web Locks API` in `LocalStorageLiveMatchRepository` verhindert Race Conditions im Browser.
+
+4.  **Kritische Punkte (Issues):**
+    *   **RLS Recursion:** In `20260128_002_consolidate_rls_v3.sql` wird `user_owns_tournament` verwendet, um Recursion zu vermeiden. Das ist gut, aber `tournament_collaborators` Policy prüft `user_id = auth.uid()`. Wenn ein User `anon` ist, ist `auth.uid()` null. Das könnte Probleme machen, wenn Anonyme User eingeladen werden (was wahrscheinlich nicht der Fall ist, aber `is_anonymous_user()` Funktion existiert).
+    *   **Denormalization Sync:** Die Trigger `sync_owner_from_tournament` und `cascade_tournament_visibility` sind komplex. Wenn ein `tournament_id` geändert wird (was selten ist), müssen die Trigger korrekt feuern. `ON UPDATE` Trigger auf `tournaments` für `is_public` sind da.
+    *   **Version Mismatch:** In `SupabaseLiveMatchRepository.save` wird ein Retry für `not_started` Matches gemacht. Das ist clever, aber wenn der Status `running` ist, wird eine `OptimisticLockError` geworfen. Das muss im UI gehandled werden (Retry UI).
+    *   **Migration Order:** `002_denormalize_owner` fügt Spalten hinzu. `003_backfill_owner` füllt sie. `004_optimized_rls` nutzt sie. Wenn jemand `004` vor `003` ausführt, bricht es (NULL `owner_id`). Die Kommentare sagen "Requires: 002 and 003 completed first". Das muss strikt eingehalten werden.
+    *   **Storage Quota:** `LocalStorageLiveMatchRepository` hat `QuotaExceededError` Handling. Gut.
+    *   **Search Path:** `20260128_003_fix_function_search_path.sql` setzt `search_path`. Das ist wichtig für Security (SQL Injection via Search Path).
+
+5.  **Score:**
+    *   Sehr starkes Konzept.
+    *   RLS ist komplex aber durchdacht.
+    *   Offline-First Strategie ist solide.
+    *   Live-Sync mit Versionierung ist gut.
+    *   Punktabzug für Komplexität (Potential für Bugs in Triggers/RLS) und fehlende Tests für RLS Policies.
+
+**Struktur des Reviews:**
+1.  Kritische DB/Auth-Probleme (RLS, Migrations).
+2.  Sync-Probleme (Konflikte, Offline).
+3.  Optimierungspotenzial (Queries, Indexes).
+4.  Positive Patterns.
+5.  Score.
+
+Ich werde die Analyse jetzt in das geforderte Format bringen.
+
+
+</details>
+
+---
+
+
+
+Hier ist das strukturierte Review der Supabase/PostgreSQL-Architektur für das **hallenfussball-pwa** Projekt.
+
+### 1. Kritische DB/Auth-Probleme
+
+**🔴 RLS Recursion & Performance in `tournament_collaborators`**
+*   **Problem:** In `20260128_002_consolidate_rls_v3.sql` wird `user_owns_tournament()` als `SECURITY DEFINER` Funktion genutzt, um RLS-Recursion zu vermeiden (da `tournaments_select_v3` auf `collaborators` zugreift und umgekehrt).
+*   **Risiko:** Wenn die Funktion `user_owns_tournament` selbst RLS auf `tournaments` auslösen würde (was sie durch `SECURITY DEFINER` umgeht), käme es zu einem Stack-Overflow.
+*   **Empfehlung:** Stelle sicher, dass `user_owns_tournament` **keine** RLS-Checks auf `tournaments` ausführt (z.B. durch explizites `SET search_path` oder Nutzung von `pg_temp`), oder füge einen expliziten Test hinzu, der eine rekursive Abfrage simuliert.
+*   **Anonym-User:** Die Funktion `is_anonymous_user()` prüft `auth.jwt()`. Wenn ein Anonymer User eingeladen wird (z.B. via Link), ist `auth.uid()` null. Die RLS-Policy `collaborators_select_v3` prüft `user_id = (SELECT auth.uid())`. Das funktioniert für Anonyme, die sich *einloggen*, aber nicht für *unauthentifizierte* Einladungen. Das ist wahrscheinlich gewollt (Einladungen nur für Auth-User), sollte aber dokumentiert sein.
+
+**🟡 Migration Order Dependency (Critical)**
+*   **Problem:** Die Migrationen `002_denormalize_owner`, `003_backfill_owner` und `004_optimized_rls` sind strikt sequenziell abhängig.
+*   **Risiko:** Wenn `004` auf einer Datenbank läuft, die `003` nicht ausgeführt hat, haben die `owner_id` Spalten in Kind-Tabellen NULL-Werte. Die RLS-Policy `owner_id = auth.uid()` würde dann **niemanden** erlauben (da `NULL != UUID`).
+*   **Empfehlung:** Füge in Migration `004` einen `ASSERT` oder eine Prüfung hinzu, die abbricht, wenn `owner_id` noch NULL ist, bevor die Policies erstellt werden.
+    ```sql
+    -- Beispiel für Safety-Check in Migration 004
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM matches WHERE owner_id IS NULL) THEN
+        RAISE EXCEPTION 'Migration 003 (Backfill) not completed. owner_id is NULL in matches table.';
+      END IF;
+    END $$;
+    ```
+
+**🟡 `is_public` Denormalisierung**
+*   **Problem:** Die `is_public` Spalte wird auf Kind-Tabellen (`teams`, `matches`) denormalisiert und via Trigger (`cascade_tournament_visibility`) synchronisiert.
+*   **Risiko:** Wenn ein `tournament` gelöscht wird (`ON DELETE CASCADE`), werden die Kinder gelöscht. Der Trigger feuert nicht. Das ist in Ordnung. Aber wenn ein `tournament` **deaktiviert** wird (Soft Delete), müssen die Trigger auch `is_public = false` setzen.
+*   **Empfehlung:** Erweitere `cascade_tournament_visibility` um den Fall `OLD.status != NEW.status` (falls Soft Delete über Status läuft), oder stelle sicher, dass `is_public` explizit beim Soft Delete gesetzt wird.
+
+### 2. Sync-Probleme (Konflikte, Datenverlust)
+
+**🟢 Offline-First Strategie (Stark)**
+*   **Positiv:** `OfflineRepository` und `HybridRepository` trennen klar zwischen "Local First" (Sofortige UI) und "Cloud Sync" (Hintergrund).
+*   **Positiv:** `MutationQueue` persistiert Änderungen lokal, auch wenn das Gerät offline ist.
+*   **Risiko:** Bei `save()` wird `localRepo.save()` zuerst ausgeführt. Wenn der Cloud-Upload später fehlschlägt (z.B. Token abgelaufen), bleibt die lokale Version "frischer" als die Cloud.
+*   **Empfehlung:** Implementiere ein "Sync Status" Flag auf dem lokalen Objekt (z.B. `syncStatus: 'pending' | 'synced' | 'error'`), damit das UI dem User anzeigen kann, ob Änderungen wirklich in der Cloud sind.
+
+**🟡 Optimistic Locking im Live-Cockpit**
+*   **Positiv:** `SupabaseLiveMatchRepository` nutzt `.eq('version', match.version)` für CAS (Compare-And-Swap).
+*   **Problem:** Wenn zwei Trainer gleichzeitig ein Tor eintragen, wird einer mit `OptimisticLockError` abgewiesen.
+*   **Risiko:** Das UI muss diesen Fehler fangen und einen **Retry-Mechanismus** haben (aktuelle Version laden, Merge, erneut speichern). Aktuell wirft der Code die Exception (`throw new OptimisticLockError`), aber es ist unklar, ob das UI das robust handhabt (z.B. bei schnellem Tippen).
+*   **Empfehlung:** Füge im UI (z.B. in `LiveMatchView`) ein `useRetry` Hook hinzu, das bei `OptimisticLockError` automatisch den Refresh- und Retry-Flow triggert.
+
+**🟡 Stale Match Recovery**
+*   **Positiv:** `LocalStorageLiveMatchRepository.recoverStaleMatch()` erkennt Matches, die nach 30 Min. noch "RUNNING" sind (Browser-Crash), und setzt sie auf "PAUSED".
+*   **Risiko:** Wenn der Browser-Crash passiert, während der Timer läuft, wird die Zeit "verloren" (auf `maxElapsed` geklemmt). Das ist akzeptabel, aber nicht perfekt.
+*   **Empfehlung:** Speichere `timerStartTime` und `timerPausedAt` auch in der DB (`live_state` JSONB), damit der Server den Stale-Check auch für Remote-User machen kann (nicht nur lokal).
+
+### 3. Optimierungspotenzial
+
+**🔵 RLS Performance (Indexierung)**
+*   **Status:** `20260121_002_denormalize_owner.sql` hat Indizes für `owner_id` und `is_public` erstellt. Das ist exzellent.
+*   **Verbesserung:** Die `EXISTS` Subqueries in `teams_select_v3` (für `tournament_collaborators`) können teuer werden, wenn ein User an **vielen** Turnieren mitwirkt (z.B. 100+).
+*   **Empfehlung:** Erstelle einen Index auf `tournament_collaborators(user_id, accepted_at IS NOT NULL)`.
+    ```sql
+    CREATE INDEX IF NOT EXISTS idx_collaborators_user_active 
+    ON tournament_collaborators(user_id) 
+    WHERE accepted_at IS NOT NULL;
+    ```
+
+**🔵 Realtime Subscriptions**
+*   **Status:** `SupabaseLiveMatchRepository` nutzt Realtime für `matches` und `match_events`.
+*   **Verbesserung:** Wenn viele Matches gleichzeitig laufen, können viele Channels offen sein.
+*   **Empfehlung:** Nutze **Broadcast** Channels für den Timer (nur Status-Updates) und **Presence** Channels für "Wer ist gerade im Cockpit?", statt alles über DB-Realtime zu lösen. Das reduziert die DB-Last.
+
+**🔵 Edge Function Performance**
+*   **Status:** `merge-accounts` Edge Function ist gut.
+*   **Verbesserung:** Die Funktion `merge_user_data` nutzt `ARRAY_AGG` für `v_tournament_ids`. Bei sehr großen Turnieren (1000+ Teams) kann das Speicher-Overhead haben.
+*   **Empfehlung:** Wenn das Limit von 3 Turnieren für Anonyme gilt, ist das kein Problem. Für Admins (die alles mergen können) sollte man prüfen, ob `ARRAY_AGG` bei >10k Zeilen skaliert. Besser: Iteratives Update in Schleifen (Batch Processing).
+
+### 4. Positive Patterns
+
+1.  **Denormalisierung für RLS:** Das Pattern, `owner_id` und `is_public` auf Kind-Tabellen zu kopieren (`002_denormalize_owner`), ist **Goldstandard** für Supabase. Es eliminiert teure JOINs in RLS Policies und macht die Sicherheit skalierbar.
+2.  **Versionierung (Optimistic Locking):** Die `version` Spalte auf `matches` und `teams` mit automatischem Trigger-Update ist die beste Praxis für Concurrent Editing.
+3.  **Edge Functions für Auth-Logik:** `merge-accounts` und `validate-registration-code` kapseln sensible Logik sicher vom Client fern (keine Secrets im Bundle).
+4.  **Local Storage Cleanup:** `LocalStorageLiveMatchRepository.cleanupOldMatches()` verhindert, dass der Browser-Speicher voll läuft. Sehr wichtig für PWAs.
+5.  **Web Locks API:** Nutzung von `navigator.locks` in `LocalStorageLiveMatchRepository` verhindert Race Conditions bei Multi-Tab-Nutzung (z.B. zwei Tabs mit demselben Turnier).
+6.  **Migration Safety:** `IF NOT EXISTS` und `DROP IF EXISTS` in allen Migrations machen sie idempotent und sicher für wiederholte Ausführung.
+
+### 5. Supabase Score
+
+**Score: 8.5 / 10**
+
+**Begründung:**
+*   **Architektur (9/10):** Die Trennung von Offline/Online, die Denormalisierung für RLS und die Versionierung sind hervorragend durchdacht.
+*   **Sicherheit (8/10):** RLS ist komplex aber robust. Die `SECURITY DEFINER` Funktionen sind gut geschützt. Ein kleiner Punkt für die `tournament_collaborators` Recursion.
+*   **Performance (8/10):** Indexe sind da, aber `EXISTS` Subqueries in RLS können bei großen Datenmengen (viele Kollaboratoren) langsam werden.
+*   **UX (9/10):** Offline-First, Stale-Recovery und Web Locks sorgen für eine sehr flüssige Nutzererfahrung.
+
+**Nächste Schritte (Priorität):**
+1.  **RLS Testing:** Füge Unit-Tests hinzu, die prüfen, ob ein User A *nicht* auf die Daten von User B zugreifen kann, selbst wenn er die IDs kennt.
+2.  **Migration Safety:** Füge den `ASSERT` Check in Migration `004` ein, um NULL `owner_id` zu verhindern.
+3.  **UI Retry:** Stelle sicher, dass `OptimisticLockError` im UI sauber behandelt wird (Auto-Retry).
+4.  **Indexierung:** Erstelle den Index `idx_collaborators_user_active` für Performance bei vielen Kollaboratoren.
+
+Das ist ein sehr professionell aufgebautes System für eine PWA mit Multi-User-Kollaboration. Die Architektur ist skalierbar und sicher.

--- a/reviews/2026-05-07_2053_testing.md
+++ b/reviews/2026-05-07_2053_testing.md
@@ -1,0 +1,302 @@
+# Code Review: Testing & Qualitaetssicherung
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 120.8s  
+**Status:** success  
+**Code-Kontext:** 99,118 Zeichen  
+
+<details><summary>Thinking Process (2,331 Zeichen)</summary>
+
+Der User möchte eine umfassende Analyse der Test-Strategie für das Projekt "hallenfussball-pwa". Ich habe den Code-Review-Input analysiert und muss nun ein strukturiertes Testing-Report erstellen, das folgende Bereiche abdeckt:
+
+1. **Testlücken** - Welche kritischen Pfade sind ungetestet?
+2. **Test-Qualitätsprobleme** - Fragile Tests, schlechte Assertions, etc.
+3. **Fehlende Test-Typen** - Was fehlt komplett?
+4. **Empfehlungen** - Priorisierte Handlungsempfehlungen
+5. **Testing Score** - Eine Bewertung von 1-10
+
+Aus dem bereitgestellten Code kann ich folgende Beobachtungen machen:
+
+**Was gut ist:**
+- Vitest wird verwendet (modern, schnell)
+- Test-Factories sind vorhanden (createMockTournament, createMockTeam, etc.)
+- Test-Setup ist solide (i18next Mocking, localStorage Mocking, etc.)
+- Unit-Tests für Kern-Logik existieren (calculations, scheduleGenerator, playoffResolver, teamDisplayNames)
+- Design-Token-Sync-Tests sind vorhanden (sehr gut für Design-System-Konsistenz)
+- Test-Utils sind vorhanden (customRender, userEvent)
+- Edge Cases werden teilweise getestet (0 Teams, 1 Team, 13 Teams, etc.)
+
+**Was fehlt oder problematisch ist:**
+1. **Keine E2E-Tests** - Playwright oder Cypress fehlt komplett
+2. **Keine Accessibility-Tests** - Keine a11y-Tests sichtbar
+3. **Keine Performance-Tests** - Nur ein Performance-Baseline-Test im Scheduler
+4. **Keine Integration-Tests** - Supabase-Integration nicht getestet
+5. **Keine PWA-spezifische Tests** - Service Worker, Offline-Mode, Install-Flow
+
+
+6. **Mocking-Strategie** - i18next und Supabase sind gemockt, aber die Mocks könnten zu stark vereinfacht sein
+7. **Test-Daten** - MockTournament ist umfangreich, aber nicht alle Szenarien sind abgedeckt
+8. **Snapshot-Tests** - Keine Snapshot-Tests sichtbar
+9. **CI/CD-Integration** - Nicht sichtbar im Code
+10. **Flaky Tests** - Keine Behandlung von Race Conditions oder Timing-Problemen sichtbar
+11. **Realtime-Tests** - Supabase Realtime wird nicht getestet
+12. **PDF-Export-Tests** - jsPDF-Integration nicht getestet
+13. **Auth-Flow-Tests** - Supabase Auth nicht getestet
+14. **Error-Handling-Tests** - Fehlerfälle nicht umfassend getestet
+15. **Boundary-Tests** - Nicht alle Grenzfälle sind abgedeckt
+
+Ich muss jetzt ein strukturiertes Report erstellen, das diese Lücken klar benennt und priorisierte Empfehlungen gibt.
+
+
+</details>
+
+---
+
+
+
+# 📊 Testing-Strategie Analyse: hallenfussball-pwa
+
+## Executive Summary
+
+Das Projekt zeigt **starke Unit-Test-Abdeckung** für Kern-Logik (Schedule-Generierung, Tabellenberechnung, Playoffs), aber **kritische Lücken** in E2E-, Integration- und PWA-spezifischen Tests. Die Test-Infrastruktur ist solide aufgebaut (Vitest, Factories, Mocking), aber nicht vollständig für Produktions-Ready-Qualität.
+
+---
+
+## 1. Testlücken (Ungetestete Kritische Pfade)
+
+| Bereich | Lücke | Risiko |
+|---------|-------|--------|
+| **E2E-Tests** | ❌ Keine Playwright/Cypress Tests | Benutzer-Flows nicht validiert |
+| **Supabase Integration** | ❌ Auth, DB, Realtime nur gemockt | Live-System kann anders funktionieren |
+| **PWA-Features** | ❌ Service Worker, Offline-Mode, Install-Flow | Kern-PWA-Features ungetestet |
+| **PDF-Export** | ❌ jsPDF-Integration nicht getestet | Export-Funktion kritisch für Turnier-Verwaltung |
+| **Realtime-Konflikte** | ❌ Gleichzeitige Updates, Race Conditions | Datenkorruption möglich |
+| **Auth-Flow** | ❌ Login, Session, Permission-Checks | Sicherheitsrisiko |
+| **Error-Handling** | ⚠️ Nur teilweise getestet | Fehlerzustände nicht robust |
+| **Mobile Responsiveness** | ❌ Keine Viewport-Tests | PWA auf Mobile nicht validiert |
+
+---
+
+## 2. Test-Qualitätsprobleme
+
+### 2.1 Fragile Tests
+
+```ts
+// ❌ Problem: Time-based assertions können flaky sein
+expect(match8?.scheduledTime).toContain('09:54:00');
+
+// ✅ Besser: Relative Zeitberechnung prüfen
+const expectedTime = new Date('2026-01-10T09:54:00.000Z');
+expect(new Date(match8.scheduledTime).getTime())
+  .toBeCloseTo(expectedTime.getTime(), -3);
+```
+
+### 2.2 Zu starke Mocking
+
+```ts
+// ❌ i18next Mock zu simpel - Interpolationen nicht vollständig
+vi.mock('i18next', () => ({
+  t: (key: string, opts?: Record<string, unknown>) => String(key)
+}))
+
+// ✅ Besser: Echte i18next-Instanz mit Test-Namespaces
+import i18next from 'i18next';
+await i18next.init({ lng: 'de', resources: { de: { translation: {} } } });
+```
+
+### 2.3 Schwache Assertions
+
+```ts
+// ❌ Zu allgemein
+expect(standings.length).toBe(3);
+
+// ✅ Besser: Spezifischer
+expect(standings[0].team.name).toBe('Team 1');
+expect(standings[0].points).toBe(6);
+expect(standings[0].goalDifference).toBe(2);
+```
+
+### 2.4 Fehlende Cleanup-Strategien
+
+```ts
+// ⚠️ localStorage Mock wird nicht zwischen Tests zurückgesetzt
+// Kann zu State-Lecks führen
+afterEach(() => {
+  cleanup();
+  // localStorageMock.clear(); // FEHLT!
+});
+```
+
+### 2.5 Performance-Tests mit zu großzügigen Timeouts
+
+```ts
+// ❌ 60s Timeout für 64 Teams ist zu großzügig (O(n²) Algorithmus)
+// ✅ Besser: Performance-Baseline mit Alert bei Regression
+expect(duration).toBeLessThan(5000); // 5s realistischer
+```
+
+---
+
+## 3. Fehlende Test-Typen
+
+| Test-Typ | Status | Priorität |
+|----------|--------|-----------|
+| **E2E Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Integration Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Accessibility Tests** | ❌ Fehlend | 🟡 Mittel |
+| **Performance Tests** | ⚠️ Teilweise | 🟡 Mittel |
+| **Security Tests** | ❌ Fehlend | 🔴 Hoch |
+| **Visual Regression** | ❌ Fehlend | 🟢 Niedrig |
+| **Load Tests** | ❌ Fehlend | 🟢 Niedrig |
+| **Contract Tests** | ❌ Fehlend | 🟡 Mittel |
+
+---
+
+## 4. Priorisierte Empfehlungen
+
+### 🔴 **P1 - Kritisch (sofort umsetzen)**
+
+1. **E2E-Tests für Kern-Flows**
+   ```ts
+   // Playwright Setup für:
+   - Turnier-Erstellung (Wizard)
+   - Spielplan-Generierung
+   - Live-Cockpit (Timer, Tore)
+   - PDF-Export
+   ```
+
+2. **Supabase Integration Tests**
+   ```ts
+   // Test-Container oder Supabase Dev-DB
+   - Auth Flow (Login, Session)
+   - Realtime Updates
+   - DB Constraints
+   ```
+
+3. **PWA-Spezifische Tests**
+   ```ts
+   // Service Worker Testing
+   - Offline-Mode
+   - Install-Flow
+   - Background Sync
+   ```
+
+4. **Error-Handling Coverage**
+   ```ts
+   // Teste alle Error-Zustände
+   - Network Failures
+   - Validation Errors
+   - Permission Denied
+   - Timeout Handling
+   ```
+
+### 🟡 **P2 - Hoch (nächste Sprint-Iteration)**
+
+5. **Accessibility Tests**
+   ```ts
+   // axe-core Integration
+   - WCAG 2.1 AA Compliance
+   - Screen Reader Tests
+   - Keyboard Navigation
+   ```
+
+6. **Performance Budgets**
+   ```ts
+   // CI-Integration
+   - Lighthouse Scores
+   - Bundle Size Limits
+   - Time-to-Interactive
+   ```
+
+7. **Contract Tests für API**
+   ```ts
+   // Supabase API Contract
+   - Response Schemas
+   - Error Formats
+   - Realtime Events
+   ```
+
+### 🟢 **P3 - Mittel (langfristig)**
+
+8. **Visual Regression Tests**
+   ```ts
+   // Percy/Chromatic
+   - UI Component Changes
+   - Responsive Layouts
+   - Theme Switching
+   ```
+
+9. **Load Tests für Realtime**
+   ```ts
+   // Concurrent Users
+   - 10+ gleichzeitige Live-Updates
+   - Broadcast Performance
+   ```
+
+10. **Mutation Testing**
+    ```ts
+    // Stryker/Mutant
+    - Test-Qualität validieren
+    - Ungetestete Code-Pfade finden
+    ```
+
+---
+
+## 5. Testing Score
+
+| Kategorie | Score | Kommentar |
+|-----------|-------|-----------|
+| **Unit Test Coverage** | 8/10 | Sehr gut für Kern-Logik |
+| **Test-Infrastructure** | 7/10 | Solide, aber Verbesserungspotential |
+| **E2E Coverage** | 1/10 | Fehlend |
+| **Integration Testing** | 2/10 | Nur Mocks |
+| **Accessibility** | 0/10 | Fehlend |
+| **Performance Testing** | 3/10 | Nur Baseline-Tests |
+| **Error Handling** | 4/10 | Teilweise abgedeckt |
+| **CI/CD Integration** | 5/10 | Unklar aus Code |
+| **Test-Maintainability** | 6/10 | Gute Factories, aber Fragility |
+| **Overall Score** | **4.6/10** | **Bedingt production-ready** |
+
+---
+
+## 6. Konkrete nächste Schritte
+
+```yaml
+# Sprint 1-2 (P1)
+- [ ] Playwright Setup + 5 Kern-E2E-Tests
+- [ ] Supabase Integration Test Suite
+- [ ] PWA Service Worker Tests
+- [ ] Error Boundary Coverage
+
+# Sprint 3-4 (P2)
+- [ ] Accessibility Audit (axe-core)
+- [ ] Performance Budgets in CI
+- [ ] Contract Tests für API
+- [ ] Test Coverage Report (80%+ Target)
+
+# Sprint 5-6 (P3)
+- [ ] Visual Regression Setup
+- [ ] Load Testing für Realtime
+- [ ] Mutation Testing Pilot
+- [ ] Flaky Test Detection
+```
+
+---
+
+## 7. Risikobewertung
+
+| Risiko | Wahrscheinlichkeit | Impact | Mitigation |
+|--------|-------------------|--------|------------|
+| **Datenkorruption durch Race Conditions** | Mittel | Hoch | Integration Tests + Realtime Mocks |
+| **PWA-Features funktionieren nicht** | Hoch | Hoch | E2E-Tests auf echten Devices |
+| **Performance-Degradation** | Mittel | Mittel | Performance Budgets + Monitoring |
+| **Accessibility Issues** | Hoch | Mittel | axe-core + Manual Testing |
+| **Supabase Integration Fehler** | Mittel | Hoch | Contract Tests + Staging Environment |
+
+---
+
+## Fazit
+
+Die Test-Strategie ist für **Unit-Tests stark**, aber für **Production-Ready-Qualität unvollständig**. Priorisiere **E2E-Tests** und **Integration-Tests**, um kritische Pfade zu validieren. Die bestehende Test-Infrastruktur (Vitest, Factories, Mocking) bietet eine solide Basis für Erweiterung.
+
+**Empfohlener nächster Schritt:** Playwright Setup mit 3-5 Kern-E2E-Tests für Turnier-Erstellungs-Flow.

--- a/reviews/2026-05-07_2053_tournament_creation.md
+++ b/reviews/2026-05-07_2053_tournament_creation.md
@@ -1,0 +1,432 @@
+# Code Review: Turnier-Erstellung (Wizard Flow)
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 172.8s  
+**Status:** success  
+**Code-Kontext:** 149,162 Zeichen  
+
+<details><summary>Thinking Process (3,408 Zeichen)</summary>
+
+Der Code ist sehr umfangreich und gut strukturiert. Ich muss als QA-Engineer und UX-Spezialist systematisch prüfen:
+
+1. **Wizard-Struktur & Flow**
+2. **Validierung & Fehlerbehandlung**
+3. **Team-Management**
+4. **Spielplan-Generierung**
+5. **Edge Cases**
+6. **UX-Probleme**
+
+Lass mich die wichtigsten Punkte analysieren:
+
+## 1. Wizard-Struktur
+
+Der Wizard hat folgende Schritte (aus dem Code ersichtlich):
+- Step1: Sport & Typ (Classic/Bambini)
+- Step2: Modus & System (Gruppen, DFB, Zeitplanung, Schiedsrichter)
+- Step3: Metadaten (Name, Ort, Datum)
+- Step4: Teams (Hinzufügen, Entfernen, Gruppierung)
+- Step5: Overview (Zusammenfassung)
+- Preview (Spielplan-Vorschau)
+
+**Probleme:**
+- Keine explizite Schritt-Indikation (Wie viele Schritte? Wo bin ich?)
+- Keine Fortschrittsanzeige
+- Keine Möglichkeit, Schritte zu überspringen
+- Keine Persistierung bei Browser-Crash
+
+## 2. Validierung
+
+**Fehlende Validierungen:**
+- `numberOfTeams` muss mit `numberOfGroups` kompatibel sein
+- Bei `groupsAndFinals`: Teams pro Gruppe müssen mindestens 2 sein
+- Keine Validierung für `title` (Pflichtfeld, aber keine Regex-Limitierung)
+- Keine Validierung für `date` (muss in Zukunft liegen?)
+- Keine Validierung für `startTime` (muss nach `date` kommen?)
+- Keine Prüfung ob Teams-Count mit `numberOfTeams` übereinstimmt
+
+## 3. Team-Management
+
+**UX-Probleme:**
+- Kein "Bulk-Import" von Teams (CSV, Excel)
+- Kein "Auto-fill" aus Vorlage
+- Keine Sortierfunktion
+- Duplicate-Check ist vorhanden, aber nur pro-Name (nicht pro-Team-Id)
+
+
+- Logo-Upload könnte besser sein (Drag & Drop, Preview)
+
+## 4. Spielplan-Generierung
+
+**Logik-Probleme:**
+- DFB-System: Bei ungerader Teamzahl wird BYE verwendet, aber nicht alle Patterns unterstützen das
+- Bei `groupsAndFinals`: Die Verteilung der Teams auf Gruppen ist nicht immer fair (bei 5 Teams, 2 Gruppen = 3+2 oder 2+3?)
+- Keine Prüfung ob Spielplan-Generierung erfolgreich war
+- Keine Fehlerbehandlung bei Schedule-Generation
+
+## 5. Edge Cases
+
+**Nicht abgedeckt:**
+- Was passiert wenn Teams nach Erstellen hinzugefügt werden?
+- Was wenn Felder nicht verfügbar sind?
+- Was wenn Datum in der Vergangenheit liegt?
+- Was wenn Browser-Tab schließt während Wizard aktiv ist?
+- Was wenn Supabase-Verbindung abbricht?
+- Was wenn Team-Name leer ist?
+- Was wenn Gruppennamen dupliziert sind?
+
+## 6. UX-Probleme
+
+- Keine Schritt-Indikation
+- Keine "Zurück"-Navigation (nur durch Klick)
+- Keine Auto-Speicherung
+- Keine "Vorschau" während Wizard
+- Keine "Export/Import" von Turnier-Vorlagen
+- Keine "Copy from existing tournament"
+
+## 7. Technische Probleme
+
+- `formData` ist `Partial<Tournament>`, aber viele Felder sind nicht optional
+- Keine Zod-Validierung im Wizard
+- Keine TypeScript-Strict-Mode Prüfung
+- Keine Unit-Tests für Generator-Logik
+- Keine E2E-Tests für Wizard-Flow
+
+## 8. Accessibility
+
+- `aria-labels` vorhanden, aber nicht konsistent
+- Keine Keyboard-Navigation für alle Elemente
+- Keine Screenreader-Optimierung für dynamische Inhalte
+- Farb-Kontraste bei "warning" und "error" könnten besser sein
+
+## 9. Performance
+
+- Bei vielen Teams (24+) könnte UI langsam werden
+- Keine Virtualisierung bei Team-Liste
+- Keine Lazy-Loading bei Preview
+
+## 10. Security
+
+- Keine Input-Sanitization bei Team-Namen
+- Keine XSS-Prüfung bei `__html` in `dangerouslySetInnerHTML`
+- Keine Rate-Limiting bei Wizard-Submit
+
+Ich muss jetzt die wichtigsten Punkte zusammenfassen und bewerten.
+
+
+</details>
+
+---
+
+
+
+# 🏆 Tournament Creation Wizard - QA & UX Review
+
+## Executive Summary
+
+Der Wizard ist **technisch ausgereift** mit guter Struktur und vielen Features, hat aber **kritische UX-Lücken** und **Validierungsprobleme** die zu fehlerhaften Turnieren führen können.
+
+---
+
+## 🚨 Logik-Fehler im Wizard/Generator
+
+### 1. **Team-Count vs. numberOfTeams Inkonsistenz**
+```typescript
+// Problem: numberOfTeams ist separate Konfiguration
+const numberOfTeams = formData.numberOfTeams ?? 4;
+// Aber teams.length wird nicht validiert
+```
+**Impact:** User kann 4 Teams konfigurieren aber nur 3 eingeben → Schedule-Generation schlägt fehl
+
+**Fix:**
+```typescript
+// In Step4_Teams.tsx
+const isTeamCountValid = teams.length === numberOfTeams;
+// Disable "Weiter" button wenn false
+```
+
+### 2. **Gruppenverteilung bei ungerader Teamzahl**
+```typescript
+// Bei 5 Teams, 2 Gruppen: 3+2 oder 2+3?
+const teamsPerGroup = Math.ceil(teams / numberOfGroups);
+// Math.ceil(5/2) = 3 → Gruppe 1: 3 Teams, Gruppe 2: 2 Teams
+```
+**Impact:** Ungleichgewicht, eine Gruppe hat mehr Spiele
+
+**Fix:**
+```typescript
+// Balanced distribution
+const baseTeams = Math.floor(teams / numberOfGroups);
+const extraTeams = teams % numberOfGroups;
+// Gruppe 1: baseTeams + 1, Gruppe 2: baseTeams
+```
+
+### 3. **DFB Pattern mit BYE nicht vollständig validiert**
+```typescript
+// DFBKeySystem.tsx
+const hasBye = pattern.rounds.some(round =>
+  round.some(match => match.includes('BYE'))
+);
+```
+**Problem:** BYE wird angezeigt aber nicht im Schedule korrekt gehandled
+
+**Fix:**
+```typescript
+// In Schedule Generator
+if (match.includes('BYE')) {
+  // Skip match generation oder als "Free Pass" markieren
+  continue;
+}
+```
+
+### 4. **Schedule-Generation ohne Fehlerbehandlung**
+```typescript
+// TournamentPreview.tsx
+const newSchedule = generateFullSchedule(updatedTournament);
+// Keine try-catch, keine Error-Handling
+```
+**Impact:** Bei ungültigen Parametern crasht die App
+
+**Fix:**
+```typescript
+try {
+  const newSchedule = generateFullSchedule(updatedTournament);
+  setSchedule(newSchedule);
+} catch (error) {
+  setError(t('scheduleGenerationFailed', { error: error.message }));
+}
+```
+
+---
+
+## ⚠️ Fehlende Validierungen
+
+### Pflichtfelder & Grenzwerte
+
+| Feld | Current | Missing |
+|------|---------|---------|
+| `title` | `required` | Max 100 Zeichen, No Special Chars |
+| `date` | `required` | Must be >= today |
+| `startTime` | `required` | Format validation (HH:MM) |
+| `numberOfTeams` | `min: 2, max: 24` | Must match `teams.length` |
+| `numberOfGroups` | `min: 2, max: 8` | Must divide teams evenly or warn |
+| `teams[].name` | No validation | No duplicates, min 2 chars |
+| `location.name` | `required` | No validation |
+
+### Missing Zod-Schema im Wizard
+
+```typescript
+// Missing: src/features/tournament-creation/wizardSchema.ts
+export const wizardSchema = z.object({
+  title: z.string().min(3).max(100),
+  date: z.string().refine(date => new Date(date) >= new Date(), "Date must be in future"),
+  numberOfTeams: z.number().min(2).max(24),
+  teams: z.array(z.object({
+    name: z.string().min(2).max(50),
+  })).refine(teams => teams.length > 0, "At least one team required")
+  // ... more validations
+});
+```
+
+---
+
+## 🎨 UX-Probleme im Wizard-Flow
+
+### 1. **Keine Fortschrittsanzeige**
+```tsx
+// Missing: Progress bar or step indicator
+<div className="wizard-progress">
+  <StepIndicator step={1} active={currentStep === 1} />
+  <StepIndicator step={2} active={currentStep === 2} />
+  ...
+</div>
+```
+
+### 2. **Keine Auto-Save / Persistierung**
+```typescript
+// Problem: Browser-Crash = Datenverlust
+// Missing: localStorage or Supabase draft save
+useEffect(() => {
+  localStorage.setItem('tournamentDraft', JSON.stringify(formData));
+}, [formData]);
+```
+
+### 3. **Keine "Zurück"-Navigation mit Warnung**
+```typescript
+// Problem: User verliert Daten bei "Zurück"
+const handleBack = () => {
+  if (hasUnsavedChanges && !confirm('Ungespeicherte Änderungen gehen verloren')) {
+    return;
+  }
+  setCurrentStep(prev => prev - 1);
+};
+```
+
+### 4. **Kein Bulk-Import für Teams**
+```typescript
+// Missing: CSV/Excel import
+<Button onClick={handleImportTeams} icon={<Icons.Upload />}>
+  Teams importieren (CSV)
+</Button>
+```
+
+### 5. **Keine Vorlagen / Copy from existing**
+```typescript
+// Missing: Template selection
+<Select
+  label="Vorlage verwenden"
+  options={existingTournaments.map(t => ({ value: t.id, label: t.title }))}
+/>
+```
+
+### 6. **Mobile UX: Zu viele Eingaben auf einem Screen**
+```css
+/* Mobile: Steps sollten gestaffelt werden */
+@media (max-width: 768px) {
+  .configGrid {
+    grid-template-columns: 1fr !important;
+  }
+  .teamRow {
+    flex-direction: column !important;
+  }
+}
+```
+
+---
+
+## 🎯 Edge Cases nicht abgedeckt
+
+| Scenario | Current Behavior | Risk |
+|----------|-----------------|------|
+| Browser schließt während Wizard | Datenverlust | 🔴 High |
+| Supabase-Connection abbricht | Keine Error-Message | 🔴 High |
+| Team-Name enthält HTML | XSS möglich | 🟡 Medium |
+| Datum in Vergangenheit | Keine Warnung | 🟡 Medium |
+| 24 Teams, 1 Feld | Schedule > 24h | 🟡 Medium |
+| Duplicate Team-Namen (Case-insensitive) | Error vorhanden | 🟢 Low |
+| Empty Group bei Gruppen-Modus | Error vorhanden | 🟢 Low |
+| Schiedsrichter-Duplicate-Namen | Error vorhanden | 🟢 Low |
+| Field-Name-Duplicate | Error vorhanden | 🟢 Low |
+| Ungültige Point-System-Werte | No validation | 🟡 Medium |
+
+### Critical: LiveMatch Optimistic Locking
+```typescript
+// LiveMatch.ts
+version: number; // ✅ Good
+// But missing: Conflict resolution in LiveMatch component
+```
+**Fix:**
+```typescript
+const handleScoreUpdate = async (newScore: number) => {
+  const currentMatch = await fetchMatch(matchId);
+  if (currentMatch.version !== match.version) {
+    // Conflict detected
+    showConflictResolutionDialog();
+    return;
+  }
+  // Proceed with update
+};
+```
+
+---
+
+## 📊 Tournament Creation Score
+
+| Kategorie | Score | Comments |
+|-----------|-------|----------|
+| **Funktionalität** | 8/10 | Alle Features vorhanden |
+| **Validierung** | 5/10 | Viele fehlende Checks |
+| **UX/Usability** | 6/10 | Keine Progress-Bar, Auto-Save |
+| **Edge Cases** | 4/10 | Viele nicht abgedeckt |
+| **Performance** | 7/10 | Virtualisierung fehlt |
+| **Accessibility** | 6/10 | ARIA vorhanden, aber unvollständig |
+| **Security** | 5/10 | XSS, Input-Sanitization fehlt |
+| **Maintainability** | 8/10 | Gut strukturiert, viele Components |
+
+## **Gesamt: 6.1/10** ⭐⭐⭐
+
+---
+
+## 🛠️ Priority Fixes
+
+### 🔴 **P0 - Critical (Sofort)**
+1. **Zod-Validierung im Wizard** hinzufügen
+2. **Auto-Save** via localStorage implementieren
+3. **Schedule-Generation Error-Handling**
+4. **Team-Count Validierung** (numberOfTeams === teams.length)
+
+### 🟡 **P1 - High (2 Wochen)**
+1. **Fortschrittsanzeige** im Wizard
+2. **Bulk-Import** für Teams (CSV)
+3. **Browser-Close Warning** (beforeunload)
+4. **Input-Sanitization** für Team-Namen
+
+### 🟢 **P2 - Medium (1 Monat)**
+1. **Vorlagen-System** (Copy from existing)
+2. **Virtualisierung** bei Team-Liste
+3. **E2E-Tests** für Wizard-Flow
+4. **Accessibility Audit** (WCAG 2.1)
+
+---
+
+## 💡 UX-Verbesserungen
+
+### 1. **Smart Defaults**
+```typescript
+// Auto-select based on team count
+if (numberOfTeams <= 8) {
+  setGroupSystem('roundRobin');
+} else if (numberOfTeams <= 16) {
+  setGroupSystem('groupsAndFinals');
+  setNumberOfGroups(2);
+}
+```
+
+### 2. **Real-time Schedule Preview**
+```tsx
+// In Step2: Live preview of estimated duration
+<LiveScheduleEstimate
+  teams={teams}
+  fields={numberOfFields}
+  gameDuration={groupPhaseGameDuration}
+/>
+```
+
+### 3. **Undo/Redo**
+```typescript
+// Use undoable state management
+const [history, setHistory] = useUndoable(formData);
+```
+
+### 4. **Tour-Guide für Erstnutzer**
+```tsx
+// First-time user onboarding
+if (isFirstTime) {
+  <TourGuide steps={wizardSteps} />;
+}
+```
+
+---
+
+## ✅ What's Done Well
+
+1. ✅ **TypeScript-Strict** mit `Partial<Tournament>`
+2. ✅ **i18n** für alle Labels
+3. ✅ **Responsive Design** mit CSS Modules
+4. ✅ **Duplicate Detection** für Teams, Gruppen, SR
+5. ✅ **Accessibility** mit `aria-*` Attributes
+6. ✅ **Modular Components** (NameGrid, DFBKeySystem, etc.)
+7. ✅ **LiveMatch Model** mit Optimistic Locking
+8. ✅ **Bambini-Mode** mit speziellen Settings
+
+---
+
+## 📝 Next Steps
+
+1. **Implement P0 Fixes** (Validierung, Auto-Save, Error-Handling)
+2. **Add Unit Tests** für Schedule-Generator
+3. **Add E2E Tests** für Wizard-Flow (Cypress/Playwright)
+4. **Performance Audit** mit Lighthouse
+5. **Accessibility Audit** mit axe-core
+6. **Security Review** (XSS, Input Validation)
+
+**Gesamturteil:** Solide Basis, aber Validierung und UX müssen verbessert werden für Production-Readiness.

--- a/reviews/2026-05-07_2055_SUMMARY.md
+++ b/reviews/2026-05-07_2055_SUMMARY.md
@@ -1,0 +1,402 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:55  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 41.8s  
+**Agents:** 1  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Hooks, State & Context | success | 41.8s | 148.0k | 43249 |
+
+---
+
+## Hooks, State & Context
+
+
+
+# 📊 React Hooks & State Management Review
+## hallenfussball-pwa | React 19 + TypeScript
+
+---
+
+## ⚠️ Re-Render-Probleme (Critical)
+
+### 1. **useMatchTimer / useMatchTimerExtended** - Frame-basierte State-Updates
+```typescript
+// ❌ Problem: setDisplayTime in jedem Frame, auch bei unverändertem Wert
+const updateTimer = () => {
+  const currentSecond = Math.floor(now / 1000);
+  if (currentSecond !== lastUpdateRef.current) {
+    lastUpdateRef.current = currentSecond;
+    setDisplayTime(totalElapsed); // Re-render bei jedem Sekunden-Update
+  }
+  animationFrameId = requestAnimationFrame(updateTimer);
+};
+```
+**Impact:** Bei 60fps werden 60 State-Updates pro Sekunde ausgelöst, aber nur 1 wird benötigt.
+
+**Fix:**
+```typescript
+// ✅ Verwende setInterval statt requestAnimationFrame für Sekunden-Updates
+useEffect(() => {
+  if (status !== 'RUNNING' || !timerStartTime) return;
+  
+  const interval = setInterval(() => {
+    const now = Date.now();
+    const runtimeSeconds = Math.floor((now - startTime) / 1000);
+    setElapsedSeconds(baseElapsedSeconds + runtimeSeconds);
+  }, 1000);
+  
+  return () => clearInterval(interval);
+}, [timerStartTime, baseElapsedSeconds, status]);
+```
+
+### 2. **useLiveMatches** - `new Map()` bei jedem Update
+```typescript
+// ❌ Problem: Neue Map-Referenz bei jedem Goal/Card-Erkennungs-Update
+const detectGoalEvent = useCallback((newMatches: Map<string, LiveMatch>): GoalEventInfo | null => {
+  // ...
+  seenGoalIds.current.add(event.id);
+  return { /* neues Objekt */ };
+}, []);
+```
+**Impact:** `liveMatches` State wird bei jedem Event neu referenziert → alle Consumer re-rendern.
+
+**Fix:**
+```typescript
+// ✅ Verwende immutable Updates nur bei tatsächlichen Änderungen
+const detectGoalEvent = useCallback((newMatches: Map<string, LiveMatch>): GoalEventInfo | null => {
+  let goalEvent: GoalEventInfo | null = null;
+  
+  for (const [, match] of newMatches) {
+    // ...
+    if (/* new goal */) {
+      goalEvent = { /* ... */ };
+      seenGoalIds.current.add(event.id);
+    }
+  }
+  
+  return goalEvent;
+}, []);
+
+// Im Eltern-Component:
+const [lastGoalEvent, setLastGoalEvent] = useState<GoalEventInfo | null>(null);
+useEffect(() => {
+  const goal = detectGoalEvent(liveMatches);
+  if (goal) setLastGoalEvent(goal);
+}, [detectGoalEvent, liveMatches]); // Nur wenn detectGoalEvent tatsächlich ein neues Event findet
+```
+
+### 3. **useAutoSave** - `JSON.stringify` bei jedem Render
+```typescript
+// ❌ Problem: Teure Stringifizierung bei jedem Render
+const hasUnsavedChanges = useCallback((): boolean => {
+  const currentData = JSON.stringify(formData); // O(n) bei jedem Render!
+  return currentData !== lastSavedDataRef.current;
+}, [formData, lastSavedDataRef]);
+```
+**Fix:**
+```typescript
+// ✅ Verwende Referenz-Tracking oder Deep-Equality nur bei Bedarf
+const hasUnsavedChanges = useCallback((): boolean => {
+  const currentData = JSON.stringify(formData);
+  return currentData !== lastSavedDataRef.current;
+}, [formData, lastSavedDataRef]);
+
+// Oder: Memoisiere die Stringifizierung
+const formDataString = useMemo(() => JSON.stringify(formData), [formData]);
+const hasUnsavedChanges = formDataString !== lastSavedDataRef.current;
+```
+
+### 4. **useMatchCockpitPro / useCorporateColors** - Neu-Berechnung bei jedem Render
+```typescript
+// ❌ Problem: effectiveSettings wird bei jedem Render neu berechnet
+const effectiveSettings = {
+  soundEnabled: overrides.soundEnabled ?? settings.soundEnabled,
+  // ...
+};
+```
+**Fix:**
+```typescript
+// ✅ Verwende useMemo
+const effectiveSettings = useMemo(() => ({
+  soundEnabled: overrides.soundEnabled ?? settings.soundEnabled,
+  // ...
+}), [overrides, settings]);
+```
+
+---
+
+## 🐛 Memory Leaks & Cleanup Issues
+
+### 1. **useDialogTimer** - Interval-Cleanup nicht robust
+```typescript
+// ⚠️ Problem: intervalRef.current wird in setRemainingSeconds callback verwendet
+setRemainingSeconds((prev) => {
+  if (prev <= 1) {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null; // ⚠️ Ref wird in Callback aktualisiert
+    }
+  }
+});
+```
+**Fix:**
+```typescript
+// ✅ Cleanup in separatem useEffect
+useEffect(() => {
+  return () => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+}, []);
+```
+
+### 2. **useFocusTrap** - `inertElements` nicht vollständig gecleanuped
+```typescript
+// ⚠️ Problem: inertElements wird in Effect erstellt, aber Cleanup könnte versagen
+const inertElements: Element[] = [];
+for (const element of siblings) {
+  element.setAttribute('inert', '');
+  inertElements.push(element);
+}
+
+return () => {
+  for (const element of inertElements) {
+    element.removeAttribute('inert'); // ⚠️ Wenn Element nicht existiert, Fehler
+  }
+};
+```
+**Fix:**
+```typescript
+// ✅ Prüfe Element-Existenz im Cleanup
+return () => {
+  for (const element of inertElements) {
+    if (element.parentNode) {
+      element.removeAttribute('inert');
+    }
+  }
+};
+```
+
+### 3. **useMonitorTheme** - Event Listener auf `window` ohne SSR-Schutz
+```typescript
+// ⚠️ Problem: useEffect ohne window-Check in Server-Component
+useEffect(() => {
+  if (typeof window === 'undefined') return;
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', handler);
+  return () => mediaQuery.removeEventListener('change', handler);
+}, []);
+```
+**Status:** ✅ Korrekt implementiert (SSR-Schutz vorhanden)
+
+---
+
+## 🚫 Anti-Patterns
+
+### 1. **useMatchTimer** - Deprecated Hook wird immer noch exportiert
+```typescript
+// ⚠️ Problem: Deprecated Hook wird in index.ts exportiert
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Exported for backwards compatibility
+export { useMatchTimer, useMatchTimerExtended } from './useMatchTimer';
+```
+**Empfehlung:** Deprecated Hooks sollten in einem separaten `legacy/` Ordner liegen und in v2 entfernt werden.
+
+### 2. **useLiveMatches** - `Map` als React State
+```typescript
+// ⚠️ Problem: Map-Referenz ändert sich bei jedem Update
+const [liveMatches, setLiveMatches] = useState<Map<string, LiveMatch>>(new Map());
+```
+**Besser:** Verwende Objekt oder Array mit `useReducer` für komplexe State-Logik.
+
+### 3. **useAutoSave** - Stale Closure in `saveAsDraft`
+```typescript
+// ⚠️ Problem: hasUnsavedChanges in useCallback hat formData als Dependency
+const saveAsDraft = useCallback(() => {
+  if (!hasUnsavedChanges()) return; // ⚠️ Stale closure wenn formData sich ändert
+  // ...
+}, [hasUnsavedChanges, formData, saveTournament, showSaveConfirmation, createDraftTournament, lastSavedDataRef]);
+```
+**Fix:**
+```typescript
+const saveAsDraft = useCallback(() => {
+  const hasChanges = hasUnsavedChanges(); // Aufruf in der Funktion
+  if (!hasChanges) return;
+  // ...
+}, [hasUnsavedChanges, formData, saveTournament, showSaveConfirmation, createDraftTournament, lastSavedDataRef]);
+```
+
+### 4. **useMatchSound** - Audio-Element wird nicht bei Sound-Wechsel aktualisiert
+```typescript
+// ⚠️ Problem: audioRef.current wird nur einmal erstellt
+audioRef.current ??= new Audio();
+
+audioRef.current.src = soundUrl;
+audioRef.current.volume = volume / 100;
+```
+**Fix:**
+```typescript
+// ✅ Erstelle neues Audio-Element bei Sound-Wechsel
+useEffect(() => {
+  const audio = new Audio();
+  audioRef.current = audio;
+  audio.src = soundUrl;
+  audio.volume = volume / 100;
+  
+  return () => {
+    audio.pause();
+    audio.src = '';
+  };
+}, [soundUrl, volume]);
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **useBreakpoint** - Passive Event Listener
+```typescript
+// ✅ Performance-optimiert
+window.addEventListener('resize', handleResize, { passive: true });
+```
+
+### 2. **useFocusTrap** - WCAG 4.1.3 Compliance
+```typescript
+// ✅ Accessibility-first Implementierung
+element.setAttribute('inert', '');
+// Focus restoration on close
+returnTarget?.focus();
+```
+
+### 3. **useMonitorHeartbeats** - Realtime mit Supabase
+```typescript
+// ✅ Gute Realtime-Implementierung
+const channel = supabase
+  .channel(`heartbeats:${tournamentId}`)
+  .on('postgres_changes', { /* ... */ }, (payload) => {
+    // ...
+  })
+  .subscribe();
+```
+
+### 4. **useLocalStorage** - Try-Catch für Storage-Fehler
+```typescript
+// ✅ Robust gegen Storage-Quota-Errors
+try {
+  const item = window.localStorage.getItem(key);
+  // ...
+} catch (error) {
+  console.error(`Error loading localStorage key "${key}":`, error);
+  return initialValue;
+}
+```
+
+### 5. **useDebounce** - `useDebouncedCallback` mit Ref für Callback
+```typescript
+// ✅ Vermeidet Stale Closures
+const callbackRef = useRef(callback);
+useEffect(() => {
+  callbackRef.current = callback;
+}, [callback]);
+```
+
+---
+
+## 📊 State Management Score: **6.5/10**
+
+### Stärken:
+- ✅ Gute Context-Architektur (RepositoryContext)
+- ✅ Viele Hooks mit korrektem Cleanup
+- ✅ SSR-Schutz in den meisten Hooks
+- ✅ Accessibility-First (useFocusTrap, useHighContrast)
+- ✅ Realtime-Implementierung mit Supabase
+
+### Schwächen:
+- ❌ `Map`/`Set` als State führt zu unnötigen Re-Renders
+- ❌ Teure Berechnungen (`JSON.stringify`) bei jedem Render
+- ❌ `requestAnimationFrame` für Sekunden-Updates (Overkill)
+- ❌ Fehlende `useMemo` für abgeleitete State-Werte
+- ❌ Deprecated Hooks werden immer noch exportiert
+
+---
+
+## 🔧 Priorisierte Fixes
+
+### **P0 (Critical):**
+1. **useMatchTimer**: Von `requestAnimationFrame` zu `setInterval` wechseln
+2. **useLiveMatches**: `Map` State durch `useReducer` ersetzen
+3. **useAutoSave**: `JSON.stringify` memoisieren
+
+### **P1 (High):**
+4. **useMatchCockpitPro**: `effectiveSettings` mit `useMemo` umschließen
+5. **useCorporateColors**: `effectiveSettings` mit `useMemo` umschließen
+6. **useDialogTimer**: Interval-Cleanup robust machen
+
+### **P2 (Medium):**
+7. **useMatchSound**: Audio-Element bei Sound-Wechsel neu erstellen
+8. **useFocusTrap**: Element-Existenz im Cleanup prüfen
+9. Deprecated Hooks in `legacy/` Ordner verschieben
+
+---
+
+## 📈 Empfohlene Architekturbesserungen
+
+### 1. **State Normalisierung**
+```typescript
+// ❌ Current: Map<string, LiveMatch>
+const [liveMatches, setLiveMatches] = useState<Map<string, LiveMatch>>(new Map());
+
+// ✅ Better: Normalized State
+interface LiveMatchesState {
+  byId: Record<string, LiveMatch>;
+  ids: string[];
+}
+const [state, setState] = useReducer(liveMatchesReducer, initialState);
+```
+
+### 2. **Custom Hook Composition**
+```typescript
+// ✅ Verwende Hooks aus anderen Hooks
+export function useMatchCockpitPro() {
+  const timer = useMatchTimerExtended(/* ... */);
+  const sound = useMatchSound(/* ... */);
+  const haptic = useHapticFeedback(/* ... */);
+  
+  // Kombiniere Logik hier
+  return { timer, sound, haptic };
+}
+```
+
+### 3. **Zustands-Management mit Zustand/Jotai**
+```typescript
+// ✅ Für komplexe State-Logik (LiveMatches, Tournament)
+import { create } from 'zustand';
+
+interface LiveMatchesStore {
+  matches: Map<string, LiveMatch>;
+  addMatch: (match: LiveMatch) => void;
+  updateMatch: (id: string, updates: Partial<LiveMatch>) => void;
+  // ...
+}
+
+export const useLiveMatchesStore = create<LiveMatchesStore>((set) => ({
+  matches: new Map(),
+  addMatch: (match) => set((state) => ({
+    matches: new Map(state.matches).set(match.id, match)
+  })),
+  // ...
+}));
+```
+
+---
+
+**Gesamtbeurteilung:** Solide Basis mit guter Architektur, aber Performance-Optimierungen bei State-Updates und Re-Renders sind dringend erforderlich. Die Realtime-Implementierung ist hervorragend, aber die State-Management-Patterns sollten modernisiert werden.
+
+---
+

--- a/reviews/2026-05-07_2055_hooks_state.md
+++ b/reviews/2026-05-07_2055_hooks_state.md
@@ -1,0 +1,513 @@
+# Code Review: Hooks, State & Context
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 41.8s  
+**Status:** success  
+**Code-Kontext:** 147,996 Zeichen  
+
+<details><summary>Thinking Process (6,058 Zeichen)</summary>
+
+Ich muss den Code systematisch auf Hooks und State Management analysieren. Lassen Sie mich die wichtigsten Punkte durchgehen:
+
+1. **Custom Hooks - Naming & Struktur**
+2. **Context Architecture**
+3. **Re-Render Optimierung**
+4. **Side Effects & Cleanup**
+5. **Hook Composition**
+6. **State Colocation**
+7. **Derived State**
+8. **Hook Dependencies**
+9. **Error Handling**
+10. **Performance**
+
+Lassen Sie mich die kritischen Probleme identifizieren:
+
+## Kritische Probleme gefunden:
+
+### 1. **useMatchTimer / useMatchTimerExtended**
+- `useMatchTimer` verwendet `requestAnimationFrame` aber setzt `setDisplayTime` in jedem Frame - das verursacht unnötige Re-Renders
+- `lastUpdateRef.current` wird verwendet um jede Sekunde zu aktualisieren, aber `requestAnimationFrame` läuft trotzdem weiter
+- **Problem**: Der Hook setzt State in jedem Frame, auch wenn sich der Wert nicht ändert (unnötige Re-Renders)
+
+### 2. **useLiveMatches**
+- Verwendet `Map` als State - `new Map()` bei jedem Update erstellt neue Referenz
+- `useMemo` wird für `parseLiveMatches` verwendet aber `storageKey` ist in den Dependencies
+- `seenGoalIds` und `seenCardIds` als `useRef` - gut für Performance
+- **Problem**: `new Map()` bei jedem Update in `detectGoalEvent` und `detectCardEvent` - könnte zu unnötigen Re-Renders führen
+
+### 3. **useAutoSave**
+- `hasUnsavedChanges` ist `useCallback` mit `formData` als Dependency - wenn `formData` neu referenziert wird (z.B. durch `JSON.stringify`), wird der Callback neu erstellt
+
+
+- `saveAsDraft` hat `hasUnsavedChanges` als Dependency, was einen Zyklus verursacht
+- **Problem**: `JSON.stringify(formData)` in `hasUnsavedChanges` wird bei jedem Render aufgerufen - teuer
+
+### 4. **useCorporateColors**
+- `applyPreset` und `applyCustomColors` haben `updateProfile` als Dependency - wenn `updateProfile` neu referenziert wird, werden alle Funktionen neu erstellt
+- **Problem**: `isPremiumUser` wird in `applyPreset` verwendet aber nicht in Dependencies - könnte stale closure sein
+
+### 5. **useFocusTrap**
+- `useEffect` mit `isActive` als Dependency - bei jedem Statuswechsel wird der Event Listener neu hinzugefügt/entfernt
+- **Problem**: `document.body.children` wird bei jedem Effect-Run durchlaufen - könnte Performance-Probleme verursachen
+
+### 6. **useHapticFeedback**
+- `isSupported` wird in `useMemo` berechnet aber `[]` als Dependency - korrekt
+- **Problem**: `navigator.vibrate` wird in `trigger` aufgerufen, aber `isSupported` könnte sich ändern (z.B. bei Geräteänderung)
+
+### 7. **useMatchCockpitPro**
+- `effectiveSettings` wird bei jedem Render neu berechnet - sollte `useMemo` verwenden
+- **Problem**: `timerResult` von `useMatchTimerExtended` wird verwendet, aber die Dependencies sind nicht vollständig
+
+### 8. **RepositoryContext**
+- `useMemo` mit `user` als Dependency - wenn `user` sich ändert, werden alle Repositories neu erstellt
+- **Problem**: `supabaseLiveMatchRepoRef.current` wird in `useEffect` gecleanuped, aber der Ref wird in `useMemo` gesetzt - Race Condition möglich
+
+### 9. **useLiveProgress**
+- `useEffect` mit `match` als Dependency - bei jedem Match-Wechsel wird der Interval neu erstellt
+- **Problem**: `getElapsed` wird in `useMemo` berechnet aber `match` ist in den Dependencies
+
+### 10. **useDebounce**
+- `useDebounce` verwendet `useEffect` mit `value` und `delay` als Dependencies - korrekt
+- **Problem**: `useDebouncedCallback` verwendet `useCallback` mit `delay` als Dependency, aber `callbackRef.current` wird in `useEffect` aktualisiert - könnte zu Race Conditions führen
+
+## Positive Patterns:
+
+1. **useLocalStorage** - Gut implementiert mit try-catch
+2. **useClickOutside** - Gute Cleanup-Logik
+3. **useMonitorTheme** - Gute System-Theme Detection
+4. **useBreakpoint** - Passive Event Listener für Performance
+5. **useFontScale** - Gutes CSS Custom Property Pattern
+6. **useHighContrast** - Gute Accessibility-Implementierung
+7. **useMultiTabSync** - BroadcastChannel für Tab-Kommunikation
+8. **useMonitorHeartbeats** - Gute Realtime-Implementierung mit Supabase
+
+## State Management Score: 6/10
+
+**Gründe:**
+- Viele Hooks verwenden `useState` für komplexe State-Objekte
+- `Map` und `Set` als State können zu Performance-Problemen führen
+- Einige Hooks haben fehlende oder falsche Dependencies
+- Keine Verwendung von `useReducer` für komplexe State-Logik
+- Context wird gut verwendet, aber könnte weiter optimiert werden
+
+## Re-Render-Probleme:
+
+1. **useMatchTimer**: `setDisplayTime` in jedem Frame, auch wenn sich der Wert nicht ändert
+2. **useLiveMatches**: `new Map()` bei jedem Update
+3. **useAutoSave**: `JSON.stringify(formData)` bei jedem Render
+4. **useCorporateColors**: `effectiveSettings` wird bei jedem Render neu berechnet
+5. **useMatchCockpitPro**: `effectiveSettings` wird bei jedem Render neu berechnet
+
+## Memory Leaks:
+
+1. **useMatchTimer**: `requestAnimationFrame` wird gecleanuped, aber `setInterval` nicht
+2. **useDialogTimer**: `setInterval` wird gecleanuped, aber `intervalRef` wird nicht korrekt gesetzt
+3. **useFocusTrap**: `inertElements` wird nicht korrekt gecleanuped
+4. **useMonitorTheme**: Event Listener werden gecleanuped, aber `systemPrefersDark` wird nicht aktualisiert
+
+## Anti-Patterns:
+
+1. **useMatchTimer**: `useMatchTimer` ist deprecated, aber wird immer noch exportiert
+2. **useLiveMatches**: Verwendet `Map` als State, was zu unnötigen Re-Renders führt
+3. **useAutoSave**: `JSON.stringify` bei jedem Render
+4. **useCorporateColors**: `effectiveSettings` wird bei jedem Render neu berechnet
+5. **useMatchCockpitPro**: `effectiveSettings` wird bei jedem Render neu berechnet
+
+## Positive Patterns:
+
+1. **useLocalStorage**: Gut implementiert mit try-catch
+2. **useClickOutside**: Gute Cleanup-Logik
+3. **useMonitorTheme**: Gute System-Theme Detection
+4. **useBreakpoint**: Passive Event Listener für Performance
+5. **useFontScale**: Gutes CSS Custom Property Pattern
+6. **useHighContrast**: Gute Accessibility-Implementierung
+7. **useMultiTabSync**: BroadcastChannel für Tab-Kommunikation
+8. **useMonitorHeartbeats**: Gute Realtime-Implementierung mit Supabase
+
+
+</details>
+
+---
+
+
+
+# 📊 React Hooks & State Management Review
+## hallenfussball-pwa | React 19 + TypeScript
+
+---
+
+## ⚠️ Re-Render-Probleme (Critical)
+
+### 1. **useMatchTimer / useMatchTimerExtended** - Frame-basierte State-Updates
+```typescript
+// ❌ Problem: setDisplayTime in jedem Frame, auch bei unverändertem Wert
+const updateTimer = () => {
+  const currentSecond = Math.floor(now / 1000);
+  if (currentSecond !== lastUpdateRef.current) {
+    lastUpdateRef.current = currentSecond;
+    setDisplayTime(totalElapsed); // Re-render bei jedem Sekunden-Update
+  }
+  animationFrameId = requestAnimationFrame(updateTimer);
+};
+```
+**Impact:** Bei 60fps werden 60 State-Updates pro Sekunde ausgelöst, aber nur 1 wird benötigt.
+
+**Fix:**
+```typescript
+// ✅ Verwende setInterval statt requestAnimationFrame für Sekunden-Updates
+useEffect(() => {
+  if (status !== 'RUNNING' || !timerStartTime) return;
+  
+  const interval = setInterval(() => {
+    const now = Date.now();
+    const runtimeSeconds = Math.floor((now - startTime) / 1000);
+    setElapsedSeconds(baseElapsedSeconds + runtimeSeconds);
+  }, 1000);
+  
+  return () => clearInterval(interval);
+}, [timerStartTime, baseElapsedSeconds, status]);
+```
+
+### 2. **useLiveMatches** - `new Map()` bei jedem Update
+```typescript
+// ❌ Problem: Neue Map-Referenz bei jedem Goal/Card-Erkennungs-Update
+const detectGoalEvent = useCallback((newMatches: Map<string, LiveMatch>): GoalEventInfo | null => {
+  // ...
+  seenGoalIds.current.add(event.id);
+  return { /* neues Objekt */ };
+}, []);
+```
+**Impact:** `liveMatches` State wird bei jedem Event neu referenziert → alle Consumer re-rendern.
+
+**Fix:**
+```typescript
+// ✅ Verwende immutable Updates nur bei tatsächlichen Änderungen
+const detectGoalEvent = useCallback((newMatches: Map<string, LiveMatch>): GoalEventInfo | null => {
+  let goalEvent: GoalEventInfo | null = null;
+  
+  for (const [, match] of newMatches) {
+    // ...
+    if (/* new goal */) {
+      goalEvent = { /* ... */ };
+      seenGoalIds.current.add(event.id);
+    }
+  }
+  
+  return goalEvent;
+}, []);
+
+// Im Eltern-Component:
+const [lastGoalEvent, setLastGoalEvent] = useState<GoalEventInfo | null>(null);
+useEffect(() => {
+  const goal = detectGoalEvent(liveMatches);
+  if (goal) setLastGoalEvent(goal);
+}, [detectGoalEvent, liveMatches]); // Nur wenn detectGoalEvent tatsächlich ein neues Event findet
+```
+
+### 3. **useAutoSave** - `JSON.stringify` bei jedem Render
+```typescript
+// ❌ Problem: Teure Stringifizierung bei jedem Render
+const hasUnsavedChanges = useCallback((): boolean => {
+  const currentData = JSON.stringify(formData); // O(n) bei jedem Render!
+  return currentData !== lastSavedDataRef.current;
+}, [formData, lastSavedDataRef]);
+```
+**Fix:**
+```typescript
+// ✅ Verwende Referenz-Tracking oder Deep-Equality nur bei Bedarf
+const hasUnsavedChanges = useCallback((): boolean => {
+  const currentData = JSON.stringify(formData);
+  return currentData !== lastSavedDataRef.current;
+}, [formData, lastSavedDataRef]);
+
+// Oder: Memoisiere die Stringifizierung
+const formDataString = useMemo(() => JSON.stringify(formData), [formData]);
+const hasUnsavedChanges = formDataString !== lastSavedDataRef.current;
+```
+
+### 4. **useMatchCockpitPro / useCorporateColors** - Neu-Berechnung bei jedem Render
+```typescript
+// ❌ Problem: effectiveSettings wird bei jedem Render neu berechnet
+const effectiveSettings = {
+  soundEnabled: overrides.soundEnabled ?? settings.soundEnabled,
+  // ...
+};
+```
+**Fix:**
+```typescript
+// ✅ Verwende useMemo
+const effectiveSettings = useMemo(() => ({
+  soundEnabled: overrides.soundEnabled ?? settings.soundEnabled,
+  // ...
+}), [overrides, settings]);
+```
+
+---
+
+## 🐛 Memory Leaks & Cleanup Issues
+
+### 1. **useDialogTimer** - Interval-Cleanup nicht robust
+```typescript
+// ⚠️ Problem: intervalRef.current wird in setRemainingSeconds callback verwendet
+setRemainingSeconds((prev) => {
+  if (prev <= 1) {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null; // ⚠️ Ref wird in Callback aktualisiert
+    }
+  }
+});
+```
+**Fix:**
+```typescript
+// ✅ Cleanup in separatem useEffect
+useEffect(() => {
+  return () => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+}, []);
+```
+
+### 2. **useFocusTrap** - `inertElements` nicht vollständig gecleanuped
+```typescript
+// ⚠️ Problem: inertElements wird in Effect erstellt, aber Cleanup könnte versagen
+const inertElements: Element[] = [];
+for (const element of siblings) {
+  element.setAttribute('inert', '');
+  inertElements.push(element);
+}
+
+return () => {
+  for (const element of inertElements) {
+    element.removeAttribute('inert'); // ⚠️ Wenn Element nicht existiert, Fehler
+  }
+};
+```
+**Fix:**
+```typescript
+// ✅ Prüfe Element-Existenz im Cleanup
+return () => {
+  for (const element of inertElements) {
+    if (element.parentNode) {
+      element.removeAttribute('inert');
+    }
+  }
+};
+```
+
+### 3. **useMonitorTheme** - Event Listener auf `window` ohne SSR-Schutz
+```typescript
+// ⚠️ Problem: useEffect ohne window-Check in Server-Component
+useEffect(() => {
+  if (typeof window === 'undefined') return;
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', handler);
+  return () => mediaQuery.removeEventListener('change', handler);
+}, []);
+```
+**Status:** ✅ Korrekt implementiert (SSR-Schutz vorhanden)
+
+---
+
+## 🚫 Anti-Patterns
+
+### 1. **useMatchTimer** - Deprecated Hook wird immer noch exportiert
+```typescript
+// ⚠️ Problem: Deprecated Hook wird in index.ts exportiert
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- Exported for backwards compatibility
+export { useMatchTimer, useMatchTimerExtended } from './useMatchTimer';
+```
+**Empfehlung:** Deprecated Hooks sollten in einem separaten `legacy/` Ordner liegen und in v2 entfernt werden.
+
+### 2. **useLiveMatches** - `Map` als React State
+```typescript
+// ⚠️ Problem: Map-Referenz ändert sich bei jedem Update
+const [liveMatches, setLiveMatches] = useState<Map<string, LiveMatch>>(new Map());
+```
+**Besser:** Verwende Objekt oder Array mit `useReducer` für komplexe State-Logik.
+
+### 3. **useAutoSave** - Stale Closure in `saveAsDraft`
+```typescript
+// ⚠️ Problem: hasUnsavedChanges in useCallback hat formData als Dependency
+const saveAsDraft = useCallback(() => {
+  if (!hasUnsavedChanges()) return; // ⚠️ Stale closure wenn formData sich ändert
+  // ...
+}, [hasUnsavedChanges, formData, saveTournament, showSaveConfirmation, createDraftTournament, lastSavedDataRef]);
+```
+**Fix:**
+```typescript
+const saveAsDraft = useCallback(() => {
+  const hasChanges = hasUnsavedChanges(); // Aufruf in der Funktion
+  if (!hasChanges) return;
+  // ...
+}, [hasUnsavedChanges, formData, saveTournament, showSaveConfirmation, createDraftTournament, lastSavedDataRef]);
+```
+
+### 4. **useMatchSound** - Audio-Element wird nicht bei Sound-Wechsel aktualisiert
+```typescript
+// ⚠️ Problem: audioRef.current wird nur einmal erstellt
+audioRef.current ??= new Audio();
+
+audioRef.current.src = soundUrl;
+audioRef.current.volume = volume / 100;
+```
+**Fix:**
+```typescript
+// ✅ Erstelle neues Audio-Element bei Sound-Wechsel
+useEffect(() => {
+  const audio = new Audio();
+  audioRef.current = audio;
+  audio.src = soundUrl;
+  audio.volume = volume / 100;
+  
+  return () => {
+    audio.pause();
+    audio.src = '';
+  };
+}, [soundUrl, volume]);
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **useBreakpoint** - Passive Event Listener
+```typescript
+// ✅ Performance-optimiert
+window.addEventListener('resize', handleResize, { passive: true });
+```
+
+### 2. **useFocusTrap** - WCAG 4.1.3 Compliance
+```typescript
+// ✅ Accessibility-first Implementierung
+element.setAttribute('inert', '');
+// Focus restoration on close
+returnTarget?.focus();
+```
+
+### 3. **useMonitorHeartbeats** - Realtime mit Supabase
+```typescript
+// ✅ Gute Realtime-Implementierung
+const channel = supabase
+  .channel(`heartbeats:${tournamentId}`)
+  .on('postgres_changes', { /* ... */ }, (payload) => {
+    // ...
+  })
+  .subscribe();
+```
+
+### 4. **useLocalStorage** - Try-Catch für Storage-Fehler
+```typescript
+// ✅ Robust gegen Storage-Quota-Errors
+try {
+  const item = window.localStorage.getItem(key);
+  // ...
+} catch (error) {
+  console.error(`Error loading localStorage key "${key}":`, error);
+  return initialValue;
+}
+```
+
+### 5. **useDebounce** - `useDebouncedCallback` mit Ref für Callback
+```typescript
+// ✅ Vermeidet Stale Closures
+const callbackRef = useRef(callback);
+useEffect(() => {
+  callbackRef.current = callback;
+}, [callback]);
+```
+
+---
+
+## 📊 State Management Score: **6.5/10**
+
+### Stärken:
+- ✅ Gute Context-Architektur (RepositoryContext)
+- ✅ Viele Hooks mit korrektem Cleanup
+- ✅ SSR-Schutz in den meisten Hooks
+- ✅ Accessibility-First (useFocusTrap, useHighContrast)
+- ✅ Realtime-Implementierung mit Supabase
+
+### Schwächen:
+- ❌ `Map`/`Set` als State führt zu unnötigen Re-Renders
+- ❌ Teure Berechnungen (`JSON.stringify`) bei jedem Render
+- ❌ `requestAnimationFrame` für Sekunden-Updates (Overkill)
+- ❌ Fehlende `useMemo` für abgeleitete State-Werte
+- ❌ Deprecated Hooks werden immer noch exportiert
+
+---
+
+## 🔧 Priorisierte Fixes
+
+### **P0 (Critical):**
+1. **useMatchTimer**: Von `requestAnimationFrame` zu `setInterval` wechseln
+2. **useLiveMatches**: `Map` State durch `useReducer` ersetzen
+3. **useAutoSave**: `JSON.stringify` memoisieren
+
+### **P1 (High):**
+4. **useMatchCockpitPro**: `effectiveSettings` mit `useMemo` umschließen
+5. **useCorporateColors**: `effectiveSettings` mit `useMemo` umschließen
+6. **useDialogTimer**: Interval-Cleanup robust machen
+
+### **P2 (Medium):**
+7. **useMatchSound**: Audio-Element bei Sound-Wechsel neu erstellen
+8. **useFocusTrap**: Element-Existenz im Cleanup prüfen
+9. Deprecated Hooks in `legacy/` Ordner verschieben
+
+---
+
+## 📈 Empfohlene Architekturbesserungen
+
+### 1. **State Normalisierung**
+```typescript
+// ❌ Current: Map<string, LiveMatch>
+const [liveMatches, setLiveMatches] = useState<Map<string, LiveMatch>>(new Map());
+
+// ✅ Better: Normalized State
+interface LiveMatchesState {
+  byId: Record<string, LiveMatch>;
+  ids: string[];
+}
+const [state, setState] = useReducer(liveMatchesReducer, initialState);
+```
+
+### 2. **Custom Hook Composition**
+```typescript
+// ✅ Verwende Hooks aus anderen Hooks
+export function useMatchCockpitPro() {
+  const timer = useMatchTimerExtended(/* ... */);
+  const sound = useMatchSound(/* ... */);
+  const haptic = useHapticFeedback(/* ... */);
+  
+  // Kombiniere Logik hier
+  return { timer, sound, haptic };
+}
+```
+
+### 3. **Zustands-Management mit Zustand/Jotai**
+```typescript
+// ✅ Für komplexe State-Logik (LiveMatches, Tournament)
+import { create } from 'zustand';
+
+interface LiveMatchesStore {
+  matches: Map<string, LiveMatch>;
+  addMatch: (match: LiveMatch) => void;
+  updateMatch: (id: string, updates: Partial<LiveMatch>) => void;
+  // ...
+}
+
+export const useLiveMatchesStore = create<LiveMatchesStore>((set) => ({
+  matches: new Map(),
+  addMatch: (match) => set((state) => ({
+    matches: new Map(state.matches).set(match.id, match)
+  })),
+  // ...
+}));
+```
+
+---
+
+**Gesamtbeurteilung:** Solide Basis mit guter Architektur, aber Performance-Optimierungen bei State-Updates und Re-Renders sind dringend erforderlich. Die Realtime-Implementierung ist hervorragend, aber die State-Management-Patterns sollten modernisiert werden.

--- a/reviews/2026-05-07_2056_SUMMARY.md
+++ b/reviews/2026-05-07_2056_SUMMARY.md
@@ -1,0 +1,378 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:56  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 41.6s  
+**Agents:** 1  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | UI-Komponenten & Design System | success | 41.6s | 147.8k | 48490 |
+
+---
+
+## UI-Komponenten & Design System
+
+
+
+# UI-Komponenten Review: hallenfussball-pwa
+
+## Executive Summary
+
+**UI Component Score: 7/10**
+
+Das Design-System ist grundsätzlich solide mit gutem Mobile-First-Ansatz, aber es gibt signifikante Inkonsistenzen im Styling-Pattern und einige kritische Accessibility-Verstösse.
+
+---
+
+## 1. INKONSISTENZEN
+
+### Styling Pattern (Critical)
+
+| Pattern | Components | Count |
+|---------|-----------|-------|
+| **Inline CSS + CSSProperties** | ActionMenu, BottomActionBar, BottomNavigation, Button, Card, etc. | ~20 |
+| **CSS Modules** | Skeleton, Toast | 2 |
+| **Mixed (Inline + `<style>` tags)** | BottomSheet, ConfirmDialog, ConnectionStatusBar | 5 |
+
+**Problem:** Drei verschiedene Styling-Ansätze erschweren Wartung und führen zu Bundle-Bloat.
+
+### Touch Target Sizes (Critical)
+
+```tsx
+// ❌ ActionMenu: 36x36px (unter WCAG Minimum!)
+const triggerStyle: CSSProperties = {
+  width: '36px',
+  height: '36px',
+};
+
+// ✅ Button: 44x44px (WCAG compliant)
+minHeight: '44px',
+
+// ✅ PasswordInput: 44x44px
+width: '44px', height: '44px',
+```
+
+### Form Component API (Major)
+
+| Component | `error` | `errorMessage` | Auto-set error |
+|-----------|---------|----------------|----------------|
+| Input | ✅ | ✅ | ✅ |
+| Select | ✅ | ❌ | ❌ |
+| Combobox | ✅ | ❌ | ❌ |
+| PasswordInput | ❌ | ❌ | ❌ |
+
+### Animation System (Major)
+
+```tsx
+// Pattern 1: Inline Keyframes in <style> tag
+<style>{`@keyframes menuFadeIn {...}`}</style>
+
+// Pattern 2: CSS Modules
+import styles from './Toast.module.css';
+
+// Pattern 3: Imported transitions
+import { transitions } from '../../styles/motion';
+```
+
+---
+
+## 2. ACCESSIBILITY-VERSTÖSSE (WCAG 2.1 AA)
+
+### Critical Issues
+
+| Component | Issue | WCAG Ref | Severity |
+|-----------|-------|----------|----------|
+| **ActionMenu Trigger** | 36x36px Touch Target | 2.5.5 Target Size | 🔴 Critical |
+| **PasswordInput Toggle** | `tabIndex={-1}` - nicht keyboard-navigierbar | 2.1.1 Keyboard | 🔴 Critical |
+| **ColorPicker Presets** | Keine Focus States | 2.4.7 Focus Visible | 🔴 Critical |
+| **Collapsible Panels** | `role="button"` ohne `aria-pressed` | 4.1.2 Name, Role, Value | 🔴 Critical |
+
+### Major Issues
+
+| Component | Issue | WCAG Ref | Severity |
+|-----------|-------|----------|----------|
+| **BottomNavigation** | Keine Keyboard-Navigation für Tabs | 2.1.1 Keyboard | 🟠 Major |
+| **NumberStepper** | Buttons ohne `aria-label` | 4.1.2 Name, Role, Value | 🟠 Major |
+| **ConfirmDialog** | Hardcoded `aria-labelledby` ID | 4.1.1 Parsing | 🟠 Major |
+| **Toast** | `role="alert"` für alle Typen | 4.1.3 Status Messages | 🟠 Major |
+| **Icons** | Viele ohne zugängliche Alternative | 1.1.1 Non-text Content | 🟠 Major |
+
+### Minor Issues
+
+- ProgressRing: `aria-valuenow` nicht konsistent
+- TeamAvatar: Initials ohne Text-Alternative
+- Skeleton: Keine `aria-live` Region
+
+---
+
+## 3. DESIGN-TOKEN-VERSTÖSSE
+
+### Hardcoded Values (Critical)
+
+```tsx
+// ❌ Should be in design-tokens
+const triggerStyle: CSSProperties = {
+  width: '36px',        // Should be cssVars.touchTargets.min
+  height: '36px',       // Should be cssVars.touchTargets.min
+};
+
+// ❌ Should be in design-tokens
+const containerStyle: CSSProperties = {
+  zIndex: 1100,         // Should be cssVars.zIndex.menu
+  top: 'calc(100% + 4px)', // Should be cssVars.spacing.menuOffset
+  minWidth: '180px',    // Should be cssVars.sizes.menuMinWidth
+};
+
+// ❌ Should be in design-tokens
+const toastContainerStyle: CSSProperties = {
+  bottom: 24,           // Should be cssVars.spacing.toastBottom
+  right: 24,            // Should be cssVars.spacing.toastRight
+  zIndex: 9999,         // Should be cssVars.zIndex.toast
+};
+```
+
+### Inconsistent Token Usage
+
+```tsx
+// ❌ Mixed border radius
+borderRadius: cssVars.borderRadius.md,
+borderRadius: '16px 16px 0 0',  // BottomSheet
+
+// ❌ Mixed spacing
+padding: cssVars.spacing.md,
+padding: `${cssVars.spacing.sm} ${cssVars.spacing.md}`,
+padding: '0 16px',  // Some components
+
+// ❌ Multiple surface variants
+cssVars.colors.surface,
+cssVars.colors.surfaceLight,
+cssVars.colors.surfaceSubtle,
+cssVars.colors.surfaceDarkMedium,
+```
+
+---
+
+## 4. VERBESSERUNGSVORSCHLÄGE
+
+### Priority 1: Critical Fixes
+
+```tsx
+// 1. Fix ActionMenu Touch Target
+const triggerStyle: CSSProperties = {
+  width: cssVars.touchTargets.minimum,  // 44px
+  height: cssVars.touchTargets.minimum,
+};
+
+// 2. Fix PasswordInput Toggle
+<button
+  type="button"
+  onClick={() => setShowPassword(prev => !prev)}
+  aria-label={showPassword ? 'Passwort verbergen' : 'Passwort anzeigen'}
+  tabIndex={0}  // Remove -1!
+>
+  {showPassword ? '◉' : '○'}
+</button>
+
+// 3. Add aria-pressed to Collapsible Panels
+<button
+  role="button"
+  tabIndex={0}
+  aria-expanded={!isCollapsed}
+  aria-pressed={!isCollapsed}  // Add this!
+  aria-controls={contentId}
+>
+```
+
+### Priority 2: Architecture
+
+```tsx
+// Create unified styling system
+// Option A: CSS Modules (recommended)
+// components/ui/Button/Button.module.css
+// components/ui/Button/Button.tsx
+
+// Option B: CSS-in-JS with tokens
+import { styled } from 'styled-components';
+const Button = styled.button`
+  padding: ${cssVars.spacing.md} ${cssVars.spacing.lg};
+  background: ${cssVars.colors.primary};
+`;
+
+// Migrate ALL components to ONE pattern
+```
+
+### Priority 3: Design Token Expansion
+
+```tsx
+// Add to design-tokens.ts
+export const zIndices = {
+  base: 0,
+  content: 100,
+  sticky: 200,
+  dropdown: 300,
+  modal: 1000,
+  popover: 1100,
+  toast: 9999,
+} as const;
+
+export const touchTargets = {
+  minimum: '44px',
+  comfortable: '48px',
+} as const;
+
+export const menuOffsets = {
+  dropdown: 'calc(100% + 4px)',
+  popover: 'calc(100% + 8px)',
+} as const;
+```
+
+### Priority 4: Component API Standardization
+
+```tsx
+// Create FormField wrapper component
+interface FormFieldProps {
+  label?: string;
+  error?: boolean;
+  errorMessage?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+export const FormField: React.FC<FormFieldProps> = ({
+  label,
+  error = false,
+  errorMessage,
+  required,
+  children,
+}) => {
+  const hasError = error || !!errorMessage;
+  
+  return (
+    <div>
+      {label && <label>{label}{required && ' *'}</label>}
+      {children}
+      {errorMessage && <span role="alert">{errorMessage}</span>}
+    </div>
+  );
+};
+
+// Use in all form components
+<FormField label="Name" error={hasError} errorMessage={errorMsg}>
+  <Input ... />
+</FormField>
+```
+
+### Priority 5: Accessibility Enhancements
+
+```tsx
+// Add keyboard navigation to BottomNavigation
+const handleKeyDown = (e: React.KeyboardEvent, tab: BottomNavTab) => {
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    const currentIndex = NAV_ITEMS.findIndex(item => item.id === tab);
+    const nextIndex = (currentIndex + 1) % NAV_ITEMS.length;
+    onTabChange(NAV_ITEMS[nextIndex].id);
+  }
+};
+
+// Add focus trap to all modals (already in use, ensure consistency)
+const focusTrap = useFocusTrap({
+  isActive: isOpen,
+  onEscape: onClose,
+  initialFocus: confirmButtonRef,  // Focus specific element
+});
+```
+
+---
+
+## 5. UI COMPONENT SCORE BREAKDOWN
+
+| Category | Score | Notes |
+|----------|-------|-------|
+| **Design Consistency** | 6/10 | Three styling patterns, mixed tokens |
+| **Accessibility** | 6/10 | Critical issues with touch targets & keyboard |
+| **Code Quality** | 8/10 | Good TypeScript, some memoization needed |
+| **Mobile UX** | 9/10 | Excellent safe-area handling |
+| **Performance** | 7/10 | Inline styles hurt performance |
+| **Maintainability** | 6/10 | Inconsistent patterns increase cognitive load |
+| **Documentation** | 7/10 | Good JSDoc, missing Storybook |
+
+**Overall: 7/10**
+
+---
+
+## 6. ACTION PLAN
+
+### Week 1: Critical Fixes
+- [ ] Fix ActionMenu 36x36px → 44x44px
+- [ ] Fix PasswordInput tabIndex
+- [ ] Add aria-pressed to collapsible panels
+- [ ] Add keyboard navigation to BottomNavigation
+
+### Week 2: Architecture
+- [ ] Choose ONE styling pattern (CSS Modules recommended)
+- [ ] Migrate 5 core components to new pattern
+- [ ] Create FormField wrapper component
+
+### Week 3: Tokens
+- [ ] Add missing z-index tokens
+- [ ] Add touch target tokens
+- [ ] Add menu offset tokens
+- [ ] Refactor hardcoded values
+
+### Week 4: Testing & Docs
+- [ ] Add Storybook for all components
+- [ ] Add a11y tests with axe-core
+- [ ] Document component patterns
+
+---
+
+## 7. POSITIVE HIGHLIGHTS
+
+✅ **Excellent Mobile-First Design**
+- Safe area insets properly handled
+- Touch targets generally good (except ActionMenu)
+- Responsive animations
+
+✅ **Good Accessibility Awareness**
+- Focus Trap implementation
+- ARIA labels on interactive elements
+- Reduced motion support
+
+✅ **Solid TypeScript Usage**
+- Good type definitions
+- Props interfaces well documented
+
+✅ **Smart Component Design**
+- Skeleton presets for common patterns
+- TeamAvatar with fallback initials
+- SyncIndicator with multiple variants
+
+---
+
+## 8. RECOMMENDATIONS
+
+### Short Term (1-2 weeks)
+1. Fix critical accessibility issues
+2. Add Storybook for documentation
+3. Create consistent FormField component
+
+### Medium Term (1-2 months)
+1. Migrate to single styling pattern
+2. Expand design token coverage
+3. Add comprehensive a11y testing
+
+### Long Term (3-6 months)
+1. Consider design system library (Radix UI, Headless UI)
+2. Implement design token export for theming
+3. Create component usage guidelines
+
+---
+
+**Zusammenfassung:** Die UI-Komponenten sind funktional und gut durchdacht, benötigen aber Konsistenz-Work in Styling und einige kritische Accessibility-Fixes, um Production-Ready für Barrierefreiheit zu sein. Mit den vorgeschlagenen Verbesserungen kann das System auf 8.5-9/10 steigen.
+
+---
+

--- a/reviews/2026-05-07_2056_components_ui.md
+++ b/reviews/2026-05-07_2056_components_ui.md
@@ -1,0 +1,548 @@
+# Code Review: UI-Komponenten & Design System
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 41.6s  
+**Status:** success  
+**Code-Kontext:** 147,788 Zeichen  
+
+<details><summary>Thinking Process (8,393 Zeichen)</summary>
+
+Der Nutzer hat mir einen umfangreichen Code-Review-Request für eine React-PWA namens "hallenfussball-pwa" gesendet. Ich soll als Frontend-Architect mit Fokus auf Component Libraries die UI-Komponenten analysieren.
+
+Ich habe 147,788 Zeichen Code erhalten, aber das Budget wurde bei 145,857 Zeichen erreicht, also wurden einige Dateien übersprungen. Trotzdem habe ich genug Informationen, um ein strukturiertes Review zu erstellen.
+
+Ich muss folgende Punkte analysieren:
+1. **Inkonsistenzen** (verschiedene Patterns für gleiche Dinge)
+2. **Accessibility-Verstösse** (WCAG 2.1 AA)
+3. **Design-Token-Verstösse** (hardcodierte Farben/Grössen)
+4. **Verbesserungsvorschläge**
+5. **UI Component Score** (1-10)
+
+Lass mich systematisch durchgehen:
+
+## 1. INKONSISTENZEN
+
+### Styling Pattern
+- **ActionMenu**: Verwendet inline CSS-Styles mit `CSSProperties`
+- **BottomActionBar**: Verwendet inline CSS-Styles
+- **BottomNavigation**: Verwendet inline CSS-Styles
+- **BottomSheet**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **Button**: Verwendet inline CSS-Styles + `transitions` import
+- **Card**: Verwendet inline CSS-Styles
+- **CollapsibleInfoPanel**: Verwendet inline CSS-Styles
+- **CollapsibleSection**: Verwendet inline CSS-Styles
+- **ColorPicker**: Verwendet inline CSS-Styles
+- **Combobox**: Verwendet inline CSS-Styles
+- **ConfirmDialog**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **ConnectionStatusBar**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **Input**: Verwendet inline CSS-Styles
+- **LogoUploadDialog**: Verwendet inline CSS-Styles
+- **NumberStepper**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **PasswordInput**: Verwendet inline CSS-Styles (konstante `styles` Objekt)
+- **ProgressRing**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **PublicBottomNav**: Verwendet inline CSS-Styles
+- **ScoreStepper**: Verwendet inline CSS-Styles
+- **Select**: Verwendet inline CSS-Styles
+- **Skeleton**: Verwendet CSS Modules (`Skeleton.module.css`)
+- **SyncIndicator**: Verwendet inline CSS-Styles + `<style>` Tag für Keyframes
+- **TeamAvatar**: Verwendet inline CSS-Styles
+- **Toast**: Verwendet CSS Modules (`Toast.module.css`)
+
+**Major Inconsistency**: Die meisten Komponenten verwenden Inline-Styles, aber Skeleton und Toast verwenden CSS Modules. Das ist inkonsistent!
+
+### Touch Target Sizes
+- **Button**: `minHeight: '44px'` (sm, md), `48px` (lg)
+- **Input**: `height: cssVars.touchTargets.minimum`
+- **Select**: `height: cssVars.touchTargets.minimum`
+- **Combobox**: `height: cssVars.touchTargets.minimum`
+- **ActionMenu**: `width: '36px', height: '36px'` (zu klein!)
+- **PasswordInput**: `width: '44px', height: '44px'`
+- **BottomNavigation**: `minWidth: '44px', minHeight: '44px'`
+- **BottomActionBar**: `minHeight: '44px'`
+- **NumberStepper**: `minWidth: '44px', height: '44px'`
+- **ScoreStepper**: `width: '44px', height: '44px'`
+
+**Inconsistency**: ActionMenu Trigger ist 36x36px, was unter dem WCAG Minimum von 44x44px liegt!
+
+### Animation Patterns
+- **Keyframes in `<style>` tags**: BottomSheet, ConfirmDialog, ConnectionStatusBar, NumberStepper, ProgressRing, SyncIndicator
+- **CSS Modules**: Skeleton, Toast
+- **transitions import**: Button
+
+**Inconsistency**: Drei verschiedene Animation-Ansätze!
+
+### Focus Management
+- **ActionMenu**: `triggerRef.current?.focus()` auf Escape
+- **BottomSheet**: `useFocusTrap` Hook
+- **ConfirmDialog**: `useFocusTrap` Hook + `confirmButtonRef.current?.focus()`
+- **Button**: `isFocusVisible` mit `:focus-visible`
+
+**Mixed**: Gute Praxis mit Focus Trap, aber nicht überall konsistent.
+
+### Error States
+- **Input**: `error` prop + `errorMessage` prop (auto-sets error)
+- **Select**: `error` prop (keine errorMessage)
+- **Combobox**: `error` prop (keine errorMessage)
+- **PasswordInput**: Keine Error-Props!
+
+**Inconsistency**: Nicht alle Form-Inputs haben konsistente Error-Handling.
+
+## 2. ACCESSIBILITY-VERSTÖSSE
+
+### WCAG 2.1 AA Issues
+
+**Critical:**
+1. **ActionMenu Trigger (36x36px)** - Unter dem 44x44px Touch Target Minimum
+2. **ColorPicker Preset Buttons** - Keine sichtbaren Focus States (nur Hover)
+3. **CollapsibleInfoPanel/CollapsibleSection** - `role="button"` aber keine `aria-pressed` State
+4. **BottomNavigation** - `aria-current="page"` ist gut, aber keine Keyboard-Navigation für Tabs
+5. **Toast** - `aria-live="polite"` ist gut, aber keine `role="status"` für wichtige Benachrichtigungen
+
+**Major:**
+1. **Icons ohne Labels** - Viele Icons haben `aria-hidden="true"` aber keine zugängliche Alternative
+2. **ConfirmDialog** - `aria-labelledby="confirm-dialog-title"` ist hardcoded, sollte dynamisch sein
+3. **PasswordInput** - Toggle Button hat `tabIndex={-1}` (kann nicht per Keyboard erreicht werden!)
+4. **Skeleton** - `aria-busy="true"` ist gut, aber keine `aria-live` Region
+5. **NumberStepper** - Buttons haben keine `aria-label` für Screen Reader
+
+**Minor:**
+1. **Toast** - `role="alert"` sollte nur für kritische Fehler sein, nicht für alle Toasts
+2. **ProgressRing** - `aria-valuenow` wird verwendet, aber nicht konsistent
+3. **TeamAvatar** - `alt` Text ist dynamisch, aber bei Initials fehlt der Text
+
+## 3. DESIGN-TOKEN-VERSTÖSSE
+
+### Hardcoded Values
+- **ActionMenu**: `top: 'calc(100% + 4px)'`, `minWidth: '180px'`
+- **BottomNavigation**: `height: '56px'`, `paddingBottom: 'env(safe-area-inset-bottom, 0px)'`
+- **BottomSheet**: `maxHeight: '80vh'`, `borderRadius: '16px 16px 0 0'`
+- **ConfirmDialog**: `maxWidth: '480px'`, `padding: cssVars.spacing.lg`
+- **ConnectionStatusBar**: `minHeight: '32px'`, `fontSize: cssVars.fontSizes.sm`
+- **Input**: `paddingRight: '52px'` (PasswordInput)
+- **PasswordInput**: `right: '4px'`, `paddingRight: '52px'`
+- **ToastContainer**: `bottom: 24`, `right: 24` (nicht aus Tokens!)
+- **TeamAvatar**: `ringWidth = size === 'xs' ? 2 : size === 'sm' ? 2 : 3` (hardcoded)
+
+### Missing Token Usage
+- **ActionMenu**: `zIndex: 1100` (hardcoded comment)
+- **BottomNavigation**: `zIndex: 1000` (hardcoded comment)
+- **ToastContainer**: `zIndex: 9999` (hardcoded)
+- **ProgressRing**: `strokeWidth = 3` (hardcoded default)
+- **NumberStepper**: `height: '8px'` (Slider)
+
+### Inconsistent Token References
+- `cssVars.colors.surface` vs `cssVars.colors.surfaceLight` vs `cssVars.colors.surfaceSubtle`
+- `cssVars.spacing.md` vs `cssVars.spacing.lg` (nicht konsistent)
+- `cssVars.borderRadius.md` vs `cssVars.borderRadius.lg` vs `'16px'` (hardcoded)
+
+## 4. VERBESSERUNGSVORSCHLÄGE
+
+### Architecture
+1. **Einheitliches Styling-System**: Entweder CSS Modules für ALLES oder Inline Styles für ALLES (oder CSS-in-JS)
+2. **Design Token Konsolidierung**: Alle Hardcoded Values in Tokens verschieben
+3. **Komponenten-API Standardisierung**: Alle Form-Inputs sollten `error` + `errorMessage` Props haben
+4. **Animation System**: Zentrales Animation-System mit CSS Modules oder CSS Variables
+
+### Accessibility
+1. **Touch Targets**: Alle Buttons auf mindestens 44x44px
+2. **Focus Management**: Konsistente Focus Trap in allen Modals
+3. **Keyboard Navigation**: Alle interaktiven Elemente keyboard-navigierbar
+4. **Screen Reader Support**: Alle Icons mit `aria-label` oder `aria-hidden`
+5. **Reduced Motion**: `prefers-reduced-motion` in ALLEN Komponenten respektieren
+
+### Performance
+1. **Memoization**: `useCallback` für Event Handler in Child Components
+2. **Lazy Loading**: Icons lazy importieren
+3. **Bundle Size**: CSS Modules statt Inline Styles reduzieren Bundle Size
+4. **Animation Performance**: `transform` und `opacity` für Animationen verwenden
+
+### Code Quality
+1. **Type Safety**: Props-Interfaces konsistent dokumentieren
+2. **Error Boundaries**: Components mit Error Boundaries umgeben
+3. **Testing**: E2E Tests mit `data-testid` konsistent
+4. **Documentation**: Storybook für alle Components
+
+## 5. UI COMPONENT SCORE
+
+**Gesamtbewertung: 7/10**
+
+**Stärken:**
+- ✅ Guter Design Token Einsatz (meistens)
+- ✅ Mobile-First Ansatz
+- ✅ Accessibility Awareness (Focus Trap, ARIA Labels)
+- ✅ Responsive Design (safe-area-inset)
+- ✅ Reduced Motion Support
+- ✅ Typisierung mit TypeScript
+
+**Schwächen:**
+- ❌ Inkonsistentes Styling Pattern (Inline vs CSS Modules)
+- ❌ Einige Hardcoded Values
+- ❌ ActionMenu Touch Target zu klein
+- ❌ PasswordInput Toggle nicht keyboard-navigierbar
+- ❌ Error States nicht konsistent
+
+**Empfehlung:** 7/10 ist solide, aber es gibt Raum für Verbesserungen in Konsistenz und Accessibility.
+
+
+</details>
+
+---
+
+
+
+# UI-Komponenten Review: hallenfussball-pwa
+
+## Executive Summary
+
+**UI Component Score: 7/10**
+
+Das Design-System ist grundsätzlich solide mit gutem Mobile-First-Ansatz, aber es gibt signifikante Inkonsistenzen im Styling-Pattern und einige kritische Accessibility-Verstösse.
+
+---
+
+## 1. INKONSISTENZEN
+
+### Styling Pattern (Critical)
+
+| Pattern | Components | Count |
+|---------|-----------|-------|
+| **Inline CSS + CSSProperties** | ActionMenu, BottomActionBar, BottomNavigation, Button, Card, etc. | ~20 |
+| **CSS Modules** | Skeleton, Toast | 2 |
+| **Mixed (Inline + `<style>` tags)** | BottomSheet, ConfirmDialog, ConnectionStatusBar | 5 |
+
+**Problem:** Drei verschiedene Styling-Ansätze erschweren Wartung und führen zu Bundle-Bloat.
+
+### Touch Target Sizes (Critical)
+
+```tsx
+// ❌ ActionMenu: 36x36px (unter WCAG Minimum!)
+const triggerStyle: CSSProperties = {
+  width: '36px',
+  height: '36px',
+};
+
+// ✅ Button: 44x44px (WCAG compliant)
+minHeight: '44px',
+
+// ✅ PasswordInput: 44x44px
+width: '44px', height: '44px',
+```
+
+### Form Component API (Major)
+
+| Component | `error` | `errorMessage` | Auto-set error |
+|-----------|---------|----------------|----------------|
+| Input | ✅ | ✅ | ✅ |
+| Select | ✅ | ❌ | ❌ |
+| Combobox | ✅ | ❌ | ❌ |
+| PasswordInput | ❌ | ❌ | ❌ |
+
+### Animation System (Major)
+
+```tsx
+// Pattern 1: Inline Keyframes in <style> tag
+<style>{`@keyframes menuFadeIn {...}`}</style>
+
+// Pattern 2: CSS Modules
+import styles from './Toast.module.css';
+
+// Pattern 3: Imported transitions
+import { transitions } from '../../styles/motion';
+```
+
+---
+
+## 2. ACCESSIBILITY-VERSTÖSSE (WCAG 2.1 AA)
+
+### Critical Issues
+
+| Component | Issue | WCAG Ref | Severity |
+|-----------|-------|----------|----------|
+| **ActionMenu Trigger** | 36x36px Touch Target | 2.5.5 Target Size | 🔴 Critical |
+| **PasswordInput Toggle** | `tabIndex={-1}` - nicht keyboard-navigierbar | 2.1.1 Keyboard | 🔴 Critical |
+| **ColorPicker Presets** | Keine Focus States | 2.4.7 Focus Visible | 🔴 Critical |
+| **Collapsible Panels** | `role="button"` ohne `aria-pressed` | 4.1.2 Name, Role, Value | 🔴 Critical |
+
+### Major Issues
+
+| Component | Issue | WCAG Ref | Severity |
+|-----------|-------|----------|----------|
+| **BottomNavigation** | Keine Keyboard-Navigation für Tabs | 2.1.1 Keyboard | 🟠 Major |
+| **NumberStepper** | Buttons ohne `aria-label` | 4.1.2 Name, Role, Value | 🟠 Major |
+| **ConfirmDialog** | Hardcoded `aria-labelledby` ID | 4.1.1 Parsing | 🟠 Major |
+| **Toast** | `role="alert"` für alle Typen | 4.1.3 Status Messages | 🟠 Major |
+| **Icons** | Viele ohne zugängliche Alternative | 1.1.1 Non-text Content | 🟠 Major |
+
+### Minor Issues
+
+- ProgressRing: `aria-valuenow` nicht konsistent
+- TeamAvatar: Initials ohne Text-Alternative
+- Skeleton: Keine `aria-live` Region
+
+---
+
+## 3. DESIGN-TOKEN-VERSTÖSSE
+
+### Hardcoded Values (Critical)
+
+```tsx
+// ❌ Should be in design-tokens
+const triggerStyle: CSSProperties = {
+  width: '36px',        // Should be cssVars.touchTargets.min
+  height: '36px',       // Should be cssVars.touchTargets.min
+};
+
+// ❌ Should be in design-tokens
+const containerStyle: CSSProperties = {
+  zIndex: 1100,         // Should be cssVars.zIndex.menu
+  top: 'calc(100% + 4px)', // Should be cssVars.spacing.menuOffset
+  minWidth: '180px',    // Should be cssVars.sizes.menuMinWidth
+};
+
+// ❌ Should be in design-tokens
+const toastContainerStyle: CSSProperties = {
+  bottom: 24,           // Should be cssVars.spacing.toastBottom
+  right: 24,            // Should be cssVars.spacing.toastRight
+  zIndex: 9999,         // Should be cssVars.zIndex.toast
+};
+```
+
+### Inconsistent Token Usage
+
+```tsx
+// ❌ Mixed border radius
+borderRadius: cssVars.borderRadius.md,
+borderRadius: '16px 16px 0 0',  // BottomSheet
+
+// ❌ Mixed spacing
+padding: cssVars.spacing.md,
+padding: `${cssVars.spacing.sm} ${cssVars.spacing.md}`,
+padding: '0 16px',  // Some components
+
+// ❌ Multiple surface variants
+cssVars.colors.surface,
+cssVars.colors.surfaceLight,
+cssVars.colors.surfaceSubtle,
+cssVars.colors.surfaceDarkMedium,
+```
+
+---
+
+## 4. VERBESSERUNGSVORSCHLÄGE
+
+### Priority 1: Critical Fixes
+
+```tsx
+// 1. Fix ActionMenu Touch Target
+const triggerStyle: CSSProperties = {
+  width: cssVars.touchTargets.minimum,  // 44px
+  height: cssVars.touchTargets.minimum,
+};
+
+// 2. Fix PasswordInput Toggle
+<button
+  type="button"
+  onClick={() => setShowPassword(prev => !prev)}
+  aria-label={showPassword ? 'Passwort verbergen' : 'Passwort anzeigen'}
+  tabIndex={0}  // Remove -1!
+>
+  {showPassword ? '◉' : '○'}
+</button>
+
+// 3. Add aria-pressed to Collapsible Panels
+<button
+  role="button"
+  tabIndex={0}
+  aria-expanded={!isCollapsed}
+  aria-pressed={!isCollapsed}  // Add this!
+  aria-controls={contentId}
+>
+```
+
+### Priority 2: Architecture
+
+```tsx
+// Create unified styling system
+// Option A: CSS Modules (recommended)
+// components/ui/Button/Button.module.css
+// components/ui/Button/Button.tsx
+
+// Option B: CSS-in-JS with tokens
+import { styled } from 'styled-components';
+const Button = styled.button`
+  padding: ${cssVars.spacing.md} ${cssVars.spacing.lg};
+  background: ${cssVars.colors.primary};
+`;
+
+// Migrate ALL components to ONE pattern
+```
+
+### Priority 3: Design Token Expansion
+
+```tsx
+// Add to design-tokens.ts
+export const zIndices = {
+  base: 0,
+  content: 100,
+  sticky: 200,
+  dropdown: 300,
+  modal: 1000,
+  popover: 1100,
+  toast: 9999,
+} as const;
+
+export const touchTargets = {
+  minimum: '44px',
+  comfortable: '48px',
+} as const;
+
+export const menuOffsets = {
+  dropdown: 'calc(100% + 4px)',
+  popover: 'calc(100% + 8px)',
+} as const;
+```
+
+### Priority 4: Component API Standardization
+
+```tsx
+// Create FormField wrapper component
+interface FormFieldProps {
+  label?: string;
+  error?: boolean;
+  errorMessage?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+export const FormField: React.FC<FormFieldProps> = ({
+  label,
+  error = false,
+  errorMessage,
+  required,
+  children,
+}) => {
+  const hasError = error || !!errorMessage;
+  
+  return (
+    <div>
+      {label && <label>{label}{required && ' *'}</label>}
+      {children}
+      {errorMessage && <span role="alert">{errorMessage}</span>}
+    </div>
+  );
+};
+
+// Use in all form components
+<FormField label="Name" error={hasError} errorMessage={errorMsg}>
+  <Input ... />
+</FormField>
+```
+
+### Priority 5: Accessibility Enhancements
+
+```tsx
+// Add keyboard navigation to BottomNavigation
+const handleKeyDown = (e: React.KeyboardEvent, tab: BottomNavTab) => {
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    const currentIndex = NAV_ITEMS.findIndex(item => item.id === tab);
+    const nextIndex = (currentIndex + 1) % NAV_ITEMS.length;
+    onTabChange(NAV_ITEMS[nextIndex].id);
+  }
+};
+
+// Add focus trap to all modals (already in use, ensure consistency)
+const focusTrap = useFocusTrap({
+  isActive: isOpen,
+  onEscape: onClose,
+  initialFocus: confirmButtonRef,  // Focus specific element
+});
+```
+
+---
+
+## 5. UI COMPONENT SCORE BREAKDOWN
+
+| Category | Score | Notes |
+|----------|-------|-------|
+| **Design Consistency** | 6/10 | Three styling patterns, mixed tokens |
+| **Accessibility** | 6/10 | Critical issues with touch targets & keyboard |
+| **Code Quality** | 8/10 | Good TypeScript, some memoization needed |
+| **Mobile UX** | 9/10 | Excellent safe-area handling |
+| **Performance** | 7/10 | Inline styles hurt performance |
+| **Maintainability** | 6/10 | Inconsistent patterns increase cognitive load |
+| **Documentation** | 7/10 | Good JSDoc, missing Storybook |
+
+**Overall: 7/10**
+
+---
+
+## 6. ACTION PLAN
+
+### Week 1: Critical Fixes
+- [ ] Fix ActionMenu 36x36px → 44x44px
+- [ ] Fix PasswordInput tabIndex
+- [ ] Add aria-pressed to collapsible panels
+- [ ] Add keyboard navigation to BottomNavigation
+
+### Week 2: Architecture
+- [ ] Choose ONE styling pattern (CSS Modules recommended)
+- [ ] Migrate 5 core components to new pattern
+- [ ] Create FormField wrapper component
+
+### Week 3: Tokens
+- [ ] Add missing z-index tokens
+- [ ] Add touch target tokens
+- [ ] Add menu offset tokens
+- [ ] Refactor hardcoded values
+
+### Week 4: Testing & Docs
+- [ ] Add Storybook for all components
+- [ ] Add a11y tests with axe-core
+- [ ] Document component patterns
+
+---
+
+## 7. POSITIVE HIGHLIGHTS
+
+✅ **Excellent Mobile-First Design**
+- Safe area insets properly handled
+- Touch targets generally good (except ActionMenu)
+- Responsive animations
+
+✅ **Good Accessibility Awareness**
+- Focus Trap implementation
+- ARIA labels on interactive elements
+- Reduced motion support
+
+✅ **Solid TypeScript Usage**
+- Good type definitions
+- Props interfaces well documented
+
+✅ **Smart Component Design**
+- Skeleton presets for common patterns
+- TeamAvatar with fallback initials
+- SyncIndicator with multiple variants
+
+---
+
+## 8. RECOMMENDATIONS
+
+### Short Term (1-2 weeks)
+1. Fix critical accessibility issues
+2. Add Storybook for documentation
+3. Create consistent FormField component
+
+### Medium Term (1-2 months)
+1. Migrate to single styling pattern
+2. Expand design token coverage
+3. Add comprehensive a11y testing
+
+### Long Term (3-6 months)
+1. Consider design system library (Radix UI, Headless UI)
+2. Implement design token export for theming
+3. Create component usage guidelines
+
+---
+
+**Zusammenfassung:** Die UI-Komponenten sind funktional und gut durchdacht, benötigen aber Konsistenz-Work in Styling und einige kritische Accessibility-Fixes, um Production-Ready für Barrierefreiheit zu sein. Mit den vorgeschlagenen Verbesserungen kann das System auf 8.5-9/10 steigen.

--- a/reviews/2026-05-07_2058_SUMMARY.md
+++ b/reviews/2026-05-07_2058_SUMMARY.md
@@ -1,0 +1,401 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:58  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 37.5s  
+**Agents:** 1  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Sport-Konfiguration & Datenmodell | success | 37.5s | 134.3k | 44535 |
+
+---
+
+## Sport-Konfiguration & Datenmodell
+
+
+
+# 🏆 Domain-Expert Review: Sportturnier-Software
+
+## Executive Summary
+
+Das Datenmodell ist **grundsätzlich solide strukturiert** mit guter Trennung zwischen Sport-Konfiguration, Runtime-Modellen und Persistenz. Es gibt jedoch **kritische Inkonsistenzen** bei Datentypen (insbesondere Date-Handling), fehlende Invarianten-Validierung und Probleme bei der Erweiterbarkeit für neue Sportarten.
+
+---
+
+## 📊 Datenmodell Score: 7.2/10
+
+| Kategorie | Score | Bewertung |
+|-----------|-------|-----------|
+| **Struktur & Trennung** | 8.5/10 | Gute Trennung zwischen Konfiguration, Runtime & Persistenz |
+| **Typ-Sicherheit** | 7.0/10 | TypeScript gut genutzt, aber Date-Union-Probleme |
+| **Validierung** | 6.5/10 | Zod vorhanden, aber `.passthrough()` riskant |
+| **Erweiterbarkeit** | 6.0/10 | Sport-Erweiterung erfordert Core-Änderungen |
+| **Datenkonsistenz** | 7.0/10 | Inkonsistente Date-Handling, redundante Felder |
+| **Domain-Logik** | 7.5/10 | State-Transitions nicht vollständig modelliert |
+
+---
+
+## 🔴 Modell-Probleme (Critical & Major)
+
+### 1. **Date/ISO-Inkonsistenz (CRITICAL)**
+```typescript
+// TournamentSchema.ts
+scheduledTime: z.union([z.string(), z.date()]).optional()
+
+// LiveMatch.ts
+scheduledKickoff: string; // ISO string
+```
+
+**Problem:** `scheduledTime` akzeptiert sowohl `Date` als auch `string`, aber JSON-Serialisierung wandelt alles zu `string`. Das führt zu:
+- Laufzeit-Fehlern bei `instanceof Date` Checks
+- Inkonsistenter Serialisierung zwischen Frontend/Backend
+- Fehler bei `z.date()` Validierung nach JSON-Parsing
+
+**Lösung:**
+```typescript
+// Immer ISO-String serialisieren, transformieren bei Bedarf
+scheduledTime: z.preprocess(
+  (val) => {
+    if (val instanceof Date) return val.toISOString();
+    if (typeof val === 'string') return val;
+    return undefined;
+  },
+  z.string().optional()
+)
+```
+
+### 2. **Redundante Sport-Felder (MAJOR)**
+```typescript
+// TournamentSchema.ts
+sport: z.string(),      // "hallenfussball" (legacy)
+sportId: z.string(),    // "football-indoor" (neu)
+```
+
+**Problem:** Zwei Felder für dieselbe Information. Welche ist autoritativ? Führt zu Inkonsistenzen bei Migrationen.
+
+**Lösung:** `sport` als `@deprecated` markieren, nur `sportId` verwenden.
+
+### 3. **Fehlende FK-Validierung (MAJOR)**
+```typescript
+// MatchSchema
+teamA: z.string(),      // Kein Validierung, ob Team existiert
+teamB: z.string(),
+group: z.string().optional()  // Kein Validierung gegen Tournament.groups
+```
+
+**Problem:** Keine Referenzintegrität zwischen Matches und Teams/Groups.
+
+**Lösung:** Business-Logic-Validierung vor Persistierung (Zod kann FK nicht prüfen).
+
+### 4. **Timer-State-Inkonsistenz (MAJOR)**
+```typescript
+// LiveMatch
+timerStartTime?: string;
+timerPausedAt?: string;
+timerElapsedSeconds?: number;
+
+// Timer kann in inkonsistenten Zuständen sein:
+// - timerStartTime gesetzt, aber timerElapsedSeconds = 0
+// - timerPausedAt > timerStartTime (ok)
+// - timerPausedAt < timerStartTime (Fehler)
+```
+
+**Problem:** Keine Validierung der Timer-Zustandskonsistenz.
+
+**Lösung:**
+```typescript
+export const LiveMatchTimerSchema = z.object({
+  timerStartTime: z.string().optional(),
+  timerPausedAt: z.string().optional(),
+  timerElapsedSeconds: z.number().min(0).optional(),
+}).refine(
+  (data) => {
+    if (data.timerPausedAt && data.timerStartTime) {
+      return new Date(data.timerPausedAt) >= new Date(data.timerStartTime);
+    }
+    return true;
+  },
+  { message: 'timerPausedAt muss nach timerStartTime liegen' }
+);
+```
+
+### 5. **Score-Validierung fehlt (MAJOR)**
+```typescript
+// Keine Validierung für:
+// - Negative Scores
+// - Overtime/Penalty Scores nur bei Final-Matches
+// - Score-Konsistenz mit Events
+```
+
+**Lösung:**
+```typescript
+export const MatchScoreSchema = z.object({
+  scoreA: z.number().min(0),
+  scoreB: z.number().min(0),
+  overtimeScoreA: z.number().min(0).optional(),
+  overtimeScoreB: z.number().min(0).optional(),
+  penaltyScoreA: z.number().min(0).optional(),
+  penaltyScoreB: z.number().min(0).optional(),
+}).refine(
+  (data) => {
+    // Overtime/Penalty nur bei isFinal
+    const hasTiebreaker = data.overtimeScoreA !== undefined || data.penaltyScoreA !== undefined;
+    return !hasTiebreaker || data.isFinal === true;
+  },
+  { message: 'Verlängerungs-/Penalty-Scores nur bei Finalspielen' }
+);
+```
+
+---
+
+## 🟡 Schema-Lücken (Medium Priority)
+
+### 6. **`.passthrough()` Risiko**
+```typescript
+// CommonSchemas.ts, TournamentSchema.ts
+.passthrough()  // Erlaubt unbekannte Felder!
+```
+
+**Problem:** Unbekannte Felder werden akzeptiert, können aber zu:
+- Datenkorruption bei Schema-Evolution
+- Fehlern bei zukünftigen Feld-Validierungen
+- Sicherheitsproblemen (Injection von unbekannten Feldern)
+
+**Lösung:** `.strict()` für Production, `.passthrough()` nur für Migrationen.
+
+### 7. **Event-Typ-Validierung unvollständig**
+```typescript
+// RuntimeMatchEventSchema
+type: z.enum(['GOAL', 'RESULT_EDIT', 'STATUS_CHANGE', ...])
+
+// Aber: payload-Validierung ist zu locker
+payload: RuntimeMatchEventPayloadSchema  // .passthrough()
+```
+
+**Problem:** GOAL-Events erfordern `team`, `direction`, `newHomeScore` etc., aber das wird nicht geprüft.
+
+**Lösung:** Discriminated Union für Event-Typen:
+```typescript
+const GoalEventSchema = z.object({
+  type: z.literal('GOAL'),
+  payload: z.object({
+    team: z.enum(['home', 'away']),
+    playerNumber: z.number(),
+    // ...
+  }),
+});
+
+const EventSchema = z.discriminatedUnion('type', [
+  GoalEventSchema,
+  CardEventSchema,
+  // ...
+]);
+```
+
+### 8. **Status-Transition-Validierung fehlt**
+```typescript
+// MatchStatus: 'scheduled' | 'waiting' | 'running' | 'finished' | 'skipped'
+// Aber: Keine Validierung von gültigen Übergängen
+```
+
+**Problem:** Status kann von `finished` zu `running` wechseln (illegal).
+
+**Lösung:** State-Machine-Validierung:
+```typescript
+const VALID_STATUS_TRANSITIONS: Record<MatchStatus, MatchStatus[]> = {
+  scheduled: ['waiting', 'running', 'skipped'],
+  waiting: ['running', 'skipped'],
+  running: ['finished', 'paused', 'skipped'],
+  finished: [], // Terminal state
+  skipped: [],  // Terminal state
+};
+```
+
+---
+
+## 🟠 Erweiterbarkeits-Probleme
+
+### 9. **Sport-Erweiterung erfordert Core-Änderungen**
+```typescript
+// football.ts exportiert footballIndoorConfig
+// index.ts hat hardcoded sportRegistry
+// types.ts hat hardcoded SportId Union
+```
+
+**Problem:** Neue Sportart erfordert Änderungen in 3+ Dateien. Kein Plugin-System.
+
+**Lösung:**
+```typescript
+// Sport-Plugins als separate Pakete
+interface SportPlugin {
+  register(config: SportConfig): void;
+  getRules(sportId: SportId): SportRules;
+}
+
+// Dynamische Registrierung
+export function registerSport(config: SportConfig): void {
+  sportRegistry.set(config.id, config);
+}
+```
+
+### 10. **AgeClasses nicht sport-neutral**
+```typescript
+// footballIndoorConfig.ageClasses hat 40+ Einträge
+// Andere Sportarten haben andere Altersklassen
+// Aber: Struktur ist identisch
+```
+
+**Problem:** Bei neuen Sportarten müssen alle AgeClasses dupliziert werden.
+
+**Lösung:** AgeClasses als separate Konfiguration pro Sportart mit Registry:
+```typescript
+export const AGE_CLASS_REGISTRY: Record<string, AgeClassOption[]> = {
+  'football': getFootballAgeClasses(),
+  'handball': getHandballAgeClasses(),
+  // ...
+};
+```
+
+### 11. **FinalsPreset-Enum nicht erweiterbar**
+```typescript
+export type FinalsPreset = 'none' | 'final-only' | 'top-4' | 'top-8' | 'top-16' | 'all-places';
+```
+
+**Problem:** Neue Presets erfordern Änderung in Enum + FinalsOptions + Schema + UI.
+
+**Lösung:** Config-basierte Presets:
+```typescript
+export interface FinalsPresetConfig {
+  id: string;
+  label: string;
+  matches: KnockoutMatch[];
+  minGroups: number;
+  recommended: boolean;
+}
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Gute Trennung von Concerns**
+- `config/sports/` für Sport-Regeln
+- `core/models/` für Runtime-Modelle
+- `types/` für Domain-Types
+- `constants/` für konfigurierbare Werte
+
+### 2. **Umfassende Zod-Tests**
+```typescript
+// TournamentSchema.test.ts
+describe('TournamentSchema round-trip', () => {
+  it('validates a complete tournament with all sub-schemas', () => {
+    // Testet Team, Match, Group, Field, Events
+  });
+});
+```
+
+### 3. **LiveMatch Runtime-Modell**
+Separation zwischen persistiertem `Match` und runtime `LiveMatch` mit Timer-State ist exzellent für Multi-User-Synchronisation.
+
+### 4. **DFB-Muster-System**
+```typescript
+export const DFB_ROUND_ROBIN_PATTERNS: DFBMatchPattern[] = [
+  // 2-18 Teams mit korrekten Runden
+];
+```
+Bietet standardisierte Spielpläne nach DFB-Regeln.
+
+### 5. **Finals-Options-Generator**
+```typescript
+export function getFinalsOptions(numberOfGroups: number): FinalsOption[]
+```
+Dynamische Generierung basierend auf Gruppengröße statt statischer Enum.
+
+### 6. **Legacy-Kompatibilität**
+```typescript
+export function legacySportToSportId(sport: 'football' | 'other'): SportId
+export function sportIdToLegacySport(sportId: SportId): 'football' | 'other'
+```
+@deprecated-Functions für Migration erhalten.
+
+---
+
+## 🔧 Empfohlene Sofort-Maßnahmen
+
+### P0 (Critical - 1 Woche)
+1. **Date-Handling konsistent machen** - Immer ISO-String, transformieren wo nötig
+2. **Timer-State-Validierung** - Refine-Checks für Timer-Konsistenz
+3. **Score-Validierung** - Negative Scores, Tiebreaker nur bei Finals
+
+### P1 (High - 2-4 Wochen)
+4. **Status-Transition-Validierung** - State-Machine für MatchStatus
+5. **Sport-Erweiterbarkeit** - Plugin-Registry statt hardcoded Map
+6. **FK-Validierung** - Business-Logic für Team/Group Referenzen
+
+### P2 (Medium - 1-2 Monate)
+7. **Event-Discriminated-Unions** - Typ-sichere Event-Validierung
+8. **AgeClass-Registry** - Sport-neutrale Altersklassen
+9. **Schema-Strict-Mode** - `.passthrough()` auf `.strict()` für Production
+
+---
+
+## 📈 Architektur-Empfehlungen
+
+### 1. **Domain Events für State Changes**
+```typescript
+// Statt direkter State-Änderung
+interface MatchStateChanged {
+  matchId: string;
+  from: MatchStatus;
+  to: MatchStatus;
+  timestamp: string;
+  userId: string;
+}
+
+// Event-Store für Audit-Trail
+export interface MatchEventStore {
+  publish(event: MatchEvent): Promise<void>;
+  getEvents(matchId: string): MatchEvent[];
+}
+```
+
+### 2. **Repository Pattern für Datenzugriff**
+```typescript
+export interface TournamentRepository {
+  findById(id: string): Promise<Tournament | null>;
+  save(tournament: Tournament): Promise<void>;
+  updateMatch(matchId: string, update: MatchUpdate): Promise<void>;
+  // Validierung vor Save
+}
+```
+
+### 3. **CQRS für Read/Write Separation**
+```typescript
+// Commands (Write)
+class UpdateMatchScoreCommand {
+  matchId: string;
+  scoreA: number;
+  scoreB: number;
+  userId: string;
+}
+
+// Queries (Read)
+class GetMatchStandingsQuery {
+  tournamentId: string;
+  groupId: string;
+}
+```
+
+---
+
+## 🎯 Fazit
+
+Das Datenmodell ist **gut durchdacht** mit klaren Trennungen und umfassenden Tests. Die **kritischen Probleme** liegen bei Datentyp-Konsistenz (Date/ISO), fehlenden Invarianten-Validierungen und Erweiterbarkeit. Mit den oben genannten Maßnahmen kann das Modell auf **9/10** gebracht werden.
+
+**Priorität:** P0-Maßnahmen sofort umsetzen, um Datenkorruption zu verhindern. P1-P2 für langfristige Wartbarkeit und Skalierbarkeit.
+
+---
+

--- a/reviews/2026-05-07_2058_security.md
+++ b/reviews/2026-05-07_2058_security.md
@@ -1,0 +1,407 @@
+# Code Review: Security & Datenschutz
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 108.9s  
+**Status:** success  
+**Code-Kontext:** 151,331 Zeichen  
+
+<details><summary>Thinking Process (3,776 Zeichen)</summary>
+
+The user is asking me to perform a security audit of their PWA (Progressive Web App) for hallenfussball (indoor football) tournament management. They've provided extensive code snippets covering authentication components, dialogs, edge functions, and storage interfaces.
+
+Let me analyze this systematically based on OWASP Top 10 + PWA-specific security concerns:
+
+## Key Areas to Audit:
+
+1. **Authentication & Session Management**
+   - Supabase Auth implementation
+   - Token handling in AuthCallback
+   - Magic link security
+   - OAuth flow security
+   - Session persistence
+
+2. **Authorization**
+   - Role-based access control (owner, co-admin, trainer, collaborator, viewer)
+   - RLS (Row Level Security) policies
+   - Client-side vs server-side authorization
+
+3. **Input Validation**
+   - Form validation (Zod schemas mentioned)
+   - XSS prevention
+   - SQL injection (through Supabase)
+
+4. **Client-Side Storage**
+   - LocalStorage/IndexedDB usage
+   - Sensitive data storage
+   - Encryption
+
+5. **API Security**
+   - Supabase key exposure
+   - Edge function security
+   - CORS configuration
+
+6. **PWA-Specific Security**
+   - Service Worker security
+   - Cache poisoning
+   - Manifest security
+
+7. **Secrets Management**
+   - Environment variables
+   - API keys
+
+8. **Dependency Security**
+   - Package.json dependencies
+
+9. **CSRF/Clickjacking**
+   - PWA-specific vectors
+
+10. **Content Security Policy**
+    - Header configuration
+
+11. **Data Privacy (DSGVO/GDPR)**
+    - Personal data handling
+    - Consent
+    - Data deletion
+
+12. **Deep Link Security**
+    - Tournament invite tokens
+    - Token guessing
+
+## Critical Findings I've Identified:
+
+### CRITICAL:
+
+1. **Supabase Service Role Key Exposure Risk** - The merge-accounts Edge Function uses SUPABASE_SERVICE_ROLE_KEY. Need to verify this is properly secured in Vercel/Supabase environment variables and not exposed client-side.
+
+
+2. **Client-Side Authorization Only** - The AuthGuard component only checks roles client-side. RLS policies in Supabase need to enforce these restrictions server-side.
+3. **Invite Token Security** - Tournament invite tokens are passed in URL parameters. Need to verify token entropy and expiration.
+4. **No CSRF Protection** - Supabase handles this mostly, but need to verify cookie settings.
+5. **Sensitive Data in URL** - Auth tokens in URL hash/query params (AuthCallback.tsx) - this is standard for OAuth but needs proper cleanup.
+
+### HIGH:
+
+1. **Missing CSP Headers** - No evidence of Content Security Policy configuration in vercel.json or similar.
+2. **No Rate Limiting** - Authentication endpoints lack rate limiting to prevent brute force attacks.
+3. **Email Enumeration** - Login errors may reveal whether an email exists in the system.
+4. **Guest Account Limits** - Need to verify tournament limits are enforced server-side, not just client-side.
+
+### MEDIUM:
+
+1. **Console Logs in Production** - DEV mode console logs should be removed or properly gated.
+2. **Error Message Disclosure** - Some error messages may leak internal information.
+3. **Focus Trap Implementation** - Focus trap hooks used but need verification for accessibility security.
+4. **Merge Function Security** - The merge-accounts edge function looks good but needs verification of the underlying SQL function.
+
+### RECOMMENDATIONS:
+
+1. Implement proper CSP headers
+2. Add rate limiting on auth endpoints
+3. Server-side validation of all role-based access
+4. Implement proper token rotation
+5. Add security headers via Vercel configuration
+6. Implement proper audit logging
+7. Add PWA security headers (Service Worker scope, etc.)
+8. Implement proper session timeout
+9. Add 2FA support for admin users
+10. Implement proper data retention policies
+
+I'll now create a comprehensive security report.
+
+
+</details>
+
+---
+
+
+
+# 🔒 Security Audit Report: Hallenfussball-PWA
+
+**Audit Date:** 2026-01-23  
+**Auditor:** Application Security Engineer  
+**Scope:** Authentication Flow, Authorization, PWA Security, Supabase Integration  
+**Code Review:** 151,331+ Zeichen (Auth Components, Edge Functions, Storage Layer)
+
+---
+
+## 📊 Security Score: 6.8/10
+
+| Category | Score | Status |
+|----------|-------|--------|
+| Authentication | 7.5 | ✅ Good |
+| Authorization | 5.0 | ⚠️ Critical Gap |
+| Input Validation | 7.0 | ✅ Good |
+| Client Storage | 6.0 | ⚠️ Needs Review |
+| API Security | 7.5 | ✅ Good |
+| PWA Security | 5.5 | ⚠️ Missing Headers |
+| Data Privacy | 6.5 | ⚠️ Partial |
+
+---
+
+## 🔴 KRITISCHE FINDINGS (Sofort beheben)
+
+### 1. **Client-Side Authorization Only** ⚠️
+**Date:** `src/features/auth/components/AuthGuard.tsx`  
+**Risk:** Authorization wird nur client-seitig geprüft. Ein Angreifer kann React-Code manipulieren oder direkte API-Calls senden.
+
+```typescript
+// ❌ UNSICHER - Nur client-seitig
+if (requireRole === 'admin' && user.globalRole !== 'admin') {
+  return <Forbidden />;
+}
+```
+
+**Empfehlung:**
+- **Supabase RLS Policies** für jede Tabelle implementieren
+- Server-seitige Validierung in Edge Functions
+- Beispiel RLS für `tournament_memberships`:
+```sql
+CREATE POLICY "Users can only see their memberships" ON tournament_memberships
+  FOR SELECT USING (auth.uid() = user_id);
+```
+
+### 2. **Supabase Service Role Key Exposure** ⚠️
+**Date:** `supabase/functions/merge-accounts/index.ts`  
+**Risk:** `SUPABASE_SERVICE_ROLE_KEY` muss in Edge Functions sicher gespeichert werden.
+
+**Empfehlung:**
+- In Vercel: `SUPABASE_SERVICE_ROLE_KEY` als **Secret** speichern (nicht im Code)
+- In Supabase Dashboard: Edge Function Environment Variables verwenden
+- Key niemals client-seitig exportieren
+
+### 3. **Invite Token im URL-Parameter** ⚠️
+**Date:** `src/features/auth/components/AuthConfirmPage.tsx`  
+**Risk:** Tokens in URL können in Browser-History, Server-Logs und Referer-Headern gespeichert werden.
+
+```typescript
+// ❌ UNSICHER - Token in URL
+void navigate(`/invite?token=${encodeURIComponent(token)}`, { replace: true });
+```
+
+**Empfehlung:**
+- Token in **Session Storage** speichern, nicht in URL
+- URL nach Token-Verarbeitung sofort bereinigen
+- Token-Entropie erhöhen (min. 128-bit UUIDs)
+
+### 4. **Keine Rate-Limiting auf Auth-Endpunkten** ⚠️
+**Risk:** Brute-Force Angriffe auf Login/Register möglich.
+
+**Empfehlung:**
+- Supabase RLS für Rate Limiting aktivieren
+- Vercel Edge Middleware für Rate Limiting
+- Beispiel: Max 5 Login-Versuche pro 15 Minuten pro IP
+
+---
+
+## 🟠 HOHE FINDINGS (Vor nächstem Release)
+
+### 5. **Fehlende Content Security Policy (CSP)**
+**Date:** `vercel.json` (nicht im Code vorhanden)  
+**Risk:** XSS-Angriffe möglich, da keine Script-Sourcen eingeschränkt sind.
+
+**Empfehlung:** `vercel.json` erweitern:
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://*.supabase.in;"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 6. **Email Enumeration durch Fehlermeldungen**
+**Date:** `src/features/auth/components/LoginScreen.tsx`  
+**Risk:** Unterschiedliche Fehlermeldungen verraten, ob Email existiert.
+
+```typescript
+// ❌ UNSICHER - Unterschiedliche Fehler
+if (oauthCheck.isOAuthOnly) {
+  setApiError(getOAuthPasswordResetMessage(oauthCheck.provider));
+}
+```
+
+**Empfehlung:**
+- Generische Fehlermeldungen für Login-Fehler
+- "Ungültige E-Mail oder Passwort" immer gleich anzeigen
+
+### 7. **Guest Tournament Limits Client-Side**
+**Date:** `src/features/auth/hooks/useTournamentLimit.ts`  
+**Risk:** Limits können client-seitig umgangen werden.
+
+**Empfehlung:**
+- Limit-Prüfung in Supabase RLS oder Edge Function
+- Beispiel RLS:
+```sql
+CREATE POLICY "Guest tournament limit" ON tournaments
+  FOR INSERT WITH CHECK (
+    (auth.jwt() ->> 'is_anonymous')::boolean = false 
+    OR (SELECT COUNT(*) FROM tournaments WHERE user_id = auth.uid()) < 3
+  );
+```
+
+### 8. **Console Logs in Production**
+**Date:** Mehrere Dateien (`AuthCallback.tsx`, `LoginScreen.tsx`, etc.)  
+**Risk:** Sensible Daten könnten in Logs exponiert werden.
+
+```typescript
+// ❌ UNSICHER
+if (import.meta.env.DEV) {
+  console.log('[AuthCallback] URL:', window.location.search);
+}
+```
+
+**Empfehlung:**
+- Production Build: Alle `console.log` entfernen
+- `NODE_ENV`-Check in Build-Step (Vite/Terser)
+- Logging-Service für Production verwenden
+
+---
+
+## 🟡 MITTLERE FINDINGS (Backlog)
+
+### 9. **Merge Function SQL Injection Risiko**
+**Date:** `supabase/functions/merge-accounts/index.ts`  
+**Risk:** `merge_user_data()` SQL-Funktion muss gegen SQL-Injection geschützt sein.
+
+**Empfehlung:**
+- Prepared Statements in PostgreSQL-Funktion
+- Parameter-Validierung in Edge Function
+- Audit-Log für alle Merge-Operationen
+
+### 10. **Session Timeout nicht implementiert**
+**Risk:** Sessions bleiben zu lange aktiv.
+
+**Empfehlung:**
+- Supabase Session TTL konfigurieren (z.B. 7 Tage)
+- Idle Timeout implementieren (30 Minuten Inaktivität)
+- "Remember Me"-Option mit längerer Session
+
+### 11. **Kein Audit-Logging**
+**Risk:** Keine Nachverfolgung von sensiblen Aktionen.
+
+**Empfehlung:**
+- Audit-Log-Tabelle in Supabase:
+  - Login/Logout
+  - Rollenänderungen
+  - Turnier-Erstellung
+  - Account-Merge
+- Logs für 90 Tage aufbewahren
+
+### 12. **Service Worker Security**
+**Risk:** Cache-Poisoning möglich.
+
+**Empfehlung:**
+- Service Worker Scope einschränken
+- Cache-Versioning implementieren
+- Integrity-Check für SW-Updates
+
+---
+
+## 🟢 EMPFEHLUNGEN (Hardening)
+
+### 13. **2FA für Admin-Benutzer**
+- TOTP oder WebAuthn für `admin`-Rolle
+- Supabase MFA-Add-on nutzen
+
+### 14. **Data Retention Policy**
+- Anonyme Accounts nach 30 Tagen löschen
+- Turnier-Daten nach 1 Jahr archivieren
+- DSGVO "Recht auf Vergessenwerden" umsetzen
+
+### 15. **Dependency Security**
+- `npm audit` in CI/CD Pipeline
+- `dependabot` für automatische Updates
+- Known CVEs prüfen (Supabase, React, Vite)
+
+### 16. **PWA-Specific Security**
+```typescript
+// manifest.json
+{
+  "display": "standalone",
+  "start_url": "/",
+  "scope": "/",
+  "background_color": "#ffffff",
+  "theme_color": "#3b82f6",
+  "prefer_related_applications": false
+}
+```
+
+### 17. **Error Handling Hardening**
+```typescript
+// ❌ UNSICHER
+setError(err.message);
+
+// ✅ SICHER
+setError('Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.');
+// Log err.message server-seitig
+```
+
+### 18. **Security Headers für Supabase**
+- CORS-Origins einschränken auf eigene Domain
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+
+---
+
+## 📋 PRIORISIERTES ACTION-ITEMS
+
+| # | Finding | Priorität | Aufwand | Deadline |
+|---|---------|-----------|---------|----------|
+| 1 | RLS Policies implementieren | 🔴 Critical | 4h | 2026-01-25 |
+| 2 | CSP Headers konfigurieren | 🔴 Critical | 2h | 2026-01-24 |
+| 3 | Rate Limiting implementieren | 🔴 Critical | 3h | 2026-01-25 |
+| 4 | Invite Token aus URL entfernen | 🟠 High | 2h | 2026-01-26 |
+| 5 | Service Role Key sichern | 🟠 High | 1h | 2026-01-24 |
+| 6 | Console Logs entfernen | 🟠 High | 2h | 2026-01-27 |
+| 7 | Guest Limits server-seitig | 🟠 High | 3h | 2026-01-28 |
+| 8 | Audit Logging implementieren | 🟡 Medium | 6h | 2026-02-01 |
+| 9 | Session Timeout | 🟡 Medium | 2h | 2026-02-01 |
+| 10 | Dependency Audit | 🟡 Medium | 1h | 2026-01-24 |
+
+---
+
+## ✅ POSITIVE FINDINGS
+
+1. **Supabase Auth Integration** - PKCE Flow korrekt implementiert
+2. **Magic Link Security** - Bestätigungs-Dialog verhindert Email-Scanner
+3. **Focus Trap** - WCAG 4.1.3 Accessibility erfüllt
+4. **Error Handling** - User-freundliche Fehlermeldungen
+5. **Offline Support** - Offline-Banner für schlechte Verbindungen
+6. **Type Safety** - TypeScript durchgehend verwendet
+7. **Design Tokens** - Konsistente Styling-Struktur
+
+---
+
+## 🛡️ NEXT STEPS
+
+1. **Sofort:** RLS Policies in Supabase Dashboard konfigurieren
+2. **24h:** Vercel Security Headers deployen
+3. **48h:** Rate Limiting implementieren
+4. **1 Woche:** Audit Logging & 2FA Roadmap erstellen
+5. **1 Monat:** Penetration Test durchführen
+
+---
+
+**Audit abgeschlossen.** Bei Fragen zu einzelnen Findings stehe ich gerne für Details zur Verfügung.
+
+*Signature: Application Security Engineer*  
+*Classification: Internal Use Only*

--- a/reviews/2026-05-07_2058_sport_config.md
+++ b/reviews/2026-05-07_2058_sport_config.md
@@ -1,0 +1,465 @@
+# Code Review: Sport-Konfiguration & Datenmodell
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 37.5s  
+**Status:** success  
+**Code-Kontext:** 134,330 Zeichen  
+
+<details><summary>Thinking Process (3,816 Zeichen)</summary>
+
+The user is asking me to analyze the data model and sport configuration for a sports tournament software system. This is a comprehensive code review task that requires me to examine:
+
+1. Data Model - Tournament, Team, Match, Group, Playoff structures
+2. Sport Configuration - Multiple sports with different rules
+3. Zod Schemas - Runtime validation
+4. Enums/Constants - Tournament status, match status, game modes
+5. Data Migration - Versioning and schema changes
+6. Type Guards - Discriminated unions and exhaustive checks
+7. Domain Events - State transitions
+8. Extensibility - Adding new sports/modes
+9. Serialization - JSON compatibility, date handling
+10. Invariants - Business rules enforcement
+
+Let me analyze the code systematically and provide a structured review.
+
+Key observations from the code:
+
+**Positive Patterns:**
+1. Sport configuration is well-structured with clear separation between terminology, defaults, rules, features, age classes, and validation
+2. Zod schemas are comprehensive with tests
+3. Type definitions are well-organized with clear barrel exports
+4. LiveMatch model separates runtime state from persisted data
+5. DFB match patterns are well-documented
+6. Finals options are dynamically generated based on group count
+7. Legacy compatibility functions are marked with @deprecated
+
+**Problems I've identified:**
+
+1. **Model Problems:**
+   - Inconsistent date handling (some use string, some Date, some ISO strings)
+   - MatchSchema has both `scheduledTime` as Date | string union which can cause issues
+   - No explicit constraint on minimum teams for tournament creation in the schema
+   - `sport` and `sportId` fields exist in TournamentSchema (potential redundancy)
+   - LiveMatch version field exists but no clear optimistic locking mechanism documented
+   - No validation that team IDs in matches actually exist in teams array
+   - Missing constraint: can't have more teams than maxTeams allows
+
+2. **Schema Gaps:**
+   - Zod schemas use `.passthrough()` which could allow invalid data through
+   - RuntimeMatchEventSchema has `matchId` as optional but it should probably be required
+   - No validation for score consistency (e.g., can't have negative scores)
+   - No validation that overtime/penalty scores only exist for final matches
+   - Missing validation for timer state consistency (timerStartTime without timerElapsedSeconds)
+   - No validation for tiebreaker scores matching the tiebreakerMode
+
+3. **Extensibility Problems:**
+   - SportConfig is hardcoded in football.ts, adding new sports requires modifying core files
+   - No plugin architecture for new sports
+   - Age classes are sport-specific but stored in a way that makes adding new ones cumbersome
+   - No clear migration path for adding new match event types
+   - FinalsPreset enum is hardcoded, adding new presets requires changing multiple files
+
+4. **Data Consistency Issues:**
+   - TournamentSchema has both `sport` and `sportId` - unclear which is authoritative
+   - MatchSchema has `teamA`/`teamB` as strings but no foreign key validation
+   - No validation that group IDs in teams match actual groups in tournament
+   - Timer persistence fields exist but no validation of their consistency
+
+5. **Domain Event Issues:**
+   - Match events are stored but no clear state machine for MatchStatus transitions
+   - No validation that status changes follow valid transitions (e.g., can't go from FINISHED back to RUNNING)
+   - LiveMatch has version field but no clear concurrency control strategy
+
+6. **Serialization Issues:**
+   - scheduledTime is Date | string union which causes JSON serialization issues
+   - No transform for dates in Zod schemas
+   - ISO strings vs Date objects inconsistency across the codebase
+
+Let me structure this into a comprehensive review with scores and actionable recommendations.
+
+
+</details>
+
+---
+
+
+
+# 🏆 Domain-Expert Review: Sportturnier-Software
+
+## Executive Summary
+
+Das Datenmodell ist **grundsätzlich solide strukturiert** mit guter Trennung zwischen Sport-Konfiguration, Runtime-Modellen und Persistenz. Es gibt jedoch **kritische Inkonsistenzen** bei Datentypen (insbesondere Date-Handling), fehlende Invarianten-Validierung und Probleme bei der Erweiterbarkeit für neue Sportarten.
+
+---
+
+## 📊 Datenmodell Score: 7.2/10
+
+| Kategorie | Score | Bewertung |
+|-----------|-------|-----------|
+| **Struktur & Trennung** | 8.5/10 | Gute Trennung zwischen Konfiguration, Runtime & Persistenz |
+| **Typ-Sicherheit** | 7.0/10 | TypeScript gut genutzt, aber Date-Union-Probleme |
+| **Validierung** | 6.5/10 | Zod vorhanden, aber `.passthrough()` riskant |
+| **Erweiterbarkeit** | 6.0/10 | Sport-Erweiterung erfordert Core-Änderungen |
+| **Datenkonsistenz** | 7.0/10 | Inkonsistente Date-Handling, redundante Felder |
+| **Domain-Logik** | 7.5/10 | State-Transitions nicht vollständig modelliert |
+
+---
+
+## 🔴 Modell-Probleme (Critical & Major)
+
+### 1. **Date/ISO-Inkonsistenz (CRITICAL)**
+```typescript
+// TournamentSchema.ts
+scheduledTime: z.union([z.string(), z.date()]).optional()
+
+// LiveMatch.ts
+scheduledKickoff: string; // ISO string
+```
+
+**Problem:** `scheduledTime` akzeptiert sowohl `Date` als auch `string`, aber JSON-Serialisierung wandelt alles zu `string`. Das führt zu:
+- Laufzeit-Fehlern bei `instanceof Date` Checks
+- Inkonsistenter Serialisierung zwischen Frontend/Backend
+- Fehler bei `z.date()` Validierung nach JSON-Parsing
+
+**Lösung:**
+```typescript
+// Immer ISO-String serialisieren, transformieren bei Bedarf
+scheduledTime: z.preprocess(
+  (val) => {
+    if (val instanceof Date) return val.toISOString();
+    if (typeof val === 'string') return val;
+    return undefined;
+  },
+  z.string().optional()
+)
+```
+
+### 2. **Redundante Sport-Felder (MAJOR)**
+```typescript
+// TournamentSchema.ts
+sport: z.string(),      // "hallenfussball" (legacy)
+sportId: z.string(),    // "football-indoor" (neu)
+```
+
+**Problem:** Zwei Felder für dieselbe Information. Welche ist autoritativ? Führt zu Inkonsistenzen bei Migrationen.
+
+**Lösung:** `sport` als `@deprecated` markieren, nur `sportId` verwenden.
+
+### 3. **Fehlende FK-Validierung (MAJOR)**
+```typescript
+// MatchSchema
+teamA: z.string(),      // Kein Validierung, ob Team existiert
+teamB: z.string(),
+group: z.string().optional()  // Kein Validierung gegen Tournament.groups
+```
+
+**Problem:** Keine Referenzintegrität zwischen Matches und Teams/Groups.
+
+**Lösung:** Business-Logic-Validierung vor Persistierung (Zod kann FK nicht prüfen).
+
+### 4. **Timer-State-Inkonsistenz (MAJOR)**
+```typescript
+// LiveMatch
+timerStartTime?: string;
+timerPausedAt?: string;
+timerElapsedSeconds?: number;
+
+// Timer kann in inkonsistenten Zuständen sein:
+// - timerStartTime gesetzt, aber timerElapsedSeconds = 0
+// - timerPausedAt > timerStartTime (ok)
+// - timerPausedAt < timerStartTime (Fehler)
+```
+
+**Problem:** Keine Validierung der Timer-Zustandskonsistenz.
+
+**Lösung:**
+```typescript
+export const LiveMatchTimerSchema = z.object({
+  timerStartTime: z.string().optional(),
+  timerPausedAt: z.string().optional(),
+  timerElapsedSeconds: z.number().min(0).optional(),
+}).refine(
+  (data) => {
+    if (data.timerPausedAt && data.timerStartTime) {
+      return new Date(data.timerPausedAt) >= new Date(data.timerStartTime);
+    }
+    return true;
+  },
+  { message: 'timerPausedAt muss nach timerStartTime liegen' }
+);
+```
+
+### 5. **Score-Validierung fehlt (MAJOR)**
+```typescript
+// Keine Validierung für:
+// - Negative Scores
+// - Overtime/Penalty Scores nur bei Final-Matches
+// - Score-Konsistenz mit Events
+```
+
+**Lösung:**
+```typescript
+export const MatchScoreSchema = z.object({
+  scoreA: z.number().min(0),
+  scoreB: z.number().min(0),
+  overtimeScoreA: z.number().min(0).optional(),
+  overtimeScoreB: z.number().min(0).optional(),
+  penaltyScoreA: z.number().min(0).optional(),
+  penaltyScoreB: z.number().min(0).optional(),
+}).refine(
+  (data) => {
+    // Overtime/Penalty nur bei isFinal
+    const hasTiebreaker = data.overtimeScoreA !== undefined || data.penaltyScoreA !== undefined;
+    return !hasTiebreaker || data.isFinal === true;
+  },
+  { message: 'Verlängerungs-/Penalty-Scores nur bei Finalspielen' }
+);
+```
+
+---
+
+## 🟡 Schema-Lücken (Medium Priority)
+
+### 6. **`.passthrough()` Risiko**
+```typescript
+// CommonSchemas.ts, TournamentSchema.ts
+.passthrough()  // Erlaubt unbekannte Felder!
+```
+
+**Problem:** Unbekannte Felder werden akzeptiert, können aber zu:
+- Datenkorruption bei Schema-Evolution
+- Fehlern bei zukünftigen Feld-Validierungen
+- Sicherheitsproblemen (Injection von unbekannten Feldern)
+
+**Lösung:** `.strict()` für Production, `.passthrough()` nur für Migrationen.
+
+### 7. **Event-Typ-Validierung unvollständig**
+```typescript
+// RuntimeMatchEventSchema
+type: z.enum(['GOAL', 'RESULT_EDIT', 'STATUS_CHANGE', ...])
+
+// Aber: payload-Validierung ist zu locker
+payload: RuntimeMatchEventPayloadSchema  // .passthrough()
+```
+
+**Problem:** GOAL-Events erfordern `team`, `direction`, `newHomeScore` etc., aber das wird nicht geprüft.
+
+**Lösung:** Discriminated Union für Event-Typen:
+```typescript
+const GoalEventSchema = z.object({
+  type: z.literal('GOAL'),
+  payload: z.object({
+    team: z.enum(['home', 'away']),
+    playerNumber: z.number(),
+    // ...
+  }),
+});
+
+const EventSchema = z.discriminatedUnion('type', [
+  GoalEventSchema,
+  CardEventSchema,
+  // ...
+]);
+```
+
+### 8. **Status-Transition-Validierung fehlt**
+```typescript
+// MatchStatus: 'scheduled' | 'waiting' | 'running' | 'finished' | 'skipped'
+// Aber: Keine Validierung von gültigen Übergängen
+```
+
+**Problem:** Status kann von `finished` zu `running` wechseln (illegal).
+
+**Lösung:** State-Machine-Validierung:
+```typescript
+const VALID_STATUS_TRANSITIONS: Record<MatchStatus, MatchStatus[]> = {
+  scheduled: ['waiting', 'running', 'skipped'],
+  waiting: ['running', 'skipped'],
+  running: ['finished', 'paused', 'skipped'],
+  finished: [], // Terminal state
+  skipped: [],  // Terminal state
+};
+```
+
+---
+
+## 🟠 Erweiterbarkeits-Probleme
+
+### 9. **Sport-Erweiterung erfordert Core-Änderungen**
+```typescript
+// football.ts exportiert footballIndoorConfig
+// index.ts hat hardcoded sportRegistry
+// types.ts hat hardcoded SportId Union
+```
+
+**Problem:** Neue Sportart erfordert Änderungen in 3+ Dateien. Kein Plugin-System.
+
+**Lösung:**
+```typescript
+// Sport-Plugins als separate Pakete
+interface SportPlugin {
+  register(config: SportConfig): void;
+  getRules(sportId: SportId): SportRules;
+}
+
+// Dynamische Registrierung
+export function registerSport(config: SportConfig): void {
+  sportRegistry.set(config.id, config);
+}
+```
+
+### 10. **AgeClasses nicht sport-neutral**
+```typescript
+// footballIndoorConfig.ageClasses hat 40+ Einträge
+// Andere Sportarten haben andere Altersklassen
+// Aber: Struktur ist identisch
+```
+
+**Problem:** Bei neuen Sportarten müssen alle AgeClasses dupliziert werden.
+
+**Lösung:** AgeClasses als separate Konfiguration pro Sportart mit Registry:
+```typescript
+export const AGE_CLASS_REGISTRY: Record<string, AgeClassOption[]> = {
+  'football': getFootballAgeClasses(),
+  'handball': getHandballAgeClasses(),
+  // ...
+};
+```
+
+### 11. **FinalsPreset-Enum nicht erweiterbar**
+```typescript
+export type FinalsPreset = 'none' | 'final-only' | 'top-4' | 'top-8' | 'top-16' | 'all-places';
+```
+
+**Problem:** Neue Presets erfordern Änderung in Enum + FinalsOptions + Schema + UI.
+
+**Lösung:** Config-basierte Presets:
+```typescript
+export interface FinalsPresetConfig {
+  id: string;
+  label: string;
+  matches: KnockoutMatch[];
+  minGroups: number;
+  recommended: boolean;
+}
+```
+
+---
+
+## ✅ Positive Patterns
+
+### 1. **Gute Trennung von Concerns**
+- `config/sports/` für Sport-Regeln
+- `core/models/` für Runtime-Modelle
+- `types/` für Domain-Types
+- `constants/` für konfigurierbare Werte
+
+### 2. **Umfassende Zod-Tests**
+```typescript
+// TournamentSchema.test.ts
+describe('TournamentSchema round-trip', () => {
+  it('validates a complete tournament with all sub-schemas', () => {
+    // Testet Team, Match, Group, Field, Events
+  });
+});
+```
+
+### 3. **LiveMatch Runtime-Modell**
+Separation zwischen persistiertem `Match` und runtime `LiveMatch` mit Timer-State ist exzellent für Multi-User-Synchronisation.
+
+### 4. **DFB-Muster-System**
+```typescript
+export const DFB_ROUND_ROBIN_PATTERNS: DFBMatchPattern[] = [
+  // 2-18 Teams mit korrekten Runden
+];
+```
+Bietet standardisierte Spielpläne nach DFB-Regeln.
+
+### 5. **Finals-Options-Generator**
+```typescript
+export function getFinalsOptions(numberOfGroups: number): FinalsOption[]
+```
+Dynamische Generierung basierend auf Gruppengröße statt statischer Enum.
+
+### 6. **Legacy-Kompatibilität**
+```typescript
+export function legacySportToSportId(sport: 'football' | 'other'): SportId
+export function sportIdToLegacySport(sportId: SportId): 'football' | 'other'
+```
+@deprecated-Functions für Migration erhalten.
+
+---
+
+## 🔧 Empfohlene Sofort-Maßnahmen
+
+### P0 (Critical - 1 Woche)
+1. **Date-Handling konsistent machen** - Immer ISO-String, transformieren wo nötig
+2. **Timer-State-Validierung** - Refine-Checks für Timer-Konsistenz
+3. **Score-Validierung** - Negative Scores, Tiebreaker nur bei Finals
+
+### P1 (High - 2-4 Wochen)
+4. **Status-Transition-Validierung** - State-Machine für MatchStatus
+5. **Sport-Erweiterbarkeit** - Plugin-Registry statt hardcoded Map
+6. **FK-Validierung** - Business-Logic für Team/Group Referenzen
+
+### P2 (Medium - 1-2 Monate)
+7. **Event-Discriminated-Unions** - Typ-sichere Event-Validierung
+8. **AgeClass-Registry** - Sport-neutrale Altersklassen
+9. **Schema-Strict-Mode** - `.passthrough()` auf `.strict()` für Production
+
+---
+
+## 📈 Architektur-Empfehlungen
+
+### 1. **Domain Events für State Changes**
+```typescript
+// Statt direkter State-Änderung
+interface MatchStateChanged {
+  matchId: string;
+  from: MatchStatus;
+  to: MatchStatus;
+  timestamp: string;
+  userId: string;
+}
+
+// Event-Store für Audit-Trail
+export interface MatchEventStore {
+  publish(event: MatchEvent): Promise<void>;
+  getEvents(matchId: string): MatchEvent[];
+}
+```
+
+### 2. **Repository Pattern für Datenzugriff**
+```typescript
+export interface TournamentRepository {
+  findById(id: string): Promise<Tournament | null>;
+  save(tournament: Tournament): Promise<void>;
+  updateMatch(matchId: string, update: MatchUpdate): Promise<void>;
+  // Validierung vor Save
+}
+```
+
+### 3. **CQRS für Read/Write Separation**
+```typescript
+// Commands (Write)
+class UpdateMatchScoreCommand {
+  matchId: string;
+  scoreA: number;
+  scoreB: number;
+  userId: string;
+}
+
+// Queries (Read)
+class GetMatchStandingsQuery {
+  tournamentId: string;
+  groupId: string;
+}
+```
+
+---
+
+## 🎯 Fazit
+
+Das Datenmodell ist **gut durchdacht** mit klaren Trennungen und umfassenden Tests. Die **kritischen Probleme** liegen bei Datentyp-Konsistenz (Date/ISO), fehlenden Invarianten-Validierungen und Erweiterbarkeit. Mit den oben genannten Maßnahmen kann das Modell auf **9/10** gebracht werden.
+
+**Priorität:** P0-Maßnahmen sofort umsetzen, um Datenkorruption zu verhindern. P1-P2 für langfristige Wartbarkeit und Skalierbarkeit.

--- a/reviews/2026-05-07_2059_SUMMARY.md
+++ b/reviews/2026-05-07_2059_SUMMARY.md
@@ -1,0 +1,133 @@
+# Code Review Summary: hallenfussball-pwa
+
+**Datum:** 2026-05-07 20:59  
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Gesamtdauer:** 32.6s  
+**Agents:** 1  
+
+## Uebersicht
+
+| # | Agent | Status | Dauer | Code | Tokens |
+|---|-------|--------|-------|------|--------|
+| 1 | Turnier-Admin & Playoff-Logik | success | 32.6s | 151.5k | 41082 |
+
+---
+
+## Turnier-Admin & Playoff-Logik
+
+
+
+# 🏆 Tournament Admin & Playoff Logic Review
+
+## Executive Summary
+
+Das Admin-Center ist **strukturiert und benutzerfreundlich** aufgebaut, aber die **Playoff-Logik ist kritisch unvollständig**. Die Implementierung konzentriert sich stark auf UI/UX, während die Kernlogik für Turniere mit Playoff-Phase fehlt.
+
+---
+
+## 🔴 Logik-Fehler
+
+| ID | Problem | Schwere | Code-Referenz |
+|----|---------|---------|---------------|
+| **LOG-001** | **Keine Playoff-Bracket-Generierung** - Der Code enthält keine Logik zur Erstellung von Playoff-Baumen (K.-o.-System, Seeding, Kreuzungen) | 🔴 Kritisch | `src/core/generators/` nicht im Code sichtbar |
+| **LOG-002** | **`reset_schedule` löscht `correctionHistory`** - Bei Reset geht die Ergebnis-Historie verloren, was Audit-Trail bricht | 🟠 Hoch | `DangerZone/index.tsx` Zeile ~200 |
+| **LOG-003** | **`regenerate_schedule` ignoriert Finished-Matches** - Setzt alle Matches auf 'scheduled', aber `finishedAt` bleibt erhalten (Inkonsistenz) | 🟠 Hoch | `DangerZone/index.tsx` Zeile ~150 |
+| **LOG-004** | **Keine Tiebreaker-Implementierung** - `LiveMatch.ts` definiert `TiebreakerMode`, aber keine Logik für Overtime/Penalty | 🔴 Kritisch | `src/core/models/LiveMatch.ts` Zeile 15-20 |
+| **LOG-005** | **Punktgleichheit nicht spezifiziert** - `calculateStandings` wird importiert, aber die Tiebreaker-Regeln (Direktvergleich, Tordifferenz, etc.) sind nicht sichtbar | 🟡 Mittel | `Exports/index.tsx` Zeile 120 |
+
+---
+
+## ⚠️ Fehlende Edge Cases
+
+| ID | Szenario | Status | Empfehlung |
+|----|----------|--------|------------|
+| **EC-001** | **Team-Rückzug während Turnier** | ❌ Fehlend | Team als "disqualified" markieren, Rest-Spielplan anpassen |
+| **EC-002** | **Byes in Playoffs (ungerade Teams)** | ❌ Fehlend | Automatisches "Freilos" für höher gesetztes Team |
+| **EC-003** | **Abbruch nach Gruppenphase** | ❌ Fehlend | Stand der Gruppen als Endstand verwenden |
+| **EC-004** | **Dritter-Platz-Spiel** | ❌ Fehlend | Optionales Feature im Setup konfigurierbar |
+| **EC-005** | **Unentschieden in Playoffs** | ⚠️ Teilweise | `LiveMatch` hat `PlayPhase`, aber keine automatische Verlängerung |
+| **EC-006** | **Mehrere Teams auf Platz X für Playoff-Quali** | ❌ Fehlend | Losentscheid oder Zusatzspiel |
+| **EC-007** | **Spielausfall (Feldverfügbarkeit)** | ⚠️ Teilweise | `reset_schedule` existiert, aber keine "reschedule"-Logik |
+
+---
+
+## 🔗 Inkonsistenzen: Gruppen vs. Playoff
+
+| Bereich | Gruppenphase | Playoff-Phase | Problem |
+|---------|--------------|---------------|---------|
+| **Standings** | `calculateStandings` wird verwendet | ❌ Keine visible Logic | Wie werden Teams qualifiziert? |
+| **Match Status** | `scheduled`/`running`/`finished` | ❌ Keine `PlayPhase`-Verknüpfung | `LiveMatch` hat `TournamentPhase`, aber keine Automatik |
+| **Tiebreaker** | ⚠️ Unklar | ❌ Fehlend | `TiebreakerMode` in `LiveMatch` wird nicht genutzt |
+| **Bracket** | N/A | ❌ Fehlend | Keine Visualisierung/Generierung |
+| **Byes** | N/A | ❌ Fehlend | Kein Handling für ungerade Teamzahlen |
+
+---
+
+## 🎨 Admin-UX-Probleme
+
+| ID | Problem | Schwere | Code-Referenz |
+|----|---------|---------|---------------|
+| **UX-001** | **DangerZone zu mächtig** - `regenerate_schedule` und `reset_schedule` haben ähnliche Namen, aber unterschiedliche Wirkung | 🟠 Hoch | `DangerZone/index.tsx` |
+| **UX-002** | **Keine Undo-Funktion** - `ActivityLog` zeigt Historie, aber keine Rückgängig-Möglichkeit | 🟡 Mittel | `ActivityLog/index.tsx` |
+| **UX-003** | **Auto-Share-Code** - `Visibility` generiert automatisch Share-Code, aber keine manuelle Kontrolle | 🟡 Mittel | `Visibility/index.tsx` Zeile 180+ |
+| **UX-004** | **Keine Playoff-Vorschau** - Admin kann Playoff-Bracket vor Generierung nicht sehen | 🟠 Hoch | Nicht im Code sichtbar |
+| **UX-005** | **Team-Management während Turnier** - Keine Möglichkeit, Teams auszutauschen | 🟠 Hoch | `TeamHelpers/index.tsx` zeigt nur Invite-Logik |
+| **UX-006** | **Feld-Zuweisung** - `FieldManagement` existiert, aber keine Zuweisung zu Matches | 🟡 Mittel | `Settings/index.tsx` |
+
+---
+
+## 📊 Tournament Admin Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Admin-UI/UX** | 8/10 | Klare Struktur, Mobile-First, gute Navigation |
+| **Sicherheit** | 7/10 | DangerZone mit Bestätigung, aber keine 2-Faktor-Auth |
+| **Gruppenphase** | 7/10 | `calculateStandings` vorhanden, aber Tiebreaker unklar |
+| **Playoff-Phase** | 2/10 | **Kritisch fehlend** - keine Bracket-Logik |
+| **Audit/Logging** | 8/10 | `ActivityLog` mit `correctionHistory` ist gut |
+| **Export/Backup** | 9/10 | PDF, JSON, Restore mit Auto-Backup |
+| **Realtime** | 8/10 | Supabase Realtime integriert |
+| **Offline** | 7/10 | PWA, aber keine Offline-Playoff-Logik |
+| **Gesamt** | **6.5/10** | **Gute Admin-UI, aber Playoff-Logik fehlt komplett** |
+
+---
+
+## 🚨 Kritische Empfehlungen (Priorität)
+
+### P0 - Sofort (Turnier-Betrieb gefährdet)
+1. **Playoff-Bracket-Generator implementieren** - Seeding, Kreuzungen, Byes
+2. **Tiebreaker-Logik** - Overtime, Golden Goal, Penalty
+3. **Team-Rückzug Handling** - Disqualification, Spielplan-Anpassung
+
+### P1 - Kurzfristig (Nächste 2 Wochen)
+4. **Undo-Funktion für Ergebnis-Korrekturen**
+5. **Playoff-Vorschau im Admin-Cockpit**
+6. **Dritter-Platz-Spiel Option**
+
+### P2 - Mittelfristig (1-2 Monate)
+7. **Referee-Management** (in `TeamHelpers` als "Coming Soon" markiert)
+8. **Push-Notifications** (in `Notifications` als "Coming Soon" markiert)
+9. **Feld-Zuweisung zu Matches**
+
+---
+
+## 💡 Positive Aspekte
+
+- ✅ **ActivityLog** mit vollständiger Historie (`correctionHistory`)
+- ✅ **Backup/Restore** mit Auto-Backup vor Restore
+- ✅ **Mobile-First** Admin-Design (Hub-and-Spoke Pattern)
+- ✅ **Lazy Loading** für bessere Performance
+- ✅ **i18next** Integration für Mehrsprachigkeit
+- ✅ **Supabase Realtime** für Live-Cockpit
+- ✅ **PDF-Export** mit Spielplan und Tabellen
+
+---
+
+## 📝 Fazit
+
+Die **Admin-UI ist hervorragend** strukturiert, aber die **Playoff-Logik ist nicht implementiert**. Für Turniere ohne Playoff-Phase (reine Gruppenphase) ist das System einsatzbereit. Für Turniere mit K.-o.-Phase muss die Playoff-Generierung priorisiert werden.
+
+**Empfehlung:** Turnier-Admin erst ab Version 1.1 für Playoffs freigeben, oder explizit "Gruppenphase-Only" als Feature kennzeichnen.
+
+---
+

--- a/reviews/2026-05-07_2059_tournament_admin.md
+++ b/reviews/2026-05-07_2059_tournament_admin.md
@@ -1,0 +1,181 @@
+# Code Review: Turnier-Admin & Playoff-Logik
+
+**Modell:** qwen-3.5-122b-sovereign (Thinking Mode)  
+**Dauer:** 32.6s  
+**Status:** success  
+**Code-Kontext:** 151,454 Zeichen  
+
+<details><summary>Thinking Process (2,721 Zeichen)</summary>
+
+Der Nutzer möchte ein strukturiertes Review der Admin-Features und Playoff-Logik der Hallenfussball-PWA. Ich habe den Code analysiert und muss nun die Ergebnisse in einem klaren, strukturierten Format präsentieren.
+
+Wichtige Punkte aus dem Code:
+1. **Playoff-Bracket**: Ich sehe keine spezifischen Playoff-Generierungs-Logiken im bereitgestellten Code. Das ist ein kritischer Punkt.
+2. **Tiebreaker-Regeln**: Die `LiveMatch.ts` zeigt `TiebreakerMode` und `PlayPhase`, aber keine konkrete Implementierung der Tiebreaker-Logik.
+3. **Bye-Handling**: Nicht sichtbar im Code.
+4. **Team-Zurueckziehung**: Nicht implementiert.
+5. **Nachtraegliche Aenderungen**: `ActivityLog` zeigt `correctionHistory` - das ist gut implementiert.
+6. **Turnier-Abbruch**: `DangerZone` hat `end_tournament` und `archive_tournament`.
+7. **Spielplan-Regenerierung**: `DangerZone` hat `regenerate_schedule` und `reset_schedule`.
+8. **Multi-Gruppen → Playoff**: Nicht im Code sichtbar.
+9. **Dritter-Platz-Spiel**: Nicht sichtbar.
+10. **Export**: `ExportsCategory` zeigt PDF-Export mit `generateFullSchedule` und `calculateStandings`.
+
+Ich muss ein strukturiertes Review mit:
+- Logik-Fehlern
+- Fehlenden Edge Cases
+- Inkonsistenzen zwischen Gruppen- und Playoff-Phase
+- Admin-UX-Problemen
+- Tournament Admin Score (1-10)
+
+Lass mich die Analyse durchfuehren:
+
+**Logik-Fehler:**
+1. Keine Playoff-Bracket-Generierungslogik im Code - kritisch fehlend
+2. `regenerate_schedule` in DangerZone setzt alle Matches auf 'scheduled' aber loescht nicht die Gruppen-Phase korrekt
+
+
+3. `reset_schedule` loescht `correctionHistory` - das ist problematisch, da Historie verloren geht
+4. `end_tournament` setzt nur `dashboardStatus` auf 'finished' - keine echte Abschlusssicherung
+
+**Fehlende Edge Cases:**
+1. Was passiert bei Team-Rueckzug mitten im Turnier?
+2. Wie werden Byes in Playoffs behandelt?
+3. Was bei Punktgleichheit in Gruppen?
+4. Wie wird der 3. Platz-Spiel entschieden?
+5. Was bei Abbruch nach Halbfinale?
+
+**Inkonsistenzen:**
+1. Gruppenphase vs. Playoff-Phase: Keine klare Trennung der Logik im Code
+2. `calculateStandings` wird fuer PDF exportiert, aber nicht fuer Playoff-Qualifikation verwendet
+3. `LiveMatch` hat `TiebreakerMode`, aber keine Implementierung dafuer
+
+**Admin-UX-Probleme:**
+1. `DangerZone` ist zu maechtig - keine Bestaetigung fuer kritische Aktionen
+2. `ActivityLog` zeigt Historie, aber keine Undo-Funktion
+3. Keine visuelle Trennung zwischen Gruppen- und Playoff-Phase im Admin-Cockpit
+4. `Visibility` hat Auto-Generation von Share-Code, aber keine manuelle Kontrolle
+
+**Score:**
+Basierend auf der Analyse: 6/10 - Gute Grundstruktur, aber kritische Playoff-Logik fehlt
+
+Ich sollte jetzt das Review in einem klaren Format ausgeben.
+
+
+</details>
+
+---
+
+
+
+# 🏆 Tournament Admin & Playoff Logic Review
+
+## Executive Summary
+
+Das Admin-Center ist **strukturiert und benutzerfreundlich** aufgebaut, aber die **Playoff-Logik ist kritisch unvollständig**. Die Implementierung konzentriert sich stark auf UI/UX, während die Kernlogik für Turniere mit Playoff-Phase fehlt.
+
+---
+
+## 🔴 Logik-Fehler
+
+| ID | Problem | Schwere | Code-Referenz |
+|----|---------|---------|---------------|
+| **LOG-001** | **Keine Playoff-Bracket-Generierung** - Der Code enthält keine Logik zur Erstellung von Playoff-Baumen (K.-o.-System, Seeding, Kreuzungen) | 🔴 Kritisch | `src/core/generators/` nicht im Code sichtbar |
+| **LOG-002** | **`reset_schedule` löscht `correctionHistory`** - Bei Reset geht die Ergebnis-Historie verloren, was Audit-Trail bricht | 🟠 Hoch | `DangerZone/index.tsx` Zeile ~200 |
+| **LOG-003** | **`regenerate_schedule` ignoriert Finished-Matches** - Setzt alle Matches auf 'scheduled', aber `finishedAt` bleibt erhalten (Inkonsistenz) | 🟠 Hoch | `DangerZone/index.tsx` Zeile ~150 |
+| **LOG-004** | **Keine Tiebreaker-Implementierung** - `LiveMatch.ts` definiert `TiebreakerMode`, aber keine Logik für Overtime/Penalty | 🔴 Kritisch | `src/core/models/LiveMatch.ts` Zeile 15-20 |
+| **LOG-005** | **Punktgleichheit nicht spezifiziert** - `calculateStandings` wird importiert, aber die Tiebreaker-Regeln (Direktvergleich, Tordifferenz, etc.) sind nicht sichtbar | 🟡 Mittel | `Exports/index.tsx` Zeile 120 |
+
+---
+
+## ⚠️ Fehlende Edge Cases
+
+| ID | Szenario | Status | Empfehlung |
+|----|----------|--------|------------|
+| **EC-001** | **Team-Rückzug während Turnier** | ❌ Fehlend | Team als "disqualified" markieren, Rest-Spielplan anpassen |
+| **EC-002** | **Byes in Playoffs (ungerade Teams)** | ❌ Fehlend | Automatisches "Freilos" für höher gesetztes Team |
+| **EC-003** | **Abbruch nach Gruppenphase** | ❌ Fehlend | Stand der Gruppen als Endstand verwenden |
+| **EC-004** | **Dritter-Platz-Spiel** | ❌ Fehlend | Optionales Feature im Setup konfigurierbar |
+| **EC-005** | **Unentschieden in Playoffs** | ⚠️ Teilweise | `LiveMatch` hat `PlayPhase`, aber keine automatische Verlängerung |
+| **EC-006** | **Mehrere Teams auf Platz X für Playoff-Quali** | ❌ Fehlend | Losentscheid oder Zusatzspiel |
+| **EC-007** | **Spielausfall (Feldverfügbarkeit)** | ⚠️ Teilweise | `reset_schedule` existiert, aber keine "reschedule"-Logik |
+
+---
+
+## 🔗 Inkonsistenzen: Gruppen vs. Playoff
+
+| Bereich | Gruppenphase | Playoff-Phase | Problem |
+|---------|--------------|---------------|---------|
+| **Standings** | `calculateStandings` wird verwendet | ❌ Keine visible Logic | Wie werden Teams qualifiziert? |
+| **Match Status** | `scheduled`/`running`/`finished` | ❌ Keine `PlayPhase`-Verknüpfung | `LiveMatch` hat `TournamentPhase`, aber keine Automatik |
+| **Tiebreaker** | ⚠️ Unklar | ❌ Fehlend | `TiebreakerMode` in `LiveMatch` wird nicht genutzt |
+| **Bracket** | N/A | ❌ Fehlend | Keine Visualisierung/Generierung |
+| **Byes** | N/A | ❌ Fehlend | Kein Handling für ungerade Teamzahlen |
+
+---
+
+## 🎨 Admin-UX-Probleme
+
+| ID | Problem | Schwere | Code-Referenz |
+|----|---------|---------|---------------|
+| **UX-001** | **DangerZone zu mächtig** - `regenerate_schedule` und `reset_schedule` haben ähnliche Namen, aber unterschiedliche Wirkung | 🟠 Hoch | `DangerZone/index.tsx` |
+| **UX-002** | **Keine Undo-Funktion** - `ActivityLog` zeigt Historie, aber keine Rückgängig-Möglichkeit | 🟡 Mittel | `ActivityLog/index.tsx` |
+| **UX-003** | **Auto-Share-Code** - `Visibility` generiert automatisch Share-Code, aber keine manuelle Kontrolle | 🟡 Mittel | `Visibility/index.tsx` Zeile 180+ |
+| **UX-004** | **Keine Playoff-Vorschau** - Admin kann Playoff-Bracket vor Generierung nicht sehen | 🟠 Hoch | Nicht im Code sichtbar |
+| **UX-005** | **Team-Management während Turnier** - Keine Möglichkeit, Teams auszutauschen | 🟠 Hoch | `TeamHelpers/index.tsx` zeigt nur Invite-Logik |
+| **UX-006** | **Feld-Zuweisung** - `FieldManagement` existiert, aber keine Zuweisung zu Matches | 🟡 Mittel | `Settings/index.tsx` |
+
+---
+
+## 📊 Tournament Admin Score
+
+| Kategorie | Score | Begründung |
+|-----------|-------|------------|
+| **Admin-UI/UX** | 8/10 | Klare Struktur, Mobile-First, gute Navigation |
+| **Sicherheit** | 7/10 | DangerZone mit Bestätigung, aber keine 2-Faktor-Auth |
+| **Gruppenphase** | 7/10 | `calculateStandings` vorhanden, aber Tiebreaker unklar |
+| **Playoff-Phase** | 2/10 | **Kritisch fehlend** - keine Bracket-Logik |
+| **Audit/Logging** | 8/10 | `ActivityLog` mit `correctionHistory` ist gut |
+| **Export/Backup** | 9/10 | PDF, JSON, Restore mit Auto-Backup |
+| **Realtime** | 8/10 | Supabase Realtime integriert |
+| **Offline** | 7/10 | PWA, aber keine Offline-Playoff-Logik |
+| **Gesamt** | **6.5/10** | **Gute Admin-UI, aber Playoff-Logik fehlt komplett** |
+
+---
+
+## 🚨 Kritische Empfehlungen (Priorität)
+
+### P0 - Sofort (Turnier-Betrieb gefährdet)
+1. **Playoff-Bracket-Generator implementieren** - Seeding, Kreuzungen, Byes
+2. **Tiebreaker-Logik** - Overtime, Golden Goal, Penalty
+3. **Team-Rückzug Handling** - Disqualification, Spielplan-Anpassung
+
+### P1 - Kurzfristig (Nächste 2 Wochen)
+4. **Undo-Funktion für Ergebnis-Korrekturen**
+5. **Playoff-Vorschau im Admin-Cockpit**
+6. **Dritter-Platz-Spiel Option**
+
+### P2 - Mittelfristig (1-2 Monate)
+7. **Referee-Management** (in `TeamHelpers` als "Coming Soon" markiert)
+8. **Push-Notifications** (in `Notifications` als "Coming Soon" markiert)
+9. **Feld-Zuweisung zu Matches**
+
+---
+
+## 💡 Positive Aspekte
+
+- ✅ **ActivityLog** mit vollständiger Historie (`correctionHistory`)
+- ✅ **Backup/Restore** mit Auto-Backup vor Restore
+- ✅ **Mobile-First** Admin-Design (Hub-and-Spoke Pattern)
+- ✅ **Lazy Loading** für bessere Performance
+- ✅ **i18next** Integration für Mehrsprachigkeit
+- ✅ **Supabase Realtime** für Live-Cockpit
+- ✅ **PDF-Export** mit Spielplan und Tabellen
+
+---
+
+## 📝 Fazit
+
+Die **Admin-UI ist hervorragend** strukturiert, aber die **Playoff-Logik ist nicht implementiert**. Für Turniere ohne Playoff-Phase (reine Gruppenphase) ist das System einsatzbereit. Für Turniere mit K.-o.-Phase muss die Playoff-Generierung priorisiert werden.
+
+**Empfehlung:** Turnier-Admin erst ab Version 1.1 für Playoffs freigeben, oder explizit "Gruppenphase-Only" als Feature kennzeichnen.


### PR DESCRIPTION
## Summary

Three small atomic commits to clean up working-tree pollution that accumulated across recent extraction/review runs:

| Commit | What |
|--------|------|
| `chore(repo): gitignore output and backup files` | Adds `*.bak.*`, `ci_logs.txt`, `test-reports/` to .gitignore |
| `data(reviews): import review snapshots from March + May 2026 sessions` | 38 review files (corpus for findings extractor) — 5 stub files from 504-timeouts excluded |
| `data(findings): import 160 findings extracted from review snapshots` | Replaces empty INDEX.md template with the actual extracted backlog |

## Why now

Before the upcoming Mega-Rebase of #115 (the consolidated review-phase stack), the working tree should be clean so rebase conflict-resolution doesn't pollute with these data files.

## Notes

- The 5 excluded review stubs are 264-275 byte 504-timeout error logs from session `2026-05-07_2053`. The successful re-runs of those modules (sessions 2055/2056/2058/2059) ARE included.
- Findings file paths come from LLM extraction. Some reference paths that don't match current repo structure (e.g., `src/admin/...`); these will surface as `NEEDS_HUMAN` verdicts when processed by `/finding-fix` — that's the `verify_path` DAG node's job.

## Test plan

- [x] Pre-commit hook (vitest) passed on each commit: 830 tests green
- [x] No code changes — pure data + .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)