### PR TITLE
feat(sentry): user-context wiring + source-map slug fix (CC-0)

### DIFF
--- a/src/features/auth/context/authActions.ts
+++ b/src/features/auth/context/authActions.ts
@@ -18,7 +18,7 @@ import { createAuthRetryService, isAbortError } from '../../../core/services';
 import { clearProfileCache, cacheUserProfile } from '../services/profileCacheService';
 import { isFeatureEnabled } from '../../../config';
 import { executeWithTimeout } from '../../../core/utils/SingleFlight';
-import { captureFeatureError } from '../../../lib/sentry';
+import { captureFeatureError, setUserContext as setSentryUserContext } from '../../../lib/sentry';
 
 /**
  * Timeout for auth operations (login, register, etc.)
@@ -91,6 +91,18 @@ export async function clearStaleAuthState(): Promise<void> {
   } catch {
     // localStorage not available or signOut failed
   }
+}
+
+/**
+ * Wraps deps.setUser to also update Sentry user-context.
+ * PII-safe: only user.id is forwarded to Sentry.
+ */
+function setUserAndSentry(
+  deps: { setUser: (u: User | null) => void },
+  user: User | null
+): void {
+  deps.setUser(user);
+  setSentryUserContext(user?.id ?? null);
 }
 
 /**
@@ -446,7 +458,7 @@ export async function logout(deps: AuthActionDeps): Promise<void> {
     safeLocalStorage.removeItem('mutation_queue_v1');
     safeLocalStorage.removeItem('mutation_queue_failed_v1');
     void clearProfileCache();
-    deps.setUser(null);
+    setUserAndSentry(deps, null);
     deps.setSession(null);
     deps.setIsGuest(false);
   };
@@ -499,7 +511,7 @@ export async function continueAsGuest(deps: AuthActionDeps): Promise<User> {
           // Clear any existing guest user data
           safeLocalStorage.removeItem('auth:guestUser');
 
-          deps.setUser(mappedUser);
+          setUserAndSentry(deps, mappedUser);
           deps.setSession(data.session ? mapSupabaseSession(data.session) : null);
           deps.setIsGuest(false); // Not a local guest, but an anonymous Supabase user
           deps.setConnectionState('connected');
@@ -528,7 +540,7 @@ export async function continueAsGuest(deps: AuthActionDeps): Promise<User> {
   // Fall back to local guest (no cloud sync)
   const guestUser = createLocalGuestUser();
   safeLocalStorage.setItem('auth:guestUser', JSON.stringify(guestUser));
-  deps.setUser(guestUser);
+  setUserAndSentry(deps, guestUser);
   deps.setSession(null);
   deps.setIsGuest(true);
   return guestUser;
@@ -642,7 +654,7 @@ export async function reconnect(deps: AuthActionDeps): Promise<boolean> {
         console.warn('[Auth] Session expired, clearing auth state for fresh login');
       }
       await clearStaleAuthState();
-      deps.setUser(null);
+      setUserAndSentry(deps, null);
       deps.setSession(null);
       deps.setIsGuest(false);
       deps.setConnectionState('connected'); // Not 'offline' - Supabase is reachable, just need re-auth
@@ -788,7 +800,7 @@ export async function updateProfile(
       avatarUrl: updates.avatarUrl ?? user.avatarUrl,
       updatedAt: new Date().toISOString(),
     };
-    deps.setUser(updatedUser);
+    setUserAndSentry(deps, updatedUser);
 
     // Sync to offline caches (localStorage + IndexedDB)
     try {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -126,8 +126,8 @@ export default defineConfig(({ mode }) => ({
     // Sentry source map upload - only in production with auth token
     mode === 'production' && process.env.SENTRY_AUTH_TOKEN
       ? sentryVitePlugin({
-          org: 'stieges',
-          project: 'hallenfussball-pwa',
+          org: 'stiegler-is',
+          project: 'javascript-react',
           authToken: process.env.SENTRY_AUTH_TOKEN,
           sourcemaps: {
             filesToDeleteAfterUpload: ['./dist/**/*.map'],


### PR DESCRIPTION
## Summary

Zwei Sentry-Audit-Befunde (CC-0 Hot-Path-Hardening) gefixt — beide klein, beide haben existing Production-Issues sichtbar gemacht.

### 1. User-Context-Wiring

\`setUserContext\` in [src/lib/sentry.ts:183-193](src/lib/sentry.ts#L183-L193) ist seit langem exportiert, wurde aber NIE aufgerufen. Folge: Sentry-Issues haben \`Users: 0\` ohne User-Attribution (verifiziert via Sentry-MCP).

Fix: Kleiner \`setUserAndSentry\`-Wrapper in [authActions.ts](src/features/auth/context/authActions.ts) ersetzt 5 \`deps.setUser(...)\`-Call-Sites. Sentry erhält bei jedem Auth-State-Change die aktuelle \`user.id\` (PII-safe — kein Email/Name).

### 2. Source-Map Upload Slugs

[vite.config.ts](vite.config.ts) hatte hardcoded Legacy-Slugs:
\`\`\`typescript
sentryVitePlugin({
  org: 'stieges',                    // ❌ existiert nicht
  project: 'hallenfussball-pwa',     // ❌ existiert nicht
  ...
})
\`\`\`

Echte Slugs (verifiziert via \`mcp__sentry__find_organizations\` + \`find_projects\`):
- \`org: 'stiegler-is'\`
- \`project: 'javascript-react'\`

Folge des Fehlers: Source-Maps wurden silently nicht hochgeladen → Stack-Traces in Production-Issues blieben minified (z.B. \`/assets/react-vendor-C6C2yFp2.js:8:41220\` statt TS-Quelle).

## Verification

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test src/features/auth\` → 53 passed
- [ ] **Nach Merge + Deploy:** Test-Error werfen, via Sentry-MCP verifizieren dass (a) User-Context gesetzt + (b) Stack-Trace de-minified ist

## Context

Teil von CC-0 (Cross-Cutting-0) aus dem Hot-Path-Hardening-Programm — Sentry als Foundation für Production-Error-Sichtbarkeit, vor den Hot-Path-Audits HP-1 bis HP-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)