### PR TITLE
feat(findings): run_lint Pre-Gate vor review_patch (False-APPROVED-Klasse fangen)

### DIFF
--- a/scripts/findings/dag_nodes/run_lint.py
+++ b/scripts/findings/dag_nodes/run_lint.py
@@ -24,4 +24,9 @@ def run_lint(
 ) -> FindingFixState:
     if not state.fix_applied:
         return state
+    if not state.path_resolved:
+        return state
+    ext = Path(state.path_resolved).suffix.lower()
+    if ext not in _LINTABLE_EXTENSIONS:
+        return state
     return state

--- a/scripts/findings/dag_nodes/run_lint.py
+++ b/scripts/findings/dag_nodes/run_lint.py
@@ -29,4 +29,31 @@ def run_lint(
     ext = Path(state.path_resolved).suffix.lower()
     if ext not in _LINTABLE_EXTENSIONS:
         return state
+
+    repo_root = Path(repo_root)
+    try:
+        proc = subprocess.run(
+            ["npx", "eslint", "--max-warnings", "0", state.path_resolved],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        state.lint_passed = False
+        state.lint_output = f"TIMEOUT after {timeout}s"
+        state.review_verdict = "NEEDS_HUMAN"
+        state.review_reasoning = state.lint_output
+        return state
+
+    state.lint_output = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode == 0:
+        state.lint_passed = True
+        return state
+
+    state.lint_passed = False
+    state.review_verdict = "NEEDS_HUMAN"
+    state.review_reasoning = (
+        f"ESLint failed (exit {proc.returncode}):\n{state.lint_output[:1500]}"
+    )
     return state

--- a/scripts/findings/dag_nodes/run_lint.py
+++ b/scripts/findings/dag_nodes/run_lint.py
@@ -1,0 +1,27 @@
+"""DAG node: run ESLint as deterministic Pre-Gate before review_patch.
+
+Rationale: review_patch (LLM reviewer) has shown to halluzinate APPROVED
+verdicts on patches that violate react-hooks/exhaustive-deps and similar
+rules (see F-037 live-run, 2026-05-10). A deterministic lint check before
+the LLM reviewer is invoked prevents this class of False-Positives.
+
+On lint-fail: sets state.review_verdict='NEEDS_HUMAN' directly, signalling
+downstream that review_patch should be skipped. On non-JS/TS files or when
+fix_applied is False, this node is a no-op.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from ..lib.models import FindingFixState
+
+_LINTABLE_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx"}
+
+
+def run_lint(
+    state: FindingFixState, *, repo_root: str | Path, timeout: int = 60
+) -> FindingFixState:
+    if not state.fix_applied:
+        return state
+    return state

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -138,11 +138,15 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
                 state.review_verdict = None
                 state.review_reasoning = None
                 state.review_concerns = []
+                state.lint_passed = None
+                state.lint_output = None
                 state = plan_changes(state, repo_root=repo_root)
                 if state.planned_changes:
                     state = apply_patch(state, repo_root=repo_root)
                     if state.fix_applied:
-                        state = review_patch(state)
+                        state = run_lint(state, repo_root=repo_root)
+                        if state.review_verdict is None:
+                            state = review_patch(state)
                         if state.review_verdict == "APPROVED":
                             state = run_tests(state, repo_root=repo_root)
 

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -50,6 +50,7 @@ from .dag_nodes.apply_fix import apply_fix  # kept for back-compat; no longer ca
 from .dag_nodes.plan_changes import plan_changes
 from .dag_nodes.apply_patch import apply_patch
 from .dag_nodes.review_patch import review_patch
+from .dag_nodes.run_lint import run_lint
 from .dag_nodes.run_tests import run_tests
 from .dag_nodes.update_index import update_finding_status, regenerate_index
 
@@ -77,9 +78,12 @@ def _run_dag(state: FindingFixState, *, repo_root: Path) -> FindingFixState:
     state = apply_patch(state, repo_root=repo_root)
     if not state.fix_applied:
         return state  # patch ops failed (e.g., replace_text not unique)
-    state = review_patch(state)
+    state = run_lint(state, repo_root=repo_root)
+    if state.review_verdict is None:
+        # lint passed (or was skipped for non-JS/TS) → ask LLM reviewer
+        state = review_patch(state)
     if state.review_verdict != "APPROVED":
-        # REJECTED or NEEDS_HUMAN: do NOT run tests, leave file as patched but flag for human
+        # REJECTED or NEEDS_HUMAN (incl. lint-fail): do NOT run tests, flag for human
         return state
     state = run_tests(state, repo_root=repo_root)
     return state

--- a/scripts/findings/finding_fix.py
+++ b/scripts/findings/finding_fix.py
@@ -174,6 +174,7 @@ def run_finding_fix(*, finding_id: str, findings_dir: Path, repo_root: Path) -> 
             "review_reasoning": state.review_reasoning,
             "review_concerns_count": len(state.review_concerns),
             "review_concerns": state.review_concerns,
+            "lint_passed": state.lint_passed,
         })
 
     return state

--- a/scripts/findings/lib/models.py
+++ b/scripts/findings/lib/models.py
@@ -103,6 +103,9 @@ class FindingFixState(BaseModel):
     # run_tests output:
     tests_pass: Optional[bool] = None
     test_output: Optional[str] = None
+    # run_lint output (Defense-in-Depth Pre-Gate before review_patch):
+    lint_passed: Optional[bool] = None
+    lint_output: Optional[str] = None
     # tracking
     tool_call_errors: int = 0
     fallback_used: bool = False

--- a/tests/findings/dag_nodes/test_run_lint.py
+++ b/tests/findings/dag_nodes/test_run_lint.py
@@ -26,3 +26,11 @@ def test_run_lint_skips_if_no_fix_applied():
     assert state.lint_passed is None
     assert state.review_verdict is None
     mock_run.assert_not_called()
+
+
+def test_run_lint_skips_for_non_js_extensions():
+    state = _state(fix_applied=True, path="docs/some.md")
+    with patch("findings.dag_nodes.run_lint.subprocess.run") as mock_run:
+        state = run_lint(state, repo_root="/tmp")
+    assert state.lint_passed is None
+    mock_run.assert_not_called()

--- a/tests/findings/dag_nodes/test_run_lint.py
+++ b/tests/findings/dag_nodes/test_run_lint.py
@@ -34,3 +34,16 @@ def test_run_lint_skips_for_non_js_extensions():
         state = run_lint(state, repo_root="/tmp")
     assert state.lint_passed is None
     mock_run.assert_not_called()
+
+
+def test_run_lint_sets_lint_passed_true_on_zero_exit():
+    state = _state(fix_applied=True, path="src/hooks/foo.ts")
+    with patch("findings.dag_nodes.run_lint.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        state = run_lint(state, repo_root="/tmp")
+    assert state.lint_passed is True
+    assert state.review_verdict is None  # downstream review_patch still runs
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    assert call_args[0][0] == ["npx", "eslint", "--max-warnings", "0", "src/hooks/foo.ts"]
+    assert call_args[1]["timeout"] == 60

--- a/tests/findings/dag_nodes/test_run_lint.py
+++ b/tests/findings/dag_nodes/test_run_lint.py
@@ -1,0 +1,28 @@
+"""Tests for run_lint DAG node (Defense-in-Depth Pre-Gate before review_patch)."""
+from __future__ import annotations
+from unittest.mock import patch, MagicMock
+from findings.dag_nodes.run_lint import run_lint
+from findings.lib.models import FindingFixState, Finding, Severity, Status, ModelChoice
+
+
+def _state(*, fix_applied: bool, path: str = "src/x.ts") -> FindingFixState:
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="t", file=path,
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[], acceptance_criteria=[],
+    )
+    s = FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="x"),
+        fix_applied=fix_applied,
+        path_resolved=path,
+    )
+    return s
+
+
+def test_run_lint_skips_if_no_fix_applied():
+    state = _state(fix_applied=False)
+    with patch("findings.dag_nodes.run_lint.subprocess.run") as mock_run:
+        state = run_lint(state, repo_root="/tmp")
+    assert state.lint_passed is None
+    assert state.review_verdict is None
+    mock_run.assert_not_called()

--- a/tests/findings/dag_nodes/test_run_lint.py
+++ b/tests/findings/dag_nodes/test_run_lint.py
@@ -47,3 +47,18 @@ def test_run_lint_sets_lint_passed_true_on_zero_exit():
     call_args = mock_run.call_args
     assert call_args[0][0] == ["npx", "eslint", "--max-warnings", "0", "src/hooks/foo.ts"]
     assert call_args[1]["timeout"] == 60
+
+
+def test_run_lint_sets_needs_human_on_lint_fail():
+    state = _state(fix_applied=True, path="src/hooks/useClickOutside.ts")
+    eslint_output = (
+        "55:6  warning  React Hook useEffect has a missing dependency: 'ref'.   react-hooks/exhaustive-deps\n"
+        "✖ 1 problem (0 errors, 1 warning)"
+    )
+    with patch("findings.dag_nodes.run_lint.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout=eslint_output, stderr="")
+        state = run_lint(state, repo_root="/tmp")
+    assert state.lint_passed is False
+    assert state.review_verdict == "NEEDS_HUMAN"
+    assert "react-hooks/exhaustive-deps" in state.review_reasoning
+    assert "exit 1" in state.review_reasoning

--- a/tests/findings/test_finding_fix.py
+++ b/tests/findings/test_finding_fix.py
@@ -222,3 +222,43 @@ def test_lint_fail_skips_review_and_tests(tmp_path):
     assert result.review_verdict == "NEEDS_HUMAN"
     assert "react-hooks/exhaustive-deps" in result.review_reasoning
     assert result.tests_pass is None
+
+
+def test_fallback_path_runs_lint_pregate(tmp_path):
+    """Fallback-flow also routes through run_lint before review_patch."""
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-006.md").write_text(
+        "---\nid: F-006\nseverity: medium\narea: ux\ntitle: t\nfile: src/u.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: [AK1]\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "u.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("let u = 1;\n")
+
+    eslint_output = "1:1  warning  some-rule  test\n✖ 1 problem"
+
+    def _fake_subprocess(args, **kwargs):
+        if "eslint" in args:
+            return MagicMock(returncode=1, stdout=eslint_output, stderr="")
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
+         patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
+         patch("findings.dag_nodes.run_tests.subprocess.run", side_effect=_fake_subprocess):
+        # First plan call (primary aihub) fails JSON, second (fallback) succeeds → triggers fallback flow
+        mock_plan.side_effect = [
+            "INVALID JSON",
+            '{"analyse": "fix", "aenderungen": [{"typ": "replace_text", "find": "let u = 1;", "replace": "const u = 1;"}]}',
+        ]
+        mock_judge.return_value = '{"is_still_valid": true, "reasoning":"y"}'
+
+        result = run_finding_fix(finding_id="F-006", findings_dir=findings, repo_root=tmp_path)
+
+    # Fallback ran AND lint Pre-Gate caught the failure → review never invoked
+    assert result.fallback_used is True
+    assert result.lint_passed is False
+    assert result.review_verdict == "NEEDS_HUMAN"
+    mock_review.assert_not_called()

--- a/tests/findings/test_finding_fix.py
+++ b/tests/findings/test_finding_fix.py
@@ -20,10 +20,14 @@ def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
     src.parent.mkdir(parents=True)
     src.write_text("let x = 1;\n")
 
+    def _fake_subprocess(args, **kwargs):
+        # run_lint runs `npx eslint ...`, run_tests runs `npm test ...`
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
     with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
          patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
          patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
-         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+         patch("findings.dag_nodes.run_tests.subprocess.run", side_effect=_fake_subprocess):
         mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
         mock_plan.return_value = (
             '{"analyse": "test fix", "aenderungen": ['
@@ -31,7 +35,6 @@ def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
             ']}'
         )
         mock_review.return_value = '{"verdict": "APPROVED", "reasoning": "looks good"}'
-        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
 
         result = run_finding_fix(
             finding_id="F-001",
@@ -42,6 +45,7 @@ def test_full_pipeline_low_severity_with_mocked_llm(tmp_path):
     assert result.fix_applied is True
     assert result.tests_pass is True
     assert result.review_verdict == "APPROVED"
+    assert result.lint_passed is True
     # File content should have changed
     assert src.read_text() == "const x = 1;\n"
     # The status should be flipped to 'fixed'
@@ -61,11 +65,14 @@ def test_fallback_kicks_in_after_aihub_failure(tmp_path):
     src.parent.mkdir(parents=True)
     src.write_text("let a = 1;\n")
 
-    # Simulate aihub failure in plan_changes → fallback to claude haiku re-runs plan
+    def _fake_subprocess(args, **kwargs):
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    # Simulate aihub failure in plan_changes → fallback re-runs plan
     with patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
          patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
          patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
-         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+         patch("findings.dag_nodes.run_tests.subprocess.run", side_effect=_fake_subprocess):
         # First call (aihub) fails JSON parse, second call (fallback) succeeds
         mock_plan.side_effect = [
             "INVALID JSON",
@@ -73,7 +80,6 @@ def test_fallback_kicks_in_after_aihub_failure(tmp_path):
         ]
         mock_judge.return_value = '{"is_still_valid": true, "reasoning":"y"}'
         mock_review.return_value = '{"verdict": "APPROVED", "reasoning": "looks good"}'
-        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
 
         result = run_finding_fix(finding_id="F-002", findings_dir=findings, repo_root=tmp_path)
 
@@ -126,10 +132,17 @@ def test_review_rejected_skips_tests(tmp_path):
     src.parent.mkdir(parents=True)
     src.write_text("let w = 1;\n")
 
+    npm_test_calls = []
+
+    def _fake_subprocess(args, **kwargs):
+        if args[0:2] == ["npm", "test"]:
+            npm_test_calls.append(args)
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
     with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
          patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
          patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
-         patch("findings.dag_nodes.run_tests.subprocess.run") as mock_run:
+         patch("findings.dag_nodes.run_tests.subprocess.run", side_effect=_fake_subprocess):
         mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
         mock_plan.return_value = (
             '{"analyse": "test fix", "aenderungen": ['
@@ -144,9 +157,68 @@ def test_review_rejected_skips_tests(tmp_path):
             repo_root=tmp_path,
         )
 
-    # Review rejected → tests must NOT have been run
-    mock_run.assert_not_called()
+    # Review rejected → tests must NOT have been run (no npm test invocation)
+    assert npm_test_calls == []
     assert result.review_verdict == "REJECTED"
     # fix_applied is True (patch was applied), but tests_pass is None
     assert result.fix_applied is True
+    assert result.tests_pass is None
+
+
+def test_lint_fail_skips_review_and_tests(tmp_path):
+    """Pre-Gate: lint-fail sets NEEDS_HUMAN, so review_patch and run_tests are skipped.
+
+    Captures the F-037 class of bugs: reviewer halluzinated APPROVED on a patch
+    that violates react-hooks/exhaustive-deps. With run_lint as deterministic
+    Pre-Gate, the LLM reviewer is never invoked.
+    """
+    findings = tmp_path / "docs" / "findings"
+    findings.mkdir(parents=True)
+    (findings / "F-005.md").write_text(
+        "---\nid: F-005\nseverity: low\narea: ux\ntitle: lint-fail case\nfile: src/v.ts\n"
+        "status: open\nsource: reviews/r.md\ndetected: 2026-05-07\nrelated: []\n"
+        "acceptance_criteria: []\n---\n\nbody\n"
+    )
+    src = tmp_path / "src" / "v.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("let v = 1;\n")
+
+    eslint_output = (
+        "1:1  warning  React Hook useEffect has a missing dependency: 'v'.   react-hooks/exhaustive-deps\n"
+        "✖ 1 problem (0 errors, 1 warning)"
+    )
+    npm_test_calls = []
+
+    def _fake_subprocess(args, **kwargs):
+        if "eslint" in args:
+            return MagicMock(returncode=1, stdout=eslint_output, stderr="")
+        if args[0:2] == ["npm", "test"]:
+            npm_test_calls.append(args)
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    with patch("findings.dag_nodes.judge_necessity._call_judge_llm") as mock_judge, \
+         patch("findings.dag_nodes.plan_changes._call_plan_llm") as mock_plan, \
+         patch("findings.dag_nodes.review_patch._call_review_llm") as mock_review, \
+         patch("findings.dag_nodes.run_tests.subprocess.run", side_effect=_fake_subprocess):
+        mock_judge.return_value = '{"is_still_valid": true, "reasoning": "yes"}'
+        mock_plan.return_value = (
+            '{"analyse": "test fix", "aenderungen": ['
+            '{"typ": "replace_text", "find": "let v = 1;", "replace": "const v = 1;"}'
+            ']}'
+        )
+
+        result = run_finding_fix(
+            finding_id="F-005",
+            findings_dir=findings,
+            repo_root=tmp_path,
+        )
+
+    # Pre-Gate semantics: review_patch and run_tests must NOT be called
+    mock_review.assert_not_called()
+    assert npm_test_calls == []
+    # State reflects the Pre-Gate verdict
+    assert result.fix_applied is True  # apply_patch ran successfully
+    assert result.lint_passed is False
+    assert result.review_verdict == "NEEDS_HUMAN"
+    assert "react-hooks/exhaustive-deps" in result.review_reasoning
     assert result.tests_pass is None

--- a/tests/findings/test_models.py
+++ b/tests/findings/test_models.py
@@ -55,3 +55,17 @@ def test_finding_acceptance_criteria_optional_for_low(sample_finding_dict):
 def test_model_choice_for_critical():
     mc = ModelChoice(provider="claude", model="opus-4-6", require_human_review=True)
     assert mc.require_human_review is True
+
+
+def test_finding_fix_state_lint_passed_defaults_to_none():
+    """run_lint output fields exist and default to None (not yet executed)."""
+    finding = Finding(
+        id="F-001", severity=Severity.LOW, area="ux", title="t", file="src/x.ts",
+        status=Status.OPEN, source="r", detected="2026-05-07", related=[], acceptance_criteria=[],
+    )
+    state = FindingFixState(
+        finding=finding,
+        routing=ModelChoice(provider="aihub", model="x"),
+    )
+    assert state.lint_passed is None
+    assert state.lint_output is None


### PR DESCRIPTION
## Summary

Neuer DAG-Node `run_lint` zwischen `apply_patch` und `review_patch` als deterministischer Pre-Gate. Bei Lint-Fail (`npx eslint --max-warnings 0 <file>`, Exit-Code ≠ 0) wird `state.review_verdict='NEEDS_HUMAN'` direkt gesetzt und `review_patch` (LLM) NICHT aufgerufen.

**Motivation:** Heutiger Live-Run F-037 zeigte `review_verdict=APPROVED` für einen Patch, der das Problem nicht löst und 2 ESLint-Warnings (`react-hooks/exhaustive-deps`) erzeugt. Der Reviewer-LLM halluzinierte ein "handlerRef-Pattern" im Reasoning, das im Patch gar nicht vorkam. Lint-Pre-Gate fängt diese Klasse algorithmisch — Reviewer wird nie gefragt.

## Changes

| Datei | Aktion |
|-------|--------|
| `scripts/findings/lib/models.py` | `lint_passed`, `lint_output` Felder zu `FindingFixState` |
| `scripts/findings/dag_nodes/run_lint.py` | **NEU** — DAG-Node mit Extension-Whitelist (.ts/.tsx/.js/.jsx) |
| `scripts/findings/finding_fix.py` | `run_lint` zwischen `apply_patch` und `review_patch` an 2 Stellen verdrahtet (primary + fallback). Reset-Block um `lint_passed`/`lint_output` ergänzt. JSONL-Logger erweitert. |
| `tests/findings/dag_nodes/test_run_lint.py` | **NEU** — 4 Unit-Tests (skip-no-fix, non-JS-skip, lint-clean, lint-fail) |
| `tests/findings/test_finding_fix.py` | 2 neue Integration-Tests (Pre-Gate-Path primary + fallback) + Refactor existing tests auf `subprocess.run`-Side-Effect-Pattern |

8 atomare Commits (TDD-Reihenfolge: write-failing-test → minimal-impl → green → commit).

## Live-Run-Validierung

**F-037 (Pre-Gate fires):**
```json
{
  "fix_applied": true,
  "lint_passed": false,
  "review_verdict": "NEEDS_HUMAN",
  "review_reasoning": "ESLint failed (exit 1):\n... react-hooks/exhaustive-deps ...",
  "review_concerns_count": 0   // reviewer-LLM nicht aufgerufen
}
```

**Regression (clean-lint Pfad):** abgedeckt durch `test_full_pipeline_low_severity_with_mocked_llm` — `lint_passed=True`, dann `review_verdict=APPROVED`, dann `tests_pass=True`.

## Test plan

- [x] `pytest tests/findings -q` → 142 passed (135 baseline + 7 neue)
- [x] Live-Run F-037 → NEEDS_HUMAN, lint_passed=false, review_reasoning enthält "react-hooks/exhaustive-deps"
- [x] Working-Tree clean nach Run (manueller `git checkout`)
- [x] Branch `investigate/apply-patch-state` pushed (separater Befund zu F-243-state-inkonsistenz, kein Code)

## Out of Scope

- Routing-Bug (sonnet-4-6 nicht in Allowlist) — bleibt regulärer Backlog-Task
- apply_patch-Atomicity-Fix — Folge-Plan auf Basis von `investigate/apply-patch-state`
- Tieferes Reviewer-Tuning — separate Session

🤖 Generated with [Claude Code](https://claude.com/claude-code)