### PR TITLE
fix(security): F-005 replace weak Math.random() UUID fallback

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -6,7 +6,7 @@
 | F-002 | 🔴 | security | Non-Null Assertions (!) können Runtime-Errors verursachen | src/utils/FairnessCalculator.ts | 1h | open |
 | F-003 | 🟠 | testing | Type-Safety in Tests durch 'as'-Casts verloren | src/utils/__tests__/ScenarioHMK.test.ts | 30m | open |
 | F-004 | 🟠 | other | || statt ?? für Boolean-Checks erhöht Logik-Risiko | src/utils/filterMatches.ts | 30m | open |
-| F-005 | 🟠 | security | Schwacher Fallback-UUID-Generator | src/utils/idGenerator.ts | 45m | open |
+| F-005 | 🟠 | security | Schwacher Fallback-UUID-Generator | src/utils/idGenerator.ts | 45m | fixed |
 | F-006 | 🟡 | testing | console.log Debug-Output in Tests vorhanden | src/utils/scheduleGenerator_finals_bug.test.ts | 15m | open |
 | F-007 | 🟡 | other | Dead-Code-Kommentar verwirrend | src/utils/knockoutMatchGenerator.ts | 10m | open |
 | F-008 | 🟡 | other | Gemischte Deutsch/Englisch Namen in utils | src/utils/ | 2h | open |

--- a/src/utils/__tests__/idGenerator.test.ts
+++ b/src/utils/__tests__/idGenerator.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  generateUniqueId,
+  generateTournamentId,
+  generateTeamId,
+  generateGroupStageMatchId,
+  generateFinalsMatchId,
+} from '../idGenerator';
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('idGenerator', () => {
+  describe('generateUniqueId — Format', () => {
+    it('matches RFC 4122 v4 pattern', () => {
+      for (let i = 0; i < 100; i++) {
+        expect(generateUniqueId()).toMatch(UUID_V4_PATTERN);
+      }
+    });
+  });
+
+  describe('generateUniqueId — Kollisions-Resistenz', () => {
+    it('produces 100k unique IDs without collision', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 100_000; i++) {
+        ids.add(generateUniqueId());
+      }
+      expect(ids.size).toBe(100_000);
+    });
+  });
+
+  describe('generateUniqueId — Fallback paths', () => {
+    let originalCrypto: typeof globalThis.crypto;
+
+    beforeEach(() => {
+      originalCrypto = globalThis.crypto;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+      });
+    });
+
+    it('falls back to crypto.getRandomValues when randomUUID is missing', () => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: {
+          getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+        },
+        configurable: true,
+      });
+      const id = generateUniqueId();
+      expect(id).toMatch(UUID_V4_PATTERN);
+    });
+
+    it('throws when neither randomUUID nor getRandomValues exist', () => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: {},
+        configurable: true,
+      });
+      expect(() => generateUniqueId()).toThrow(
+        /Cryptographically secure UUID generation unavailable/
+      );
+    });
+  });
+
+  describe('Wrappers delegate to generateUniqueId', () => {
+    it.each([
+      ['generateTournamentId', generateTournamentId],
+      ['generateTeamId', generateTeamId],
+      ['generateGroupStageMatchId', generateGroupStageMatchId],
+      ['generateFinalsMatchId', generateFinalsMatchId],
+    ])('%s returns valid UUID v4', (_name, fn) => {
+      expect(fn()).toMatch(UUID_V4_PATTERN);
+    });
+  });
+});

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -1,38 +1,45 @@
 /**
- * ID Generator für garantiert eindeutige IDs
+ * Cryptographically secure UUID v4 generator.
  *
- * Generiert IDs im Format: {prefix}-{timestamp}-{random}-{counter}
- * - prefix: Namespace (z.B. 'gs' für Gruppenphase, 'fr' für Finalrunde)
- * - timestamp: Millisekunden seit Epoch
- * - random: Zufälliger 6-stelliger String (Base36)
- * - counter: Fortlaufender Zähler
+ * Replaces a previous Math.random()-based fallback that was not CSPRNG-safe.
+ * IDs produced here are used as primary keys for tournaments, teams, matches
+ * and mutation-queue entries; collisions across devices would corrupt sync.
  */
