### PR TITLE
feat(reliability): retry failed lazy-imports (Fixes JAVASCRIPT-REACT-9)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, lazy, Suspense, useCallback } from 'react';
+import { useState, useEffect, useRef, Suspense, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -35,47 +35,59 @@ import { ConsentDialog } from './components/dialogs/ConsentDialog';
 import { hasConsent } from './lib/consent';
 import { reinitializeSentry, captureFeatureError } from './lib/sentry';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { lazyWithRetry } from './lib/lazyWithRetry';
 
 // Lazy load screens for better initial load performance
-const DashboardScreen = lazy(() =>
-  import('./screens/DashboardScreen').then(m => ({ default: m.DashboardScreen }))
+const DashboardScreen = lazyWithRetry(
+  () => import('./screens/DashboardScreen').then(m => ({ default: m.DashboardScreen })),
+  'DashboardScreen'
 );
-const TournamentCreationScreen = lazy(() =>
-  import('./screens/TournamentCreationScreen').then(m => ({ default: m.TournamentCreationScreen }))
+const TournamentCreationScreen = lazyWithRetry(
+  () => import('./screens/TournamentCreationScreen').then(m => ({ default: m.TournamentCreationScreen })),
+  'TournamentCreationScreen'
 );
-const TournamentManagementScreen = lazy(() =>
-  import('./screens/TournamentManagementScreen').then(m => ({ default: m.TournamentManagementScreen }))
+const TournamentManagementScreen = lazyWithRetry(
+  () => import('./screens/TournamentManagementScreen').then(m => ({ default: m.TournamentManagementScreen })),
+  'TournamentManagementScreen'
 );
-const PublicTournamentViewScreen = lazy(() =>
-  import('./screens/PublicTournamentViewScreen').then(m => ({ default: m.PublicTournamentViewScreen }))
+const PublicTournamentViewScreen = lazyWithRetry(
+  () => import('./screens/PublicTournamentViewScreen').then(m => ({ default: m.PublicTournamentViewScreen })),
+  'PublicTournamentViewScreen'
 );
-const LiveViewScreen = lazy(() =>
-  import('./screens/LiveViewScreen').then(m => ({ default: m.LiveViewScreen }))
+const LiveViewScreen = lazyWithRetry(
+  () => import('./screens/LiveViewScreen').then(m => ({ default: m.LiveViewScreen })),
+  'LiveViewScreen'
 );
 // NOTE: PublicLiveViewScreen removed - LiveViewScreen handles /live/:code
-const ImpressumScreen = lazy(() =>
-  import('./screens/ImpressumScreen').then(m => ({ default: m.ImpressumScreen }))
+const ImpressumScreen = lazyWithRetry(
+  () => import('./screens/ImpressumScreen').then(m => ({ default: m.ImpressumScreen })),
+  'ImpressumScreen'
 );
-const DatenschutzScreen = lazy(() =>
-  import('./screens/DatenschutzScreen').then(m => ({ default: m.DatenschutzScreen }))
+const DatenschutzScreen = lazyWithRetry(
+  () => import('./screens/DatenschutzScreen').then(m => ({ default: m.DatenschutzScreen })),
+  'DatenschutzScreen'
 );
-const SettingsScreen = lazy(() =>
-  import('./screens/SettingsScreen').then(m => ({ default: m.SettingsScreen }))
+const SettingsScreen = lazyWithRetry(
+  () => import('./screens/SettingsScreen').then(m => ({ default: m.SettingsScreen })),
+  'SettingsScreen'
 );
 
 // Local Test Screen (DEV only)
-const LocalTestScreen = lazy(() =>
-  import('./screens/LocalTestScreen').then(m => ({ default: m.LocalTestScreen }))
+const LocalTestScreen = lazyWithRetry(
+  () => import('./screens/LocalTestScreen').then(m => ({ default: m.LocalTestScreen })),
+  'LocalTestScreen'
 );
 
 // MON-KONF-01: Monitor Display für TVs/Beamer
-const MonitorDisplayPage = lazy(() =>
-  import('./features/monitor-display').then(m => ({ default: m.MonitorDisplayPage }))
+const MonitorDisplayPage = lazyWithRetry(
+  () => import('./features/monitor-display').then(m => ({ default: m.MonitorDisplayPage })),
+  'MonitorDisplayPage'
 );
 
 // Tournament Admin Center
-const TournamentAdminCenter = lazy(() =>
-  import('./features/tournament-admin').then(m => ({ default: m.TournamentAdminCenter }))
+const TournamentAdminCenter = lazyWithRetry(
+  () => import('./features/tournament-admin').then(m => ({ default: m.TournamentAdminCenter })),
+  'TournamentAdminCenter'
 );
 
 // Loading fallback component

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,7 +2,10 @@
 import React, { Component, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cssVars } from '../design-tokens';
+import { LAZY_IMPORT_FAILED_EVENT, type LazyImportFailedDetail } from '../lib/lazyWithRetry';
 import { captureFeatureError } from '../lib/sentry';
+
+const LAZY_IMPORT_ERROR_PREFIX = 'Lazy import failed:';
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
@@ -30,6 +33,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true, error };
   }
 
+  componentDidMount(): void {
+    window.addEventListener(LAZY_IMPORT_FAILED_EVENT, this.handleLazyImportFailed);
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener(LAZY_IMPORT_FAILED_EVENT, this.handleLazyImportFailed);
+  }
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('[ErrorBoundary] Caught error:', error, errorInfo);
 
@@ -40,6 +51,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     this.props.onError?.(error, errorInfo);
   }
+
+  handleLazyImportFailed = (e: Event): void => {
+    const detail = (e as CustomEvent<LazyImportFailedDetail>).detail;
+    this.setState({
+      hasError: true,
+      error: new Error(`${LAZY_IMPORT_ERROR_PREFIX} ${detail?.chunkName ?? 'unknown chunk'}`),
+    });
+  };
 
   handleReset = (): void => {
     this.setState({ hasError: false, error: null });
@@ -66,6 +85,7 @@ interface DefaultErrorFallbackProps {
 
 const DefaultErrorFallback: React.FC<DefaultErrorFallbackProps> = ({ error, onReset }) => {
   const { t } = useTranslation('common');
+  const isLazyImportError = error?.message.startsWith(LAZY_IMPORT_ERROR_PREFIX) ?? false;
   return (
   <div
     style={{
@@ -100,7 +120,7 @@ const DefaultErrorFallback: React.FC<DefaultErrorFallbackProps> = ({ error, onRe
             lineHeight: '1.5',
           }}
         >
-          {t('errorBoundary.message')}
+          {isLazyImportError ? t('errorBoundary.refreshRequired') : t('errorBoundary.message')}
         </p>
 
         {error && process.env.NODE_ENV === 'development' && (
@@ -122,31 +142,33 @@ const DefaultErrorFallback: React.FC<DefaultErrorFallbackProps> = ({ error, onRe
         )}
 
         <div style={{ display: 'flex', gap: cssVars.spacing.sm }}>
-          <button
-            onClick={onReset}
-            style={{
-              padding: `${cssVars.spacing.sm} ${cssVars.spacing.md}`,
-              background: cssVars.colors.primary,
-              border: 'none',
-              borderRadius: cssVars.borderRadius.sm,
-              color: cssVars.colors.onPrimary,
-              fontSize: cssVars.fontSizes.md,
-              fontWeight: cssVars.fontWeights.semibold,
-              cursor: 'pointer',
-            }}
-          >
-            {t('actions.retry')}
-          </button>
+          {!isLazyImportError && (
+            <button
+              onClick={onReset}
+              style={{
+                padding: `${cssVars.spacing.sm} ${cssVars.spacing.md}`,
+                background: cssVars.colors.primary,
+                border: 'none',
+                borderRadius: cssVars.borderRadius.sm,
+                color: cssVars.colors.onPrimary,
+                fontSize: cssVars.fontSizes.md,
+                fontWeight: cssVars.fontWeights.semibold,
+                cursor: 'pointer',
+              }}
+            >
+              {t('actions.retry')}
+            </button>
+          )}
           <button
             onClick={() => window.location.reload()}
             style={{
               padding: `${cssVars.spacing.sm} ${cssVars.spacing.md}`,
-              background: cssVars.colors.surfaceElevated,
-              border: `1px solid ${cssVars.colors.border}`,
+              background: isLazyImportError ? cssVars.colors.primary : cssVars.colors.surfaceElevated,
+              border: isLazyImportError ? 'none' : `1px solid ${cssVars.colors.border}`,
               borderRadius: cssVars.borderRadius.sm,
-              color: cssVars.colors.textPrimary,
+              color: isLazyImportError ? cssVars.colors.onPrimary : cssVars.colors.textPrimary,
               fontSize: cssVars.fontSizes.md,
-              fontWeight: cssVars.fontWeights.medium,
+              fontWeight: isLazyImportError ? cssVars.fontWeights.semibold : cssVars.fontWeights.medium,
               cursor: 'pointer',
             }}
           >

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -38,7 +38,8 @@
   },
   "errorBoundary": {
     "title": "Etwas ist schiefgelaufen",
-    "message": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+    "message": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.",
+    "refreshRequired": "Eine neue App-Version ist verfügbar. Bitte lade die Seite neu, um fortzufahren."
   },
   "footer": {
     "copyright": "© {{year}} Spielplan",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -38,7 +38,8 @@
   },
   "errorBoundary": {
     "title": "Something went wrong",
-    "message": "An unexpected error occurred. Please try again."
+    "message": "An unexpected error occurred. Please try again.",
+    "refreshRequired": "A new version of the app is available. Please reload the page to continue."
   },
   "footer": {
     "copyright": "© {{year}} Spielplan",

--- a/src/lib/__tests__/lazyWithRetry.test.ts
+++ b/src/lib/__tests__/lazyWithRetry.test.ts
@@ -14,4 +14,17 @@ describe('lazyWithRetry', () => {
 
     expect(importer).not.toHaveBeenCalled();
   });
+
+  it('retries on transient import failure and eventually succeeds', async () => {
+    const fakeComponent = { default: () => null };
+    const importer = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce(fakeComponent);
+
+    const mod = await import('../lazyWithRetry');
+    expect(typeof mod.importWithRetry).toBe('function');
+    await expect(mod.importWithRetry(importer, 'TestChunk')).resolves.toEqual(fakeComponent);
+    expect(importer).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/lib/__tests__/lazyWithRetry.test.ts
+++ b/src/lib/__tests__/lazyWithRetry.test.ts
@@ -27,4 +27,33 @@ describe('lazyWithRetry', () => {
     await expect(mod.importWithRetry(importer, 'TestChunk')).resolves.toEqual(fakeComponent);
     expect(importer).toHaveBeenCalledTimes(2);
   });
+
+  it('reports to Sentry and dispatches event after all retries fail', async () => {
+    const sentryMock = vi.hoisted(() => vi.fn());
+    vi.mock('../sentry', () => ({ captureFeatureError: sentryMock }));
+
+    const eventListener = vi.fn();
+    window.addEventListener('lazy-import-failed', eventListener);
+
+    const importer = vi.fn().mockRejectedValue(new Error('chunk not found'));
+    const mod = await import('../lazyWithRetry');
+
+    await expect(mod.importWithRetry(importer, 'FailChunk')).rejects.toThrow('chunk not found');
+    expect(importer).toHaveBeenCalledTimes(3);
+    expect(sentryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'chunk not found' }),
+      'lazy-import',
+      'FailChunk',
+      { attempts: 3 },
+    );
+    expect(eventListener).toHaveBeenCalled();
+    const customEvent = eventListener.mock.calls[0][0] as CustomEvent;
+    expect(customEvent.detail).toEqual({
+      chunkName: 'FailChunk',
+      error: expect.any(Error),
+      attempts: 3,
+    });
+
+    window.removeEventListener('lazy-import-failed', eventListener);
+  });
 });

--- a/src/lib/__tests__/lazyWithRetry.test.ts
+++ b/src/lib/__tests__/lazyWithRetry.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { lazyWithRetry } from '../lazyWithRetry';
+
+describe('lazyWithRetry', () => {
+  it('returns a React.lazy component when import succeeds first try', async () => {
+    const fakeComponent = { default: () => null };
+    const importer = vi.fn().mockResolvedValue(fakeComponent);
+
+    const LazyComp = lazyWithRetry(importer, 'TestChunk');
+
+    // React.lazy returns a special exotic component
+    expect(LazyComp).toHaveProperty('$$typeof');
+    expect(LazyComp).toHaveProperty('_payload');
+
+    expect(importer).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/lazyWithRetry.ts
+++ b/src/lib/lazyWithRetry.ts
@@ -19,7 +19,13 @@ export const LAZY_IMPORT_FAILED_EVENT = 'lazy-import-failed';
 const RETRY_COUNT = 3;
 const RETRY_BACKOFF_MS = [200, 500, 1500];
 
-type ModuleFactory<T> = () => Promise<{ default: ComponentType<T> }>;
+// `any` is the canonical generic constraint for "a React component with any props shape";
+// it preserves each call site's specific Props type via inference.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyComponent = ComponentType<any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+type ModuleFactory<T extends AnyComponent> = () => Promise<{ default: T }>;
 
 export interface LazyImportFailedDetail {
   chunkName: string;
@@ -27,10 +33,10 @@ export interface LazyImportFailedDetail {
   attempts: number;
 }
 
-export async function importWithRetry<T>(
+export async function importWithRetry<T extends AnyComponent>(
   factory: ModuleFactory<T>,
   chunkName: string,
-): Promise<{ default: ComponentType<T> }> {
+): Promise<{ default: T }> {
   let lastError: Error | null = null;
   for (let attempt = 0; attempt < RETRY_COUNT; attempt++) {
     try {
@@ -52,6 +58,9 @@ export async function importWithRetry<T>(
   throw finalError;
 }
 
-export function lazyWithRetry<T>(factory: ModuleFactory<T>, chunkName: string) {
+export function lazyWithRetry<T extends AnyComponent>(
+  factory: ModuleFactory<T>,
+  chunkName: string,
+) {
   return lazy(() => importWithRetry(factory, chunkName));
 }

--- a/src/lib/lazyWithRetry.ts
+++ b/src/lib/lazyWithRetry.ts
@@ -1,0 +1,57 @@
+/**
+ * lazyWithRetry — retries failed dynamic imports before giving up.
+ *
+ * Fixes the class of bug seen in Sentry issue JAVASCRIPT-REACT-9:
+ * stale Service-Worker / CDN cache hands the browser an old chunk
+ * hash that no longer exists, producing "Failed to fetch dynamically
+ * imported module".
+ *
+ * Strategy: up to RETRY_COUNT attempts with exponential backoff.
+ * On final failure: dispatch a CustomEvent('lazy-import-failed') so
+ * a top-level ErrorBoundary can show a Refresh-CTA, and report to
+ * Sentry via captureFeatureError.
+ */
+import { lazy } from 'react';
+import type { ComponentType } from 'react';
+import { captureFeatureError } from './sentry';
+
+export const LAZY_IMPORT_FAILED_EVENT = 'lazy-import-failed';
+const RETRY_COUNT = 3;
+const RETRY_BACKOFF_MS = [200, 500, 1500];
+
+type ModuleFactory<T> = () => Promise<{ default: ComponentType<T> }>;
+
+export interface LazyImportFailedDetail {
+  chunkName: string;
+  error: Error;
+  attempts: number;
+}
+
+async function importWithRetry<T>(
+  factory: ModuleFactory<T>,
+  chunkName: string,
+): Promise<{ default: ComponentType<T> }> {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < RETRY_COUNT; attempt++) {
+    try {
+      return await factory();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < RETRY_COUNT - 1) {
+        await new Promise(resolve => setTimeout(resolve, RETRY_BACKOFF_MS[attempt]));
+      }
+    }
+  }
+  const finalError = lastError ?? new Error('lazyWithRetry: unknown failure');
+  captureFeatureError(finalError, 'lazy-import', chunkName, { attempts: RETRY_COUNT });
+  window.dispatchEvent(
+    new CustomEvent<LazyImportFailedDetail>(LAZY_IMPORT_FAILED_EVENT, {
+      detail: { chunkName, error: finalError, attempts: RETRY_COUNT },
+    }),
+  );
+  throw finalError;
+}
+
+export function lazyWithRetry<T>(factory: ModuleFactory<T>, chunkName: string) {
+  return lazy(() => importWithRetry(factory, chunkName));
+}

--- a/src/lib/lazyWithRetry.ts
+++ b/src/lib/lazyWithRetry.ts
@@ -27,7 +27,7 @@ export interface LazyImportFailedDetail {
   attempts: number;
 }
 
-async function importWithRetry<T>(
+export async function importWithRetry<T>(
   factory: ModuleFactory<T>,
   chunkName: string,
 ): Promise<{ default: ComponentType<T> }> {


### PR DESCRIPTION
## Summary

Reale Sentry-Issue [JAVASCRIPT-REACT-9](https://stiegler-is.sentry.io/issues/JAVASCRIPT-REACT-9):
`TypeError: Failed to fetch dynamically imported module: TournamentCreationScreen-DxRGgHTE.js`

Ursache: stale Service-Worker / CDN-Cache reicht alte Chunk-Hashes raus, die nach
einem Deploy nicht mehr existieren. `React.lazy` hatte keinen Retry.

## Fix

Neuer `lazyWithRetry`-Helper ersetzt alle **11** `React.lazy`-Calls in App.tsx.
- 3 Retries mit exponential Backoff (200ms / 500ms / 1500ms)
- Bei finalem Fail: `captureFeatureError` + Custom-Event `lazy-import-failed`
- ErrorBoundary fängt das Event, zeigt Refresh-CTA mit i18n-Key
- Type-safe Generic (`T extends ComponentType<any>`)

## Commits

- `feat(reliability): scaffold lazyWithRetry helper`
- `feat(reliability): retry on transient lazy-import failures`
- `test(reliability): cover lazy-import exhaustion path`
- `feat(reliability): ErrorBoundary handles lazy-import-failed events`
- `feat(reliability): wire lazyWithRetry into all 11 App lazy-imports`

## Tests

- 3 neue Unit-Tests in `src/lib/__tests__/lazyWithRetry.test.ts`
- Komplette Test-Suite grün (841 passed, 8 skipped)
- TypeScript clean, ESLint clean

## Subagent-Driven Development

Plan: `docs/superpowers/plans/2026-05-10-hp-1a-lazy-import-retry.md` (lokal)
- 5 Implementation-Tasks, je dispatched mit fresh Subagent
- 2-stufiger Review (Spec-Compliance + Code-Quality) am Ende der Sequenz
- 3 Minor-Hinweise vom Code-Reviewer (Polish für Folge-PR)

Closes JAVASCRIPT-REACT-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)