### PR TITLE
chore: gitignore reviews/ for future internal-only files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,9 @@ clarify-*.js
 search-property-names.js
 validate-bye-fix.js
 
-# Interne Dokumentation (nicht öffentlich)
+# Interne Dokumentation, Pläne, Reviews, Investigates (nicht öffentlich)
 docs/
+reviews/
 
 # Playwright test results
 test-results/


### PR DESCRIPTION
Strategie-Pläne, Spec-Docs und künftige Review-Snapshots bleiben lokal. docs/ war bereits gitignored; reviews/ kommt dazu. Bestehende getrackte Files unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)