-
-let counter = 0;
 
 /**
- * Generiert eine eindeutige ID
- * @param prefix Optional: Namespace-Präfix (default: 'match')
- * @returns Eindeutige ID im Format prefix-timestamp-random-counter
+ * Generiert eine kryptographisch sichere UUID v4.
+ *
+ * Browser-Kompatibilität (Stand 2026):
+ *   - Bevorzugt: crypto.randomUUID()      → Chrome 92+, Firefox 95+, Safari 15.4+, Node 14.17+
+ *   - Fallback:  crypto.getRandomValues() → IE11+, alle modernen Browser, Node 16+
+ *   - Wenn keines verfügbar: throw (kein schwacher Math.random()-Fallback)
+ *
+ * @returns RFC 4122 v4 UUID, z.B. "550e8400-e29b-41d4-a716-446655440000"
+ * @throws Error wenn weder crypto.randomUUID noch crypto.getRandomValues verfügbar
  */
 export function generateUniqueId(): string {
-  // Use crypto.randomUUID for collision-free IDs (essential for sync)
-  // Fallback for older browsers included
-   
-  if (crypto?.randomUUID) {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-
-  // Fallback: timestamp + random (simulated UUID-ish)
-  const timestamp = Date.now().toString(16);
-  const random = Math.random().toString(16).substring(2);
-  const count = (counter++).toString(16);
-  return `${timestamp}-${random}-${count}`.padEnd(36, '0').substring(0, 36); // weak fallback but consistent format
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    // RFC 4122 v4: 128 random bits with version+variant bits set per spec.
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+  }
+  throw new Error(
+    'Cryptographically secure UUID generation unavailable: ' +
+      'neither crypto.randomUUID nor crypto.getRandomValues is supported. ' +
+      'Update your runtime (Browser ≥4 Jahre alt, Node ≥16).'
+  );
 }
 
 /**
  * Generiert eine Match-ID
- * @returns UUID
+ * @returns UUID v4
  */
 export function generateGroupStageMatchId(): string {
   return generateUniqueId();
@@ -40,7 +47,7 @@ export function generateGroupStageMatchId(): string {
 
 /**
  * Generiert eine Match-ID
- * @returns UUID
+ * @returns UUID v4
  */
 export function generateFinalsMatchId(): string {
   return generateUniqueId();
@@ -48,7 +55,7 @@ export function generateFinalsMatchId(): string {
 
 /**
  * Generiert eine Tournament-ID
- * @returns UUID
+ * @returns UUID v4
  */
 export function generateTournamentId(): string {
   return generateUniqueId();
@@ -56,15 +63,8 @@ export function generateTournamentId(): string {
 
 /**
  * Generiert eine Team-ID
- * @returns UUID (kompatibel mit Supabase)
+ * @returns UUID v4 (kompatibel mit Supabase)
  */
 export function generateTeamId(): string {
   return generateUniqueId();
-}
-
-/**
- * Reset counter (nur für Tests)
- */
-export function resetCounter(): void {
-  counter = 0;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2020",
+      "ES2022",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
## Summary

Replaces the `Math.random()`-based fallback in [src/utils/idGenerator.ts](src/utils/idGenerator.ts) with a proper `crypto.getRandomValues()` v4 polyfill. Adds first test coverage for `idGenerator` (8 tests, including 100k-collision-resistance). Bumps tsconfig target ES2020 → ES2022 to match the actually-used `crypto.randomUUID()` API.

Closes finding **F-005** (medium severity, security area).

## Why

The previous fallback path:

```typescript
if (crypto?.randomUUID) {
  return crypto.randomUUID();
}
const random = Math.random().toString(16).substring(2);  // ← not CSPRNG
return `${timestamp}-${random}-${count}`.padEnd(36, '0').substring(0, 36);
```

`Math.random()` is **not cryptographically secure**. With 10 callers (`generateTournamentId`, `generateTeamId`, `generateGroupStageMatchId`, `generateFinalsMatchId`, all wrapping `generateUniqueId`) producing primary keys for tournaments, teams, matches and `MutationQueue` entries, collisions across devices could corrupt sync state.

## What's new

```typescript
export function generateUniqueId(): string {
  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
    return crypto.randomUUID();
  }
  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
    // RFC 4122 v4: 128 random bits with version+variant bits set per spec.
    const bytes = new Uint8Array(16);
    crypto.getRandomValues(bytes);
    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
  }
  throw new Error('Cryptographically secure UUID generation unavailable: ...');
}
```

Browser support:
- `crypto.randomUUID()`: Chrome 92+ (Aug 2021), Firefox 95+ (Dec 2021), Safari 15.4+ (Mar 2022), Node 14.17+
- `crypto.getRandomValues()`: IE11+, all modern browsers, Node 16+
- If neither: throw (no silent weak fallback)

## Acceptance Criteria (from F-005)

- [x] crypto.randomUUID() in allen Umgebungen verfügbar (mit getRandomValues-Fallback)
- [x] Keine schwachen Fallback-Implementierungen (Math.random() entfernt)
- [x] ID-Kollisionstests bestehen (100k unique IDs)
- [x] Browser-Kompatibilität dokumentiert (JSDoc inline)

## Test plan

- [x] **New test file** `src/utils/__tests__/idGenerator.test.ts`: 8 tests
  - format (UUID v4 pattern, 100 iterations)
  - collision-resistance (100k unique)
  - fallback paths (mocked crypto)
  - wrapper delegation
- [x] Full vitest suite: **838 passed, 8 skipped** (was 830, +8 new)
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds (8.9s, ES2022 target works)

## Notes

- `resetCounter()` was removed (zero callers — was only relevant for the removed weak-fallback path)
- Live-run of `/finding-fix F-005` produced a structurally broken patch (LLM removed the weak fallback but didn't add a replacement → function returned undefined). Reviewer correctly REJECTED. Manual implementation followed the plan in `~/.claude/plans/f-005-umsetzen-foamy-dijkstra.md`. **Defense-in-depth working as designed.**

## Out of scope (future PRs)

- `src/features/auth/utils/tokenGenerator.ts:45-57` has the **same** Math.random() pattern — separate finding deserves its own PR
- `src/core/sync/SyncQueueStore.ts:131` calls `crypto.randomUUID()` directly without the safety wrapper — refactor candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)